### PR TITLE
Port OpenClaw realtime call parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Common realtime env vars:
 export OPENAI_API_KEY="sk-..."
 export INKBOX_REALTIME_MODEL="gpt-realtime-2"
 export INKBOX_REALTIME_VOICE="cedar"
+export INKBOX_REALTIME_FALLBACK_TO_INKBOX_STT_TTS=true
 ```
 
 Disable realtime:
@@ -142,6 +143,8 @@ hermes gateway restart
 ```
 
 Realtime calls receive the agent's Inkbox handle, mailbox, phone number, caller contact metadata, and outbound-call purpose before greeting. The realtime model has direct access to `hermes_agent_consult`, `register_post_call_action`, `edit_post_call_action`, `delete_post_call_action`, and `hang_up_call`.
+
+When Realtime is enabled, the plugin preflights the OpenAI Realtime websocket before accepting the Inkbox call in raw-media mode. If that preflight fails, calls fall back to Inkbox STT/TTS by default. Set `INKBOX_REALTIME_FALLBACK_TO_INKBOX_STT_TTS=false` to fail the call instead.
 
 ## CLI
 
@@ -200,6 +203,8 @@ After the gateway starts:
 | `OPENAI_API_KEY` | no | - | OpenAI API key used for realtime calls when `INKBOX_REALTIME_API_KEY` is absent. |
 | `INKBOX_REALTIME_MODEL` | no | `gpt-realtime-2` | Realtime voice model. |
 | `INKBOX_REALTIME_VOICE` | no | `cedar` | Realtime voice name. |
+| `INKBOX_REALTIME_CONNECT_TIMEOUT_S` | no | `8` | Seconds to wait for OpenAI Realtime preflight before falling back or failing. |
+| `INKBOX_REALTIME_FALLBACK_TO_INKBOX_STT_TTS` | no | `true` | Fall back to Inkbox STT/TTS if OpenAI Realtime connect/auth fails before call accept. |
 
 ## Tools
 

--- a/adapter.py
+++ b/adapter.py
@@ -123,7 +123,9 @@ try:
         DEFAULT_CONSULT_TIMEOUT_S as REALTIME_DEFAULT_CONSULT_TIMEOUT_S,
         RealtimeCallMeta,
         RealtimeConfig,
-        run_inkbox_realtime_bridge,
+        RealtimeBridgeConnectError,
+        RealtimeConsultResult,
+        open_inkbox_realtime_bridge,
     )
 except ImportError:  # pragma: no cover - direct local import/test fallback
     from realtime import (
@@ -132,7 +134,9 @@ except ImportError:  # pragma: no cover - direct local import/test fallback
         DEFAULT_CONSULT_TIMEOUT_S as REALTIME_DEFAULT_CONSULT_TIMEOUT_S,
         RealtimeCallMeta,
         RealtimeConfig,
-        run_inkbox_realtime_bridge,
+        RealtimeBridgeConnectError,
+        RealtimeConsultResult,
+        open_inkbox_realtime_bridge,
     )
 
 logger = logging.getLogger(__name__)
@@ -270,6 +274,19 @@ def _conversation_summary_is_group(summary: Any) -> bool:
     return bool(_field(summary, "isGroup", "is_group", "is_group_conversation"))
 
 
+def _realtime_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in ("true", "1", "yes", "on"):
+        return True
+    if text in ("false", "0", "no", "off"):
+        return False
+    return default
+
+
 def _resolve_realtime_config(extra: Dict[str, Any]) -> RealtimeConfig:
     rt_extra = extra.get("realtime") if isinstance(extra.get("realtime"), dict) else {}
     rt_api_key = (
@@ -299,6 +316,17 @@ def _resolve_realtime_config(extra: Dict[str, Any]) -> RealtimeConfig:
             rt_extra.get("consult_timeout_s")
             or os.getenv("INKBOX_REALTIME_CONSULT_TIMEOUT_S")
             or REALTIME_DEFAULT_CONSULT_TIMEOUT_S
+        ),
+        connect_timeout_s=float(
+            rt_extra.get("connect_timeout_s")
+            or os.getenv("INKBOX_REALTIME_CONNECT_TIMEOUT_S")
+            or 8.0
+        ),
+        fallback_to_inkbox_stt_tts=_realtime_bool(
+            rt_extra.get("fallback_to_inkbox_stt_tts")
+            if "fallback_to_inkbox_stt_tts" in rt_extra
+            else os.getenv("INKBOX_REALTIME_FALLBACK_TO_INKBOX_STT_TTS"),
+            True,
         ),
     )
     if rt_enabled_text in ("true", "1", "yes", "on") and not rt_has_cred:
@@ -2387,22 +2415,20 @@ class InkboxAdapter(BasePlatformAdapter):
             if not ok:
                 return web.Response(status=401, text="invalid signature")
 
-        # ``WebSocketResponse`` doesn't take ``headers=`` as a constructor kwarg;
-        # we mutate ``ws.headers`` before ``prepare()`` instead, which is what
-        # aiohttp's ``StreamResponse`` accepts.
-        #
-        # When realtime is enabled and configured, we instruct Inkbox NOT to
-        # do server-side STT/TTS so raw G.711 μ-law audio frames flow in
-        # both directions. Without realtime, Inkbox runs STT and TTS itself
-        # and we exchange text events on the WS.
+        # ``WebSocketResponse`` doesn't take ``headers=`` as a constructor kwarg.
+        # We mutate ``ws.headers`` immediately before ``prepare()`` once we know
+        # whether this call can really use OpenAI Realtime. Preparing too early
+        # commits Inkbox to raw-media mode before we know Realtime is reachable.
         ws = web.WebSocketResponse()
-        if self._realtime_config.enabled:
-            ws.headers["x-use-inkbox-text-to-speech"] = "false"
-            ws.headers["x-use-inkbox-speech-to-text"] = "false"
-        else:
-            ws.headers["x-use-inkbox-text-to-speech"] = "true"
-            ws.headers["x-use-inkbox-speech-to-text"] = "true"
-        await ws.prepare(request)
+
+        async def _prepare_call_ws(*, use_realtime: bool) -> None:
+            if use_realtime:
+                ws.headers["x-use-inkbox-text-to-speech"] = "false"
+                ws.headers["x-use-inkbox-speech-to-text"] = "false"
+            else:
+                ws.headers["x-use-inkbox-text-to-speech"] = "true"
+                ws.headers["x-use-inkbox-speech-to-text"] = "true"
+            await ws.prepare(request)
 
         # Resolve call context.  Three sources, tried in order:
         #   1. webhook-mode pre-stash from ``_on_incoming_call`` (legacy)
@@ -2523,11 +2549,12 @@ class InkboxAdapter(BasePlatformAdapter):
                     "[Inkbox] Failed to load context_token %s: %s", ctx_token, exc,
                 )
 
-        # Realtime voice bridge — when configured, hand the WS off to the
-        # OpenAI Realtime API bridge instead of the legacy text-event
-        # flow below. The bridge owns the WS lifecycle until call end and
-        # then we fall through to the post-call cleanup at the bottom.
+        # Realtime voice bridge — when configured, pre-open OpenAI Realtime
+        # before accepting the Inkbox websocket in raw-media mode. If preflight
+        # fails and fallback is allowed, we still accept the same phone call
+        # with Inkbox STT/TTS and continue into the text-event flow below.
         if self._realtime_config.enabled:
+            realtime_bridge = None
             try:
                 identity_for_meta = None
                 if self._inkbox is not None:
@@ -2574,31 +2601,78 @@ class InkboxAdapter(BasePlatformAdapter):
                         call_context.get("conversation_summary") or ""
                     ).strip() or None,
                 )
-                await run_inkbox_realtime_bridge(
-                    inkbox_ws=ws,
+                realtime_bridge = await open_inkbox_realtime_bridge(
                     config=self._realtime_config,
                     meta=rt_meta,
-                    on_agent_consult=self._realtime_agent_consult,
-                    on_post_call_actions=self._realtime_post_call_actions,
-                    on_call_ended=self._realtime_call_ended,
                 )
+            except RealtimeBridgeConnectError as exc:
+                if self._realtime_config.fallback_to_inkbox_stt_tts:
+                    logger.warning(
+                        "[Inkbox] realtime bridge connect failed for call_id=%s; "
+                        "falling back to Inkbox STT/TTS: %s",
+                        call_id,
+                        exc.cause,
+                    )
+                else:
+                    logger.warning(
+                        "[Inkbox] realtime bridge connect failed for call_id=%s and "
+                        "fallback is disabled: %s",
+                        call_id,
+                        exc.cause,
+                    )
+                    self._active_call_ws.pop(contact_id, None)
+                    if self._last_inbound_modality.get(str(contact_id)) == "voice":
+                        self._last_inbound_modality.pop(str(contact_id), None)
+                    return web.Response(status=503, text="realtime bridge unavailable")
             except Exception as exc:
-                logger.warning(
-                    "[Inkbox] realtime bridge crashed for call_id=%s: %s",
-                    call_id, exc,
-                )
-            finally:
-                self._active_call_ws.pop(contact_id, None)
-                if self._last_inbound_modality.get(str(contact_id)) == "voice":
-                    self._last_inbound_modality.pop(str(contact_id), None)
-                self._voice_recently_closed[str(contact_id)] = time.time()
+                if self._realtime_config.fallback_to_inkbox_stt_tts:
+                    logger.warning(
+                        "[Inkbox] realtime bridge preflight crashed for call_id=%s; "
+                        "falling back to Inkbox STT/TTS: %s",
+                        call_id,
+                        exc,
+                    )
+                else:
+                    logger.warning(
+                        "[Inkbox] realtime bridge preflight crashed for call_id=%s "
+                        "and fallback is disabled: %s",
+                        call_id,
+                        exc,
+                    )
+                    self._active_call_ws.pop(contact_id, None)
+                    if self._last_inbound_modality.get(str(contact_id)) == "voice":
+                        self._last_inbound_modality.pop(str(contact_id), None)
+                    return web.Response(status=503, text="realtime bridge unavailable")
+
+            if realtime_bridge is not None:
                 try:
-                    if not ws.closed:
-                        await ws.close()
-                except Exception:
-                    pass
-                logger.info("[Inkbox] Call WS closed: call_id=%s", call_id)
-            return ws
+                    await _prepare_call_ws(use_realtime=True)
+                    await realtime_bridge.run(
+                        inkbox_ws=ws,
+                        on_agent_consult=self._realtime_agent_consult,
+                        on_post_call_actions=self._realtime_post_call_actions,
+                        on_call_ended=self._realtime_call_ended,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "[Inkbox] realtime bridge crashed for call_id=%s: %s",
+                        call_id, exc,
+                    )
+                finally:
+                    await realtime_bridge.close()
+                    self._active_call_ws.pop(contact_id, None)
+                    if self._last_inbound_modality.get(str(contact_id)) == "voice":
+                        self._last_inbound_modality.pop(str(contact_id), None)
+                    self._voice_recently_closed[str(contact_id)] = time.time()
+                    try:
+                        if not ws.closed:
+                            await ws.close()
+                    except Exception:
+                        pass
+                    logger.info("[Inkbox] Call WS closed: call_id=%s", call_id)
+                return ws
+
+        await _prepare_call_ws(use_realtime=False)
 
         logger.info(
             "[Inkbox] Call WS open: call_id=%s contact_id=%s remote=%s "
@@ -2843,11 +2917,33 @@ class InkboxAdapter(BasePlatformAdapter):
     # Realtime voice bridge callbacks
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _format_realtime_post_call_actions(actions: List[Dict[str, str]]) -> str:
+        lines = []
+        for i, action in enumerate(actions, start=1):
+            text = f"{i}. {action.get('action', '')}".strip()
+            details = (action.get("details") or "").strip()
+            if details:
+                text += f"\n   Details: {details}"
+            lines.append(text)
+        return "\n".join(lines)
+
+    @staticmethod
+    def _format_realtime_consult_results(results: List[RealtimeConsultResult]) -> str:
+        lines = []
+        for i, result in enumerate(results, start=1):
+            request = getattr(result, "request", "")
+            answer = getattr(result, "result", "")
+            lines.append(f"{i}. Request: {request}\nResult: {answer}")
+        return "\n\n".join(lines)
+
     async def _realtime_agent_consult(
         self,
         meta: RealtimeCallMeta,
         query: str,
         transcript: List[Tuple[str, str]],
+        post_call_actions: Optional[List[Dict[str, str]]] = None,
+        consult_results: Optional[List[RealtimeConsultResult]] = None,
     ) -> str:
         """Run the agent_consult tool: spawn a one-shot Hermes agent invocation.
 
@@ -2873,6 +2969,29 @@ class InkboxAdapter(BasePlatformAdapter):
         ]
         for role, text in transcript[-10:]:
             prompt_lines.append(f"  {role}: {text}")
+        post_call_actions = post_call_actions or []
+        consult_results = consult_results or []
+        if post_call_actions:
+            prompt_lines.extend([
+                "",
+                "Pending after-call actions already queued by the realtime call agent:",
+                self._format_realtime_post_call_actions(post_call_actions),
+                (
+                    "If this consult completes, queues, cancels, or supersedes one "
+                    "of those pending actions, say so explicitly in your result so "
+                    "the call agent can delete that after-call action before hangup."
+                ),
+            ])
+        if consult_results:
+            prompt_lines.extend([
+                "",
+                "Previous Hermes consult results during this same live call:",
+                self._format_realtime_consult_results(consult_results),
+                (
+                    "Do not repeat work that was already completed or queued unless "
+                    "the caller explicitly asked for another, repeat, or different action."
+                ),
+            ])
         prompt_lines.extend([
             "",
             f"The realtime voice agent asked: {query}",
@@ -2964,6 +3083,7 @@ class InkboxAdapter(BasePlatformAdapter):
         meta: RealtimeCallMeta,
         actions: List[Dict[str, str]],
         transcript: List[Tuple[str, str]],
+        consult_results: Optional[List[RealtimeConsultResult]] = None,
     ) -> None:
         """Dispatch queued post-call actions as a synthetic SMS-mode turn.
 
@@ -2972,28 +3092,40 @@ class InkboxAdapter(BasePlatformAdapter):
         transcript, push it through the normal inbound queue so the main
         agent executes them with its full toolset.
         """
-        action_lines = []
-        for i, action in enumerate(actions, start=1):
-            line = f"{i}. {action.get('action', '')}"
-            details = (action.get("details") or "").strip()
-            if details:
-                line += f"\n   Details: {details}"
-            action_lines.append(line)
+        action_lines = self._format_realtime_post_call_actions(actions).splitlines()
+        consult_results = consult_results or []
+        consult_block = self._format_realtime_consult_results(consult_results)
         transcript_block = "\n".join(
-            f"{role}: {text}" for role, text in transcript[-30:]
+            f"{role}: {text}" for role, text in transcript
         )
         body = "\n".join([
             f"[inkbox:voice_post_call_actions call_id={meta.call_id}]",
-            "The realtime voice call ended. Execute these queued actions now "
-            "using your tools where appropriate. Do NOT send a confirmation "
-            "follow-up after successful work unless the caller explicitly "
-            "requested one. If required info is missing, prefer SMS to ask, "
-            "then email, then a follow-up call.",
+            "The realtime voice call ended. Review these queued post-call actions "
+            "and execute only the actions that are still needed.",
+            "These actions were registered during the live call and may be stale. "
+            "Before doing anything, reconcile them against the full live-call "
+            "transcript, in-call Hermes consult results, and prior messages in "
+            "this session.",
+            "If an action was already completed or queued during the call, canceled, "
+            "superseded, or the caller said it already happened, do not perform it "
+            "again. A same-channel in-call consult result that says an SMS/email "
+            "was sent or queued counts as already handled.",
+            "Do not merely say still-needed actions are impossible. If an email, "
+            "SMS, note, or contact update is still needed and enough recipient/"
+            "content info is present, perform it.",
+            "Do NOT send a confirmation follow-up after successful work unless the "
+            "caller explicitly requested one. Only if required information is "
+            "missing, ask the caller for the missing information. Try SMS first; "
+            "if SMS is unavailable or not opted in, try email; if email is "
+            "unavailable, place a follow-up call with the question.",
             "",
             "Queued actions:",
             *action_lines,
             "",
-            "Recent live-call transcript:" if transcript_block else "",
+            "In-call Hermes consult results:" if consult_block else "",
+            consult_block,
+            "",
+            "Full live-call transcript:" if transcript_block else "",
             transcript_block,
         ])
         source = self.build_source(
@@ -3014,6 +3146,16 @@ class InkboxAdapter(BasePlatformAdapter):
             raw_message={
                 "event": "realtime_post_call_actions",
                 "actions": actions,
+                "consult_results": [
+                    {
+                        "id": result.id,
+                        "request": result.request,
+                        "result": result.result,
+                        "created_at": result.created_at,
+                        "dedupe_key": result.dedupe_key,
+                    }
+                    for result in consult_results
+                ],
             },
             message_id=f"call:{meta.call_id}:post-call-actions",
             reply_to_message_id=meta.call_id,

--- a/hemres-plugin-port-plan.md
+++ b/hemres-plugin-port-plan.md
@@ -1,0 +1,222 @@
+# Hermes Plugin Port Plan
+
+Date: 2026-06-04
+
+Scope: compare the current Hermes Inkbox plugin against the OpenClaw plugin work that landed in PR #4
+(`realtime-post-call-hangup`) and PR #5 (`realtime-connect-fallback`). This doc lists what is already
+ported, what still needs to move over, and how to sequence the remaining work.
+
+Implementation note: the branch that adds this document also ports the P0/P1 items below in one PR. The matrix is
+kept as the audit record that drove the implementation.
+
+## Current Baseline
+
+Hermes plugin branch inspected: `main` at `2e0e7a2` (`Reuse Hermes OpenAI API credentials for realtime setup`).
+
+OpenClaw changes used as reference:
+
+- PR #4: realtime setup wizard auth, GA OpenAI Realtime API-key path, edit/delete post-call tools, delayed two-step hangup, SMS conversation-id handling, group SMS behavior, email subject preservation, post-call prompt cleanup, README gateway restart docs.
+- PR #5: connect to OpenAI Realtime before accepting raw Inkbox media, with fallback to Inkbox STT/TTS when the realtime connection fails.
+
+## Summary Matrix
+
+| OpenClaw item | Hermes status | Port action |
+| --- | --- | --- |
+| Realtime setup wizard detects existing OpenAI API keys and validates `gpt-realtime-2` | Already ported | No runtime port needed. `setup_wizard.py` checks plugin config, `INKBOX_REALTIME_API_KEY`, Hermes OpenAI API credentials, and `OPENAI_API_KEY`; it retries after validation failure. |
+| GA OpenAI Realtime API-key-only auth | Already ported | No port needed. Hermes removed Codex/OAuth minting for GA Realtime and uses OpenAI API keys. |
+| Realtime websocket GA header shape | Already ported | No port needed. Hermes sends the bearer auth header and uses the GA `session.update` payload shape; tests assert the old beta header is not sent. |
+| `register_post_call_action`, `edit_post_call_action`, `delete_post_call_action` | Already ported | No port needed. Tool schemas and tests exist in `realtime.py` and `tests/test_realtime_bridge_parity.py`. |
+| Two-step `hang_up_call` with a short final delay | Already ported | No port needed. Hermes arms hangup first, then sleeps for 2 seconds on the actual close. |
+| SMS conversation-id centric replies | Already ported | No port needed. `adapter.py` replies with `conversation_id`; tests cover direct and group SMS. |
+| Group SMS silence policy | Already ported | No port needed. Group messages include explicit silence policy and `[SILENT]` handling. |
+| Email subject and `In-Reply-To` preservation | Already ported | No port needed. Hermes stashes inbound subject/message id and replies with `Re:` plus `in_reply_to_message_id`. |
+| Voice progress/post-call leakage suppression | Already ported | No port needed. Existing tests cover voice progress suppression. |
+| README install/update/restart flow | Already ported | No port needed. README has `hermes gateway run`, `hermes plugins update inkbox`, and `hermes gateway restart`. |
+| OpenClaw auto-skill warning fix | Already ported | No port needed. Hermes has the `inkbox-call-review` split and no post-call auto-skill warning path. |
+| OpenAI Realtime connect-before-accept fallback | Missing | Port as P0. Hermes currently accepts the Inkbox call WebSocket with raw-media headers before OpenAI connection succeeds. |
+| Runtime fallback config equivalent to `voiceRealtime.fallbackToInkboxSttTts` | Missing/partial | Port as part of P0. Hermes can disable realtime with `INKBOX_REALTIME_ENABLED=false`, but there is no explicit "do not fallback" switch for runtime connect failure. |
+| In-call consult result memory | Missing | Port as P1. Hermes returns consult answers to Realtime but does not store them for post-call reconciliation. |
+| Post-call handoff includes consult results and full transcript | Partial | Port as P1. Hermes includes queued actions and recent transcript, but not consult results or the stronger stale-action instructions from OpenClaw. |
+| Duplicate same SMS consult guard | Missing | Port as P1. OpenClaw dedupes repeated in-call SMS sends while pending or already completed unless caller asks for another/repeat/different message. |
+| Realtime prompt clarity for "do it now" vs "after the call" | Partial | Port as P1/P2. Hermes has basic guidance, but OpenClaw is more explicit that live tool work should use consult, after-call deferral should use queued actions, and completed consults should delete duplicate queued actions. |
+| OpenClaw `visibleReplySent` / `pendingFinalDelivery` delivery fix | Not directly applicable | Do not port literally. Hermes consults run through a one-shot `hermes -z` subprocess, but the equivalent behavior is consult result tracking and post-call dedupe. |
+
+## P0: Realtime Connect Fallback Before Inkbox Accept
+
+### Problem
+
+Hermes currently does this in `adapter.py`:
+
+1. Build `web.WebSocketResponse`.
+2. If realtime is enabled, set:
+   - `x-use-inkbox-text-to-speech: false`
+   - `x-use-inkbox-speech-to-text: false`
+3. `await ws.prepare(request)`.
+4. Call `run_inkbox_realtime_bridge(...)`.
+5. `run_inkbox_realtime_bridge` then opens the OpenAI Realtime websocket.
+
+If OpenAI auth, model access, DNS, or Realtime service connection fails after step 3, the call has already been
+accepted in raw-media mode. At that point Inkbox STT/TTS is disabled and fallback is too late.
+
+OpenClaw fixed this by connecting to Realtime before accepting the Inkbox raw-media websocket. If Realtime connect
+fails before accept, it accepts the same phone call in Inkbox STT/TTS mode instead.
+
+### Proposed Hermes Port
+
+Refactor `realtime.py` so Realtime connection can be preflighted before `ws.prepare(request)`.
+
+One clean shape:
+
+- Add `open_inkbox_realtime_bridge(...)` or similar in `realtime.py`.
+- That function:
+  - resolves the OpenAI bearer/API key,
+  - opens the OpenAI Realtime websocket with an 8 second timeout,
+  - sends the session update once metadata is available,
+  - returns a bridge object with `run(inkbox_ws)` and `close()`.
+- Update `adapter.py`:
+  - resolve call metadata and outbound call context before choosing media mode,
+  - if realtime is enabled, attempt the preflight connection first,
+  - on success, set raw-media headers, `await ws.prepare(request)`, then run the bridge,
+  - on failure and fallback is allowed, set Inkbox STT/TTS headers, `await ws.prepare(request)`, and continue down the existing text-mode call path,
+  - on failure and fallback is disabled, reject/close with a clear log.
+
+Add a config/env knob equivalent to OpenClaw's `voiceRealtime.fallbackToInkboxSttTts`:
+
+- config: `platforms.inkbox.realtime.fallback_to_inkbox_stt_tts`
+- env: `INKBOX_REALTIME_FALLBACK_TO_INKBOX_STT_TTS`
+- default: `true`
+
+### Tests
+
+- Realtime connect failure before `prepare()` falls back to Inkbox STT/TTS and sets both Inkbox headers to `true`.
+- Realtime connect failure with fallback disabled closes/rejects and does not enter the text-mode call path.
+- Successful realtime connection still sets both Inkbox headers to `false` and runs the realtime bridge.
+- Connect attempt times out after the configured timeout and falls back.
+
+## P1: Consult Result Tracking And Post-Call Reconciliation
+
+### Problem
+
+Hermes has the tools, but the post-call handoff is missing the main evidence that prevents duplicate work:
+
+- `_BridgeState` tracks transcript and post-call actions only.
+- `hermes_agent_consult` returns a result to OpenAI but does not persist it in bridge state.
+- `_dispatch_post_call` passes only actions and transcript to `_realtime_post_call_actions`.
+- `_realtime_post_call_actions` tells the main agent to execute queued actions, but it does not include in-call consult results or the stronger "only still-needed work" instructions.
+
+This is the path that can make the main Hermes agent repeat work after hangup, even if the realtime model already used
+`hermes_agent_consult` to send an SMS/email or queue the work during the live call.
+
+### Proposed Hermes Port
+
+- Add `consult_results` to `_BridgeState`.
+- Store each consult result with:
+  - tool call id,
+  - request text,
+  - result text or error,
+  - timestamp,
+  - optional dedupe key.
+- Extend `AgentConsultCallback` so `_realtime_agent_consult` receives pending post-call actions and prior consult results.
+- Extend `PostCallActionsCallback` so `_realtime_post_call_actions` receives consult results.
+- Update `_realtime_agent_consult` prompt to include:
+  - pending after-call actions,
+  - prior consult results from the same call,
+  - instruction to say explicitly if the consult completed, queued, canceled, or superseded a queued after-call action.
+- Update `_realtime_post_call_actions` prompt to match OpenClaw's behavior:
+  - review queued actions against the full transcript,
+  - review in-call consult results,
+  - execute only still-needed actions,
+  - do not repeat SMS/email/note/contact work already completed or queued during the call,
+  - ask for missing info only when necessary,
+  - do not send confirmation follow-ups unless requested.
+
+### Tests
+
+- A consult result is recorded in `_BridgeState`.
+- The post-call synthetic message includes consult results.
+- The post-call synthetic message includes the full call transcript, not only the last few turns.
+- The post-call instructions explicitly say not to repeat work already completed or queued by in-call consults.
+
+## P1: Duplicate Same-SMS Consult Guard
+
+### Problem
+
+OpenClaw prevents the realtime model from sending the same SMS twice when it calls the consult tool repeatedly for the
+same phone number and same quoted/generic SMS request. Hermes does not currently have this guard.
+
+### Proposed Hermes Port
+
+Add OpenClaw-style dedupe helpers to `realtime.py`:
+
+- normalize consult request text,
+- identify SMS/text/message requests with a phone number,
+- include quoted message content when present,
+- allow repeats only when the caller says `again`, `another`, `different`, `new`, `repeat`, or `second`.
+
+Track:
+
+- `pending_consult_keys` for in-flight requests,
+- completed consult keys in `consult_results`.
+
+Return tool results:
+
+- `already_running` when the same request is in flight,
+- `already_handled` when the same request already completed,
+- proceed normally when the caller explicitly asks for another/repeat/different message.
+
+### Tests
+
+- Duplicate SMS consult while pending returns `already_running`.
+- Duplicate SMS consult after completion returns `already_handled`.
+- Requests containing `another`, `repeat`, or `different` are allowed through.
+- Non-SMS consults are not deduped.
+
+## P1/P2: Realtime Prompt Parity
+
+Hermes should copy the stronger intent split from OpenClaw's realtime instructions:
+
+- If caller asks for work to happen now during the live call and it needs Hermes/Inkbox tools, call `hermes_agent_consult`.
+- If caller explicitly asks for work after the call, or accepts after-call deferral, call `register_post_call_action`.
+- If a consult completes or queues work that matches a queued after-call action, call `delete_post_call_action` so it does not run twice after hangup.
+- `hang_up_call` is two-step: first arm and say goodbye, then call it again to end the call.
+- Do not call consult for greetings, caller identity at call start, or generic chat.
+
+This is mostly a prompt/test parity change once P1 state tracking is in place.
+
+## Not Recommended To Port Literally
+
+- OpenClaw's `visibleReplySent` and `pendingFinalDelivery` fixes are tied to OpenClaw's channel runtime delivery API.
+  Hermes uses a one-shot `hermes -z` consult subprocess, so the literal code does not apply.
+- OpenClaw's realtime provider abstraction and tool policy calls are OpenClaw SDK-specific. Hermes should keep its own
+  direct `aiohttp` Realtime bridge unless a Hermes-native provider abstraction appears.
+
+## Suggested PR Sequence
+
+1. PR A: realtime preflight connection and Inkbox STT/TTS fallback before `ws.prepare`.
+2. PR B: consult result memory, post-call reconciliation prompt, and callback signature updates.
+3. PR C: duplicate SMS consult dedupe and prompt/test polish.
+
+## Full Test Plan
+
+Run the focused Hermes suite:
+
+```bash
+python -m pytest tests/test_realtime_auth.py tests/test_realtime_bridge_parity.py tests/test_setup_wizard.py tests/test_sms_conversations.py tests/test_voice_progress_suppression.py
+```
+
+Manual smoke tests after PR A:
+
+1. Force OpenAI Realtime connect to fail before accepting the Inkbox websocket.
+2. Call the agent.
+3. Verify the call stays alive through Inkbox STT/TTS.
+4. Verify logs clearly say Realtime connect failed and fallback was used.
+5. Remove the forced failure.
+6. Call again and verify raw OpenAI Realtime is used.
+
+Manual smoke tests after PR B/C:
+
+1. During a realtime call, ask the agent to send an SMS now.
+2. Ask the same SMS request again without saying repeat/another.
+3. Verify the second request is not sent again.
+4. Ask for an after-call email, then ask the live consult to do the same work now.
+5. Verify the queued post-call action is deleted or the post-call handoff skips it.

--- a/realtime.py
+++ b/realtime.py
@@ -7,17 +7,18 @@ Inkbox-side STT/TTS.
 
 The bridge:
 
-1. Accepts the Inkbox call WS with ``x-use-inkbox-text-to-speech: false`` and
-   ``x-use-inkbox-speech-to-text: false`` headers, so Inkbox forwards raw
-   G.711 μ-law @ 8 kHz frames in both directions.
-2. Opens an OpenAI Realtime API WebSocket
+1. Preflights an OpenAI Realtime API WebSocket
    (``wss://api.openai.com/v1/realtime?model=<model>``) and sends
    ``session.update`` configuring tools, instructions, and the
    ``g711_ulaw`` input/output audio format.
+2. Lets the adapter accept the Inkbox call WS with
+   ``x-use-inkbox-text-to-speech: false`` and
+   ``x-use-inkbox-speech-to-text: false`` headers only after OpenAI is ready,
+   so fallback to Inkbox STT/TTS is still possible before accept.
 3. Bridges audio bidirectionally: Inkbox → OpenAI as
    ``input_audio_buffer.append`` events, OpenAI → Inkbox as
    ``media`` frames carrying ``response.audio.delta`` payloads.
-4. Exposes two tools to the realtime model:
+4. Exposes realtime-only tools to the model:
 
    - ``hermes_agent_consult`` — pauses the conversation, dispatches a synthetic
      SMS-mode turn through Hermes' main agent loop, and submits the agent's
@@ -25,6 +26,10 @@ The bridge:
    - ``register_post_call_action`` — queues a follow-up task. When the call
      ends, all queued actions are dispatched as a single synthetic SMS-mode
      turn so the main agent can execute them (send email, create note, etc.).
+   - ``edit_post_call_action`` / ``delete_post_call_action`` — modify queued
+     after-call work while the call is still live.
+   - ``hang_up_call`` — a two-step hangup that lets the model say goodbye
+     before closing the phone leg.
 
 The shape mirrors Inkbox's channel-plugin ``RealtimeCallWebSocket``.
 """
@@ -36,7 +41,9 @@ import base64
 import inspect
 import json
 import logging
+import re
 import time
+from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 from urllib.parse import urlencode
@@ -74,6 +81,11 @@ HANGUP_CONFIRM_WINDOW_S = 60.0
 # sending Inkbox the actual hangup frame. This gives already-forwarded goodbye
 # audio time to play out instead of being clipped by immediate teardown.
 HANGUP_CLOSE_DELAY_S = 2.0
+
+# OpenAI Realtime must be reachable before the Inkbox websocket is accepted in
+# raw-media mode. If this preflight fails, the adapter can still accept the
+# same phone call with Inkbox STT/TTS enabled.
+DEFAULT_CONNECT_TIMEOUT_S = 8.0
 
 
 def _openai_realtime_ws_headers(bearer: str) -> Dict[str, str]:
@@ -276,6 +288,8 @@ class RealtimeConfig:
     voice: str = DEFAULT_VOICE
     additional_instructions: str = ""
     consult_timeout_s: float = DEFAULT_CONSULT_TIMEOUT_S
+    connect_timeout_s: float = DEFAULT_CONNECT_TIMEOUT_S
+    fallback_to_inkbox_stt_tts: bool = True
     # ``api.openai.com`` by default; override for Azure / proxies.
     base_url: str = REALTIME_URL
 
@@ -292,9 +306,20 @@ class _ToolCallEvent:
 
 
 @dataclass
+class RealtimeConsultResult:
+    id: str
+    request: str
+    result: str
+    created_at: float
+    dedupe_key: Optional[str] = None
+
+
+@dataclass
 class _BridgeState:
     transcript: List[Tuple[str, str]] = field(default_factory=list)
     post_call_actions: List[Dict[str, str]] = field(default_factory=list)
+    consult_results: List[RealtimeConsultResult] = field(default_factory=list)
+    pending_consult_keys: Dict[str, str] = field(default_factory=dict)
     last_response_id: Optional[str] = None
     closed: bool = False
     greeting_triggered: bool = False
@@ -375,19 +400,26 @@ def build_realtime_instructions(
     lines.extend([
         "Do not perform a context lookup before greeting the caller. Do not say you "
         "are waiting on a lookup or checking context.",
-        f"If the caller asks for work to happen after the call, call "
-        f"{POST_CALL_ACTION_TOOL_NAME}. Tell the caller the action is queued for "
-        f"after the call; do not claim it has already been completed.",
+        f"If the caller asks for work to happen now during the live call and it needs "
+        f"Hermes/Inkbox tools, call {AGENT_CONSULT_TOOL_NAME}. This includes sending "
+        f"SMS/email, reading SMS/email/call history, creating notes, updating contacts, "
+        f"or checking current workspace/session data.",
+        f"If the caller explicitly asks for work to happen after the call, or accepts "
+        f"an after-call deferral, call {POST_CALL_ACTION_TOOL_NAME}. Tell the caller "
+        f"the action is queued for after the call; do not claim it has already been "
+        f"completed.",
         f"If the caller changes or cancels previously queued after-call work, call "
         f"{EDIT_POST_CALL_ACTION_TOOL_NAME} or {DELETE_POST_CALL_ACTION_TOOL_NAME} "
         f"using the action index returned when the work was queued.",
+        f"If {AGENT_CONSULT_TOOL_NAME} completes or queues work that matches a "
+        f"previously registered after-call action, call {DELETE_POST_CALL_ACTION_TOOL_NAME} "
+        f"for that action so it is not executed twice after hangup.",
         f"If the caller asks to hang up, says goodbye, or the conversation is "
-        f"clearly complete, call {HANG_UP_CALL_TOOL_NAME}. Say any needed final "
-        f"goodbye before calling it.",
-        f"Call {AGENT_CONSULT_TOOL_NAME} only when the caller asks for current "
-        f"external data, session history, a calendar lookup, or other work that "
-        f"requires the full Hermes agent. Do not call it for greetings, identity, "
-        f"or generic chat.",
+        f"clearly complete, call {HANG_UP_CALL_TOOL_NAME}. The first call arms "
+        f"hangup and asks you to say goodbye; after the goodbye, call it once "
+        f"more to end the phone call.",
+        f"Do not call {AGENT_CONSULT_TOOL_NAME} for greetings, caller identity at "
+        f"call start, or generic chat.",
     ])
     if additional_instructions.strip():
         lines.append(additional_instructions.strip())
@@ -439,14 +471,25 @@ def build_realtime_greeting(meta: RealtimeCallMeta) -> str:
 # implementation that runs a synthetic SMS-mode turn through the main agent
 # and returns the agent's reply as plain text.
 AgentConsultCallback = Callable[
-    [RealtimeCallMeta, str, List[Tuple[str, str]]],
+    [
+        RealtimeCallMeta,
+        str,
+        List[Tuple[str, str]],
+        List[Dict[str, str]],
+        List[RealtimeConsultResult],
+    ],
     Awaitable[str],
 ]
 
 # Called when the call ends, with the accumulated post-call actions list.
 # Platform dispatches them as a synthetic SMS-mode turn to the main agent.
 PostCallActionsCallback = Callable[
-    [RealtimeCallMeta, List[Dict[str, str]], List[Tuple[str, str]]],
+    [
+        RealtimeCallMeta,
+        List[Dict[str, str]],
+        List[Tuple[str, str]],
+        List[RealtimeConsultResult],
+    ],
     Awaitable[None],
 ]
 
@@ -458,6 +501,134 @@ CallEndedCallback = Callable[
     [RealtimeCallMeta, List[Tuple[str, str]]],
     Awaitable[None],
 ]
+
+
+class RealtimeBridgeConnectError(Exception):
+    """Raised when OpenAI Realtime cannot be opened before Inkbox accept."""
+
+    def __init__(self, cause: Any):
+        self.cause = cause
+        message = str(cause) if cause is not None else "unknown error"
+        super().__init__(f"OpenAI Realtime connect failed: {message}")
+
+
+@dataclass
+class OpenedRealtimeBridge:
+    session: Any
+    openai_ws: Any
+    state: _BridgeState
+    config: RealtimeConfig
+    meta: RealtimeCallMeta
+    _closed: bool = False
+
+    async def run(
+        self,
+        *,
+        inkbox_ws: Any,
+        on_agent_consult: AgentConsultCallback,
+        on_post_call_actions: PostCallActionsCallback,
+        on_call_ended: CallEndedCallback,
+    ) -> None:
+        """Bridge one already-opened OpenAI Realtime connection to Inkbox."""
+        state = self.state
+        openai_ws = self.openai_ws
+        try:
+            inkbox_task = asyncio.create_task(
+                _inkbox_to_openai_pump(inkbox_ws, openai_ws, state, self.meta),
+                name=f"realtime-inkbox-pump-{self.meta.call_id}",
+            )
+            openai_task = asyncio.create_task(
+                _openai_to_inkbox_pump(
+                    openai_ws=openai_ws,
+                    inkbox_ws=inkbox_ws,
+                    state=state,
+                    config=self.config,
+                    meta=self.meta,
+                    on_agent_consult=on_agent_consult,
+                ),
+                name=f"realtime-openai-pump-{self.meta.call_id}",
+            )
+
+            done, pending = await asyncio.wait(
+                {inkbox_task, openai_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for task in pending:
+                task.cancel()
+            for task in done:
+                try:
+                    exc = task.exception()
+                except asyncio.CancelledError:
+                    exc = None
+                if exc:
+                    logger.warning(
+                        "[Inkbox realtime] Pump %s raised: %s",
+                        task.get_name(),
+                        exc,
+                    )
+        finally:
+            state.closed = True
+            await self.close()
+
+        await _dispatch_post_call(state, self.meta, on_post_call_actions, on_call_ended)
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        with suppress(Exception):
+            await self.openai_ws.close()
+        with suppress(Exception):
+            await self.session.close()
+
+
+async def open_inkbox_realtime_bridge(
+    *,
+    config: RealtimeConfig,
+    meta: RealtimeCallMeta,
+) -> OpenedRealtimeBridge:
+    """Open OpenAI Realtime before the Inkbox websocket commits media mode."""
+    if aiohttp is None:
+        raise RealtimeBridgeConnectError("aiohttp not available")
+    if not config.has_credential:
+        raise RealtimeBridgeConnectError("no OpenAI API key configured")
+
+    session = aiohttp.ClientSession()
+    openai_ws = None
+    try:
+        bearer = await _resolve_realtime_bearer(session, config)
+        if not bearer:
+            raise RealtimeBridgeConnectError("no OpenAI bearer token resolved")
+
+        separator = "&" if "?" in config.base_url else "?"
+        url = f"{config.base_url}{separator}{urlencode({'model': config.model})}"
+        headers = _openai_realtime_ws_headers(bearer)
+        openai_ws = await asyncio.wait_for(
+            session.ws_connect(url, headers=headers, heartbeat=30),
+            timeout=config.connect_timeout_s,
+        )
+        await _send_session_update(openai_ws, config, meta)
+        return OpenedRealtimeBridge(
+            session=session,
+            openai_ws=openai_ws,
+            state=_BridgeState(),
+            config=config,
+            meta=meta,
+        )
+    except RealtimeBridgeConnectError:
+        if openai_ws is not None:
+            with suppress(Exception):
+                await openai_ws.close()
+        with suppress(Exception):
+            await session.close()
+        raise
+    except Exception as exc:
+        if openai_ws is not None:
+            with suppress(Exception):
+                await openai_ws.close()
+        with suppress(Exception):
+            await session.close()
+        raise RealtimeBridgeConnectError(exc) from exc
 
 
 async def run_inkbox_realtime_bridge(
@@ -478,77 +649,17 @@ async def run_inkbox_realtime_bridge(
     Errors are logged; the function does not re-raise so a partial failure
     doesn't crash the gateway's WS handler chain.
     """
-    if aiohttp is None:
-        logger.error("[Inkbox realtime] aiohttp not available; cannot open Realtime API WS")
-        return
-    if not config.has_credential:
-        logger.error("[Inkbox realtime] No OpenAI API key; refusing to bridge")
-        return
-
-    state = _BridgeState()
-    separator = "&" if "?" in config.base_url else "?"
-    url = f"{config.base_url}{separator}{urlencode({'model': config.model})}"
-
-    session = aiohttp.ClientSession()
     try:
-        try:
-            bearer = await _resolve_realtime_bearer(session, config)
-        except Exception as exc:
-            logger.error("[Inkbox realtime] Could not resolve OpenAI bearer: %s", exc)
-            return
-        if not bearer:
-            return
-
-        headers = _openai_realtime_ws_headers(bearer)
-        try:
-            openai_ws = await session.ws_connect(url, headers=headers, heartbeat=30)
-        except Exception as exc:
-            logger.error("[Inkbox realtime] Failed to connect to OpenAI Realtime: %s", exc)
-            return
-
-        try:
-            await _send_session_update(openai_ws, config, meta)
-            # Two concurrent pumps:
-            inkbox_task = asyncio.create_task(
-                _inkbox_to_openai_pump(inkbox_ws, openai_ws, state, meta),
-                name=f"realtime-inkbox-pump-{meta.call_id}",
-            )
-            openai_task = asyncio.create_task(
-                _openai_to_inkbox_pump(
-                    openai_ws=openai_ws,
-                    inkbox_ws=inkbox_ws,
-                    state=state,
-                    config=config,
-                    meta=meta,
-                    on_agent_consult=on_agent_consult,
-                ),
-                name=f"realtime-openai-pump-{meta.call_id}",
-            )
-
-            done, pending = await asyncio.wait(
-                {inkbox_task, openai_task},
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-            for task in pending:
-                task.cancel()
-            for task in done:
-                exc = task.exception()
-                if exc:
-                    logger.warning(
-                        "[Inkbox realtime] Pump %s raised: %s",
-                        task.get_name(),
-                        exc,
-                    )
-        finally:
-            state.closed = True
-            try:
-                await openai_ws.close()
-            except Exception:
-                pass
-
-        await _dispatch_post_call(state, meta, on_post_call_actions, on_call_ended)
-    finally:
-        await session.close()
+        bridge = await open_inkbox_realtime_bridge(config=config, meta=meta)
+    except RealtimeBridgeConnectError as exc:
+        logger.error("[Inkbox realtime] Failed to connect to OpenAI Realtime: %s", exc.cause)
+        return
+    await bridge.run(
+        inkbox_ws=inkbox_ws,
+        on_agent_consult=on_agent_consult,
+        on_post_call_actions=on_post_call_actions,
+        on_call_ended=on_call_ended,
+    )
 
 
 async def _dispatch_post_call(
@@ -560,7 +671,12 @@ async def _dispatch_post_call(
     """Dispatch exactly one follow-up turn after a call ends."""
     if state.post_call_actions:
         try:
-            await on_post_call_actions(meta, state.post_call_actions, list(state.transcript))
+            await on_post_call_actions(
+                meta,
+                state.post_call_actions,
+                list(state.transcript),
+                list(state.consult_results),
+            )
         except Exception as exc:
             logger.warning("[Inkbox realtime] Post-call action dispatch failed: %s", exc)
     else:
@@ -575,6 +691,42 @@ async def _resolve_realtime_bearer(session: Any, config: RealtimeConfig) -> str:
     if config.api_key:
         return config.api_key
     return ""
+
+
+def _normalize_consult_text(value: str) -> str:
+    return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9+]+", " ", value.lower())).strip()
+
+
+def _quoted_consult_text(value: str) -> Optional[str]:
+    match = re.search(r'["“]([^"”]{8,280})["”]', value)
+    if not match:
+        return None
+    normalized = _normalize_consult_text(match.group(1))
+    return normalized or None
+
+
+def _realtime_consult_dedupe_key(request: str) -> Optional[str]:
+    normalized = _normalize_consult_text(request)
+    phone_match = re.search(r"\+\d{8,15}", normalized)
+    is_sms = re.search(r"\b(sms|text|message)\b", normalized) is not None
+    if not phone_match or not is_sms:
+        return None
+    quoted = _quoted_consult_text(request) or "generic"
+    return f"sms:{phone_match.group(0)}:{quoted}"
+
+
+def _realtime_consult_allows_repeat(request: str) -> bool:
+    return re.search(r"\b(again|another|different|new|repeat|second)\b", request, re.I) is not None
+
+
+def _consult_result_text(output: Dict[str, Any]) -> str:
+    result = output.get("answer") or output.get("result")
+    if isinstance(result, str) and result.strip():
+        return result.strip()
+    error = output.get("error")
+    if isinstance(error, str) and error.strip():
+        return f"ERROR: {error.strip()}"
+    return json.dumps(output)
 
 
 async def _maybe_send_greeting(
@@ -1010,6 +1162,40 @@ async def _dispatch_tool_call(
             )
             return
 
+        consult_key = _realtime_consult_dedupe_key(query)
+        if consult_key and not _realtime_consult_allows_repeat(query):
+            pending_call_id = state.pending_consult_keys.get(consult_key)
+            if pending_call_id:
+                await _submit_tool_result(openai_ws, call_id, {
+                    "status": "already_running",
+                    "existing_tool_call_id": pending_call_id,
+                    "answer": (
+                        "Hermes is already handling this same in-call request. "
+                        "Do not call the consult tool again or queue a duplicate "
+                        "post-call action; wait briefly for the existing result."
+                    ),
+                })
+                return
+            completed = next(
+                (
+                    entry
+                    for entry in reversed(state.consult_results)
+                    if entry.dedupe_key == consult_key
+                ),
+                None,
+            )
+            if completed:
+                await _submit_tool_result(openai_ws, call_id, {
+                    "status": "already_handled",
+                    "existing_tool_call_id": completed.id,
+                    "answer": (
+                        "Hermes already handled this same in-call request: "
+                        f"{completed.result}. Do not send it again unless the "
+                        "caller explicitly asks for another, repeat, or different message."
+                    ),
+                })
+                return
+
         # OpenAI Realtime doesn't have a native "I'll continue later" mechanism
         # for one tool call, but we can ALSO inject an interim instruction so
         # the model says "one moment" while the agent thinks. The final tool
@@ -1033,36 +1219,80 @@ async def _dispatch_tool_call(
             # authoritative.
             pass
 
+        if consult_key:
+            state.pending_consult_keys[consult_key] = call_id
         try:
             answer = await asyncio.wait_for(
-                on_agent_consult(meta, query, list(state.transcript)),
+                on_agent_consult(
+                    meta,
+                    query,
+                    list(state.transcript),
+                    list(state.post_call_actions),
+                    list(state.consult_results),
+                ),
                 timeout=config.consult_timeout_s,
             )
         except asyncio.TimeoutError:
-            await _submit_tool_result(openai_ws, call_id, {
+            output = {
                 "error": "agent_consult timed out",
                 "message": (
                     "Tell the caller you couldn't get an answer right now. "
                     "Offer to follow up after the call."
                 ),
-            })
+            }
+            state.consult_results.append(RealtimeConsultResult(
+                id=call_id,
+                request=query,
+                result=_consult_result_text(output),
+                created_at=time.time(),
+                dedupe_key=consult_key,
+            ))
+            if consult_key and state.pending_consult_keys.get(consult_key) == call_id:
+                state.pending_consult_keys.pop(consult_key, None)
+            await _submit_tool_result(openai_ws, call_id, output)
             return
         except Exception as exc:
             logger.warning("[Inkbox realtime] agent_consult failed: %s", exc)
-            await _submit_tool_result(openai_ws, call_id, {
+            output = {
                 "error": f"agent_consult error: {exc}",
                 "message": "Apologize briefly and ask if you can help another way.",
-            })
+            }
+            state.consult_results.append(RealtimeConsultResult(
+                id=call_id,
+                request=query,
+                result=_consult_result_text(output),
+                created_at=time.time(),
+                dedupe_key=consult_key,
+            ))
+            if consult_key and state.pending_consult_keys.get(consult_key) == call_id:
+                state.pending_consult_keys.pop(consult_key, None)
+            await _submit_tool_result(openai_ws, call_id, output)
             return
 
-        await _submit_tool_result(openai_ws, call_id, {
+        output = {
             "status": "ok",
             "answer": answer,
             "instructions": (
                 "Read the answer back to the caller in your own spoken voice. "
                 "Keep it natural and concise."
             ),
-        })
+        }
+        if state.post_call_actions:
+            output["post_call_action_guidance"] = (
+                "If this result completed, queued, canceled, or superseded a "
+                "pending after-call action, call delete_post_call_action for "
+                "that action_index before the call ends."
+            )
+        state.consult_results.append(RealtimeConsultResult(
+            id=call_id,
+            request=query,
+            result=_consult_result_text(output),
+            created_at=time.time(),
+            dedupe_key=consult_key,
+        ))
+        if consult_key and state.pending_consult_keys.get(consult_key) == call_id:
+            state.pending_consult_keys.pop(consult_key, None)
+        await _submit_tool_result(openai_ws, call_id, output)
         return
 
     # Unknown tool — refuse politely.

--- a/tests/test_realtime_auth.py
+++ b/tests/test_realtime_auth.py
@@ -24,6 +24,8 @@ def _clear_realtime_env(monkeypatch):
     monkeypatch.delenv("INKBOX_REALTIME_MODEL", raising=False)
     monkeypatch.delenv("INKBOX_REALTIME_VOICE", raising=False)
     monkeypatch.delenv("INKBOX_REALTIME_CONSULT_TIMEOUT_S", raising=False)
+    monkeypatch.delenv("INKBOX_REALTIME_CONNECT_TIMEOUT_S", raising=False)
+    monkeypatch.delenv("INKBOX_REALTIME_FALLBACK_TO_INKBOX_STT_TTS", raising=False)
 
 
 def test_realtime_auto_stays_off_without_api_key(monkeypatch):
@@ -52,6 +54,26 @@ def test_realtime_explicit_enable_without_any_credential_stays_off(monkeypatch):
 
     assert cfg.enabled is False
     assert cfg.api_key == ""
+
+
+def test_realtime_fallback_defaults_on_and_can_be_disabled(monkeypatch):
+    _clear_realtime_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-wins")
+
+    cfg = adapter_mod._resolve_realtime_config({})
+    assert cfg.fallback_to_inkbox_stt_tts is True
+
+    cfg = adapter_mod._resolve_realtime_config({
+        "realtime": {
+            "enabled": True,
+            "fallback_to_inkbox_stt_tts": False,
+        }
+    })
+    assert cfg.fallback_to_inkbox_stt_tts is False
+
+    monkeypatch.setenv("INKBOX_REALTIME_FALLBACK_TO_INKBOX_STT_TTS", "false")
+    cfg = adapter_mod._resolve_realtime_config({})
+    assert cfg.fallback_to_inkbox_stt_tts is False
 
 
 class _FakeResponse:

--- a/tests/test_realtime_bridge_parity.py
+++ b/tests/test_realtime_bridge_parity.py
@@ -17,8 +17,10 @@ from inkbox_plugin.realtime import (
     EDIT_POST_CALL_ACTION_TOOL_NAME,
     HANG_UP_CALL_TOOL_NAME,
     POST_CALL_ACTION_TOOL_NAME,
+    RealtimeBridgeConnectError,
     RealtimeCallMeta,
     RealtimeConfig,
+    RealtimeConsultResult,
     _BridgeState,
     _dispatch_tool_call,
     _dispatch_post_call,
@@ -27,6 +29,7 @@ from inkbox_plugin.realtime import (
     _send_session_update,
     build_realtime_greeting,
     build_realtime_instructions,
+    open_inkbox_realtime_bridge,
 )
 
 
@@ -90,6 +93,23 @@ class _FakeOpenAIWS(_FakeWS):
             raise StopAsyncIteration
 
 
+class _FakeClientSession:
+    def __init__(self, *, ws=None, error=None):
+        self.ws = ws or _FakeWS()
+        self.error = error
+        self.calls = []
+        self.closed = False
+
+    async def ws_connect(self, url, *, headers, heartbeat):
+        self.calls.append({"url": url, "headers": headers, "heartbeat": heartbeat})
+        if self.error:
+            raise self.error
+        return self.ws
+
+    async def close(self):
+        self.closed = True
+
+
 def test_instructions_include_full_contact_and_outbound_context():
     text = build_realtime_instructions(_meta(
         contact_name="Dima Vremenko",
@@ -112,6 +132,43 @@ def test_instructions_include_full_contact_and_outbound_context():
     assert "Follow up on the overdue invoice" in text
     assert "billing workflow" in text
     assert "Customer promised to pay by Friday." in text
+
+
+def test_open_realtime_bridge_preflights_openai_before_inkbox_accept(monkeypatch):
+    openai_ws = _FakeWS()
+    session = _FakeClientSession(ws=openai_ws)
+    monkeypatch.setattr(realtime_mod.aiohttp, "ClientSession", lambda: session, raising=False)
+
+    bridge = asyncio.run(open_inkbox_realtime_bridge(
+        config=RealtimeConfig(enabled=True, api_key="sk-test", connect_timeout_s=1),
+        meta=_meta(),
+    ))
+
+    assert bridge.openai_ws is openai_ws
+    assert session.calls[0]["url"].startswith("wss://api.openai.com/v1/realtime?")
+    assert session.calls[0]["headers"] == {"Authorization": "Bearer sk-test"}
+    assert openai_ws.sent[0]["type"] == "session.update"
+
+    asyncio.run(bridge.close())
+    assert openai_ws.closed is True
+    assert session.closed is True
+
+
+def test_open_realtime_bridge_raises_connect_error_and_closes_session(monkeypatch):
+    session = _FakeClientSession(error=RuntimeError("boom"))
+    monkeypatch.setattr(realtime_mod.aiohttp, "ClientSession", lambda: session, raising=False)
+
+    try:
+        asyncio.run(open_inkbox_realtime_bridge(
+            config=RealtimeConfig(enabled=True, api_key="sk-test", connect_timeout_s=1),
+            meta=_meta(),
+        ))
+    except RealtimeBridgeConnectError as exc:
+        assert "boom" in str(exc.cause)
+    else:
+        raise AssertionError("expected RealtimeBridgeConnectError")
+
+    assert session.closed is True
 
 
 def test_session_update_exposes_post_call_edit_and_delete_tools():
@@ -386,20 +443,140 @@ def test_hangup_second_call_sleeps_then_sends_frame_and_closes_sockets(monkeypat
 def test_post_call_dispatch_runs_exactly_one_path():
     state = _BridgeState()
     state.post_call_actions = [{"action": "Email Dima", "details": ""}]
+    state.consult_results = [
+        RealtimeConsultResult(
+            id="consult-1",
+            request="Send SMS now",
+            result="SMS queued",
+            created_at=1.0,
+            dedupe_key="sms:+15555550101:generic",
+        )
+    ]
     calls = {"actions": 0, "ended": 0}
+    seen = {}
 
-    async def _actions(*_args):
+    async def _actions(meta, actions, transcript, consult_results):
         calls["actions"] += 1
+        seen["consult_results"] = consult_results
 
     async def _ended(*_args):
         calls["ended"] += 1
 
     asyncio.run(_dispatch_post_call(state, _meta(), _actions, _ended))
     assert calls == {"actions": 1, "ended": 0}
+    assert seen["consult_results"][0].result == "SMS queued"
 
     state = _BridgeState()
     asyncio.run(_dispatch_post_call(state, _meta(), _actions, _ended))
     assert calls == {"actions": 1, "ended": 1}
+
+
+def test_agent_consult_records_result_and_guides_post_call_cleanup():
+    state = _BridgeState()
+    state.post_call_actions = [{"action": "Text Alex after call", "details": ""}]
+    openai_ws = _FakeWS()
+    seen = {}
+
+    async def _consult(meta, query, transcript, post_call_actions, consult_results):
+        seen["query"] = query
+        seen["post_call_actions"] = post_call_actions
+        seen["consult_results"] = consult_results
+        return "SMS sent to Alex."
+
+    asyncio.run(_dispatch_tool_call(
+        openai_ws=openai_ws,
+        call_id="consult-call",
+        name="hermes_agent_consult",
+        arguments_json=json.dumps({"query": 'Send SMS to +15555550101 "hello alex" now'}),
+        state=state,
+        config=RealtimeConfig(enabled=True, api_key="sk-test"),
+        meta=_meta(),
+        on_agent_consult=_consult,
+    ))
+
+    assert seen["query"].startswith("Send SMS")
+    assert seen["post_call_actions"] == [{"action": "Text Alex after call", "details": ""}]
+    assert seen["consult_results"] == []
+    assert len(state.consult_results) == 1
+    assert state.consult_results[0].result == "SMS sent to Alex."
+    outputs = [
+        json.loads(frame["item"]["output"])
+        for frame in openai_ws.sent
+        if frame["type"] == "conversation.item.create"
+    ]
+    assert outputs[-1]["status"] == "ok"
+    assert "post_call_action_guidance" in outputs[-1]
+
+
+def test_agent_consult_dedupes_completed_same_sms_request():
+    state = _BridgeState()
+    state.consult_results = [
+        RealtimeConsultResult(
+            id="consult-original",
+            request='Send SMS to +15555550101 "hello alex"',
+            result="SMS sent to Alex.",
+            created_at=1.0,
+            dedupe_key="sms:+15555550101:hello alex",
+        )
+    ]
+    openai_ws = _FakeWS()
+    called = False
+
+    async def _consult(*_args):
+        nonlocal called
+        called = True
+        return "should not run"
+
+    asyncio.run(_dispatch_tool_call(
+        openai_ws=openai_ws,
+        call_id="consult-dupe",
+        name="hermes_agent_consult",
+        arguments_json=json.dumps({"query": 'Please text +15555550101 "hello alex"'}),
+        state=state,
+        config=RealtimeConfig(enabled=True, api_key="sk-test"),
+        meta=_meta(),
+        on_agent_consult=_consult,
+    ))
+
+    outputs = [
+        json.loads(frame["item"]["output"])
+        for frame in openai_ws.sent
+        if frame["type"] == "conversation.item.create"
+    ]
+    assert called is False
+    assert outputs[-1]["status"] == "already_handled"
+    assert outputs[-1]["existing_tool_call_id"] == "consult-original"
+
+
+def test_agent_consult_allows_explicit_repeat_sms_request():
+    state = _BridgeState()
+    state.consult_results = [
+        RealtimeConsultResult(
+            id="consult-original",
+            request='Send SMS to +15555550101 "hello alex"',
+            result="SMS sent to Alex.",
+            created_at=1.0,
+            dedupe_key="sms:+15555550101:hello alex",
+        )
+    ]
+    openai_ws = _FakeWS()
+
+    async def _consult(*_args):
+        return "Second SMS sent."
+
+    asyncio.run(_dispatch_tool_call(
+        openai_ws=openai_ws,
+        call_id="consult-repeat",
+        name="hermes_agent_consult",
+        arguments_json=json.dumps({"query": 'Send another text to +15555550101 "hello alex"'}),
+        state=state,
+        config=RealtimeConfig(enabled=True, api_key="sk-test"),
+        meta=_meta(),
+        on_agent_consult=_consult,
+    ))
+
+    assert len(state.consult_results) == 2
+    assert state.consult_results[-1].result == "Second SMS sent."
 
 
 def test_adapter_realtime_call_ended_enqueues_reflection():
@@ -435,11 +612,28 @@ def test_adapter_realtime_post_call_actions_enqueues_without_auto_skill():
     asyncio.run(adapter._realtime_post_call_actions(
         _meta(),
         [{"action": "Email Dima after the call", "details": "Keep it short."}],
-        [("caller", "Can you email me after this call?")],
+        [
+            ("caller", "Can you email me after this call?"),
+            ("agent", "I queued it for after the call."),
+        ],
+        [
+            RealtimeConsultResult(
+                id="consult-1",
+                request="Send the email now",
+                result="Email sent to Dima.",
+                created_at=1.0,
+            )
+        ],
     ))
 
     assert len(events) == 1
     assert "voice_post_call_actions" in events[0].text
     assert "Email Dima after the call" in events[0].text
+    assert "execute only the actions that are still needed" in events[0].text
+    assert "In-call Hermes consult results" in events[0].text
+    assert "Email sent to Dima." in events[0].text
+    assert "Full live-call transcript" in events[0].text
+    assert "I queued it for after the call." in events[0].text
     assert events[0].raw_message["event"] == "realtime_post_call_actions"
+    assert events[0].raw_message["consult_results"][0]["result"] == "Email sent to Dima."
     assert getattr(events[0], "auto_skill", None) is None


### PR DESCRIPTION
## Summary
- preflight OpenAI Realtime before accepting Inkbox raw-media calls, with configurable fallback to Inkbox STT/TTS
- track live-call consult results, pass them into post-call action handoff, and strengthen prompts to avoid duplicate/stale work
- dedupe repeated same-SMS consult requests unless the caller explicitly asks for another/repeat/different message
- document the port plan and new realtime fallback env vars

## Tests
- python3 -m pytest