### PR TITLE
Ignore self-originated inbound email

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -1088,6 +1088,7 @@ class InkboxAdapter(BasePlatformAdapter):
         ).strip()
         self._identity_id: Optional[str] = None
         self._identity_email_addresses: set[str] = set()
+        self._identity_email_addresses_loaded = False
         self._base_url = (
             extra.get("base_url") or os.getenv("INKBOX_BASE_URL") or INKBOX_BASE_URL_DEFAULT
         ).strip()
@@ -1463,6 +1464,7 @@ class InkboxAdapter(BasePlatformAdapter):
         identity = self._inkbox.get_identity(self._identity_handle)
         self._identity_id = str(getattr(identity, "id", "") or "") or None
         self._identity_email_addresses = _identity_email_addresses(identity)
+        self._identity_email_addresses_loaded = True
 
         # Mailbox: register the inbound-mail subscription.
         if identity.mailbox is not None:
@@ -1990,7 +1992,7 @@ class InkboxAdapter(BasePlatformAdapter):
         ):
             return True
 
-        if self._identity_email_addresses:
+        if getattr(self, "_identity_email_addresses_loaded", False):
             return from_address in self._identity_email_addresses
 
         if self._inkbox is None or not self._identity_handle:
@@ -2007,6 +2009,7 @@ class InkboxAdapter(BasePlatformAdapter):
 
         self._identity_id = str(getattr(identity, "id", "") or "") or None
         self._identity_email_addresses = _identity_email_addresses(identity)
+        self._identity_email_addresses_loaded = True
         if _mail_agent_identity_matches(
             envelope,
             from_address,

--- a/adapter.py
+++ b/adapter.py
@@ -736,6 +736,61 @@ def _plain_value(value: Any) -> Optional[str]:
     return text or None
 
 
+def _normalize_email_address(value: Any) -> str:
+    text = str(value or "").strip()
+    match = re.search(r"<([^<>]+)>", text)
+    if match:
+        text = match.group(1).strip()
+    text = re.sub(r"^mailto:", "", text, flags=re.IGNORECASE).strip().lower()
+    return text if "@" in text else ""
+
+
+def _normalized_identity_handle(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _identity_email_addresses(identity: Any) -> set[str]:
+    mailbox = _field(identity, "mailbox")
+    return {
+        addr
+        for addr in (
+            _normalize_email_address(_field(mailbox, "email_address", "emailAddress")),
+            _normalize_email_address(_field(identity, "email_address", "emailAddress")),
+        )
+        if addr
+    }
+
+
+def _mail_agent_identity_matches(
+    envelope: Dict[str, Any],
+    from_address: str,
+    *,
+    identity_handle: str = "",
+    identity_id: str = "",
+) -> bool:
+    handle = _normalized_identity_handle(identity_handle)
+    own_id = str(identity_id or "").strip()
+    if not handle and not own_id:
+        return False
+    identities = _webhook_list(
+        envelope.get("data") or {},
+        "agent_identities",
+        "agentIdentities",
+    )
+    for entry in identities:
+        bucket = _field(entry, "bucket")
+        address = _normalize_email_address(_field(entry, "address"))
+        if bucket != "from" or address != from_address:
+            continue
+        entry_id = str(_field(entry, "id") or "").strip()
+        entry_handle = _normalized_identity_handle(
+            _field(entry, "agent_handle", "agentHandle")
+        )
+        if (own_id and entry_id == own_id) or (handle and entry_handle == handle):
+            return True
+    return False
+
+
 def _json_safe_detail(value: Any) -> Any:
     """Keep structured provider error details if they are JSON-safe."""
     if isinstance(value, (dict, list, str, int, float, bool)) or value is None:
@@ -1031,6 +1086,8 @@ class InkboxAdapter(BasePlatformAdapter):
         self._identity_handle = (
             extra.get("identity") or os.getenv("INKBOX_IDENTITY") or ""
         ).strip()
+        self._identity_id: Optional[str] = None
+        self._identity_email_addresses: set[str] = set()
         self._base_url = (
             extra.get("base_url") or os.getenv("INKBOX_BASE_URL") or INKBOX_BASE_URL_DEFAULT
         ).strip()
@@ -1404,6 +1461,8 @@ class InkboxAdapter(BasePlatformAdapter):
         previous_webhook_url = _read_previous_webhook_url()
 
         identity = self._inkbox.get_identity(self._identity_handle)
+        self._identity_id = str(getattr(identity, "id", "") or "") or None
+        self._identity_email_addresses = _identity_email_addresses(identity)
 
         # Mailbox: register the inbound-mail subscription.
         if identity.mailbox is not None:
@@ -1918,10 +1977,56 @@ class InkboxAdapter(BasePlatformAdapter):
         self._seen_request_ids[request_id] = now
         return False
 
+    async def _is_self_mail_received(
+        self,
+        envelope: Dict[str, Any],
+        from_address: str,
+    ) -> bool:
+        if _mail_agent_identity_matches(
+            envelope,
+            from_address,
+            identity_handle=self._identity_handle,
+            identity_id=self._identity_id or "",
+        ):
+            return True
+
+        if self._identity_email_addresses:
+            return from_address in self._identity_email_addresses
+
+        if self._inkbox is None or not self._identity_handle:
+            return False
+
+        try:
+            identity = await asyncio.to_thread(
+                self._inkbox.get_identity,
+                self._identity_handle,
+            )
+        except Exception as exc:
+            logger.debug("[Inkbox] Could not resolve identity for self-mail check: %s", exc)
+            return False
+
+        self._identity_id = str(getattr(identity, "id", "") or "") or None
+        self._identity_email_addresses = _identity_email_addresses(identity)
+        if _mail_agent_identity_matches(
+            envelope,
+            from_address,
+            identity_handle=self._identity_handle,
+            identity_id=self._identity_id or "",
+        ):
+            return True
+        return from_address in self._identity_email_addresses
+
     async def _on_mail_received(self, envelope: Dict[str, Any]) -> "web.Response":
         message = (envelope.get("data") or {}).get("message") or {}
-        from_address = (message.get("from_address") or "").strip().lower()
+        from_address = _normalize_email_address(message.get("from_address"))
         if not from_address:
+            return web.Response(status=200, text="ok")
+
+        if await self._is_self_mail_received(envelope, from_address):
+            logger.info(
+                "[Inkbox] Ignored self-originated inbound email from %s; not waking agent",
+                from_address,
+            )
             return web.Response(status=200, text="ok")
 
         contact = await self._resolve_contact_full(kind="email", value=from_address)

--- a/tests/test_email_self_guard.py
+++ b/tests/test_email_self_guard.py
@@ -1,0 +1,117 @@
+import asyncio
+import sys
+import types
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("inkbox_plugin")
+pkg.__path__ = [str(ROOT)]
+sys.modules.setdefault("inkbox_plugin", pkg)
+
+from inkbox_plugin import adapter as adapter_mod
+from inkbox_plugin.adapter import InkboxAdapter
+
+
+def _mail_envelope(from_address, *, agent_identities=None):
+    return {
+        "event_type": "message.received",
+        "timestamp": "2026-05-21T00:00:00Z",
+        "data": {
+            "message": {
+                "id": "mail-in-1",
+                "mailbox_id": "mailbox-1",
+                "thread_id": "thread-1",
+                "message_id": "<mail-in-1@example.com>",
+                "from_address": from_address,
+                "to_addresses": ["agent@inkboxmail.com"],
+                "cc_addresses": None,
+                "bcc_addresses": None,
+                "subject": "Loop test",
+                "snippet": "Please reply to yourself.",
+                "direction": "inbound",
+                "status": "received",
+                "has_attachments": False,
+                "created_at": "2026-05-21T00:00:00Z",
+            },
+            "contacts": [],
+            "agent_identities": agent_identities or [],
+        },
+    }
+
+
+def _adapter_for_self_mail_check():
+    adapter = object.__new__(InkboxAdapter)
+    adapter._identity_handle = "agent"
+    adapter._identity_id = None
+    adapter._identity_email_addresses = {"agent@inkboxmail.com"}
+    adapter._inkbox = None
+    return adapter
+
+
+def test_inbound_email_from_own_mailbox_does_not_wake_agent(monkeypatch):
+    monkeypatch.setattr(
+        adapter_mod,
+        "web",
+        types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
+    )
+    calls = {"resolve": 0, "enqueue": 0}
+
+    async def _resolve_contact_full(**_kwargs):
+        calls["resolve"] += 1
+        return None
+
+    async def _enqueue(_event):
+        calls["enqueue"] += 1
+
+    adapter = _adapter_for_self_mail_check()
+    adapter._resolve_contact_full = _resolve_contact_full
+    adapter._enqueue = _enqueue
+
+    response = asyncio.run(
+        adapter._on_mail_received(_mail_envelope("Agent <agent@inkboxmail.com>"))
+    )
+
+    assert response.status == 200
+    assert calls == {"resolve": 0, "enqueue": 0}
+
+
+def test_inbound_email_from_same_agent_identity_marker_does_not_wake_agent(monkeypatch):
+    monkeypatch.setattr(
+        adapter_mod,
+        "web",
+        types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
+    )
+    calls = {"resolve": 0, "enqueue": 0}
+
+    async def _resolve_contact_full(**_kwargs):
+        calls["resolve"] += 1
+        return None
+
+    async def _enqueue(_event):
+        calls["enqueue"] += 1
+
+    adapter = _adapter_for_self_mail_check()
+    adapter._identity_email_addresses = set()
+    adapter._resolve_contact_full = _resolve_contact_full
+    adapter._enqueue = _enqueue
+
+    response = asyncio.run(
+        adapter._on_mail_received(
+            _mail_envelope(
+                "alias@inkboxmail.com",
+                agent_identities=[
+                    {
+                        "bucket": "from",
+                        "address": "alias@inkboxmail.com",
+                        "id": "identity-1",
+                        "agent_handle": "agent",
+                        "display_name": "Agent",
+                    },
+                ],
+            )
+        )
+    )
+
+    assert response.status == 200
+    assert calls == {"resolve": 0, "enqueue": 0}

--- a/tests/test_email_self_guard.py
+++ b/tests/test_email_self_guard.py
@@ -45,6 +45,7 @@ def _adapter_for_self_mail_check():
     adapter._identity_handle = "agent"
     adapter._identity_id = None
     adapter._identity_email_addresses = {"agent@inkboxmail.com"}
+    adapter._identity_email_addresses_loaded = True
     adapter._inkbox = None
     return adapter
 
@@ -74,6 +75,32 @@ def test_inbound_email_from_own_mailbox_does_not_wake_agent(monkeypatch):
 
     assert response.status == 200
     assert calls == {"resolve": 0, "enqueue": 0}
+
+
+def test_self_mail_check_caches_identity_with_no_mailbox_address(monkeypatch):
+    calls = {"get_identity": 0}
+
+    async def _inline_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    class FakeInkbox:
+        def get_identity(self, _handle):
+            calls["get_identity"] += 1
+            return types.SimpleNamespace(id="identity-1", mailbox=None, email_address=None)
+
+    monkeypatch.setattr(adapter_mod.asyncio, "to_thread", _inline_to_thread)
+    adapter = object.__new__(InkboxAdapter)
+    adapter._identity_handle = "agent"
+    adapter._identity_id = None
+    adapter._identity_email_addresses = set()
+    adapter._identity_email_addresses_loaded = False
+    adapter._inkbox = FakeInkbox()
+
+    envelope = _mail_envelope("person@example.com")
+
+    assert asyncio.run(adapter._is_self_mail_received(envelope, "person@example.com")) is False
+    assert asyncio.run(adapter._is_self_mail_received(envelope, "person@example.com")) is False
+    assert calls["get_identity"] == 1
 
 
 def test_inbound_email_from_same_agent_identity_marker_does_not_wake_agent(monkeypatch):


### PR DESCRIPTION
## Summary
- suppress inbound email wakeups when the sender is the configured Inkbox agent mailbox
- also suppress when the mail webhook from-bucket agent identity marker matches the configured agent identity
- normalize inbound mail from-addresses before self checks, contact lookup, and routing so display-name / angle-bracket / mailto forms resolve consistently
- cache/lazily resolve the local identity addresses used by the self-mail guard, including the no-mailbox-address case
- add unit coverage for both self-origin signals and the empty-address cache case

## Testing
- pytest tests/test_email_self_guard.py
- pytest