### PR TITLE
Run hermes_agent_consult off the realtime audio pump (fix mid-call dead air)

### DIFF
--- a/realtime.py
+++ b/realtime.py
@@ -20,9 +20,11 @@ The bridge:
    ``media`` frames carrying ``response.audio.delta`` payloads.
 4. Exposes realtime-only tools to the model:
 
-   - ``hermes_agent_consult`` — pauses the conversation, dispatches a synthetic
-     SMS-mode turn through Hermes' main agent loop, and submits the agent's
-     reply as the tool result so the realtime model can speak it.
+   - ``hermes_agent_consult`` — dispatches a synthetic SMS-mode turn through
+     Hermes' main agent loop *in the background* and submits the agent's reply
+     as the tool result so the realtime model can speak it. It runs off the
+     audio pump so the model can keep talking (filler, small talk, barge-in)
+     while the main agent thinks, rather than the call going silent.
    - ``register_post_call_action`` — queues a follow-up task. When the call
      ends, all queued actions are dispatched as a single synthetic SMS-mode
      turn so the main agent can execute them (send email, create note, etc.).
@@ -45,7 +47,7 @@ import re
 import time
 from contextlib import suppress
 from dataclasses import dataclass, field
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Set, Tuple
 from urllib.parse import urlencode
 
 try:
@@ -329,6 +331,11 @@ class _BridgeState:
     # Monotonic timestamp of the first hang_up_call ("armed"). A second call
     # within HANGUP_CONFIRM_WINDOW_S fires the real hangup. None = not yet armed.
     hangup_armed_at: Optional[float] = None
+    # In-flight hermes_agent_consult dispatches. The consult tool runs the full
+    # main agent loop (seconds), so it is dispatched as a background task to keep
+    # the OpenAI→Inkbox audio pump flowing; we track the tasks here so they can
+    # be cancelled when the call tears down.
+    consult_tasks: Set["asyncio.Task[None]"] = field(default_factory=set)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -568,6 +575,10 @@ class OpenedRealtimeBridge:
                     )
         finally:
             state.closed = True
+            # The call is over, so any consult still mid-flight can no longer be
+            # spoken to the caller — cancel the background tasks and let them
+            # settle before we close the sockets.
+            await _cancel_consult_tasks(state)
             await self.close()
 
         await _dispatch_post_call(state, self.meta, on_post_call_actions, on_call_ended)
@@ -660,6 +671,17 @@ async def run_inkbox_realtime_bridge(
         on_post_call_actions=on_post_call_actions,
         on_call_ended=on_call_ended,
     )
+
+
+async def _cancel_consult_tasks(state: _BridgeState) -> None:
+    """Cancel any in-flight background consult tasks and await their teardown."""
+    tasks = list(state.consult_tasks)
+    state.consult_tasks.clear()
+    for task in tasks:
+        task.cancel()
+    for task in tasks:
+        with suppress(asyncio.CancelledError, Exception):
+            await task
 
 
 async def _dispatch_post_call(
@@ -859,10 +881,11 @@ async def _openai_to_inkbox_pump(
         if not cid or cid in dispatched:
             return
         dispatched.add(cid)
-        await _dispatch_tool_call(
+        name = entry.get("name") or ""
+        coro = _dispatch_tool_call(
             openai_ws=openai_ws,
             call_id=cid,
-            name=entry.get("name") or "",
+            name=name,
             arguments_json=entry.get("args") or "{}",
             state=state,
             config=config,
@@ -870,6 +893,20 @@ async def _openai_to_inkbox_pump(
             on_agent_consult=on_agent_consult,
             inkbox_ws=inkbox_ws,
         )
+        # hermes_agent_consult runs the full main agent loop, which can take many
+        # seconds. Awaiting it inline here would block this read loop for the
+        # whole consult — no audio deltas (not even the "one moment" filler) and
+        # no barge-in would reach the caller, so the agent appears to go silent.
+        # Dispatch it as a background task instead; the pump keeps streaming
+        # audio while the agent thinks, and the task submits the tool result when
+        # it finishes (this is exactly the async-tool flow gpt-realtime expects).
+        # Every other tool is an instant in-memory op, so it stays inline.
+        if name == AGENT_CONSULT_TOOL_NAME:
+            task = asyncio.create_task(coro, name=f"realtime-consult-{cid}")
+            state.consult_tasks.add(task)
+            task.add_done_callback(state.consult_tasks.discard)
+        else:
+            await coro
 
     async for msg in openai_ws:
         if state.closed:

--- a/tests/test_realtime_bridge_parity.py
+++ b/tests/test_realtime_bridge_parity.py
@@ -13,6 +13,7 @@ sys.modules.setdefault("inkbox_plugin", pkg)
 from inkbox_plugin import adapter as adapter_mod
 from inkbox_plugin import realtime as realtime_mod
 from inkbox_plugin.realtime import (
+    AGENT_CONSULT_TOOL_NAME,
     DELETE_POST_CALL_ACTION_TOOL_NAME,
     EDIT_POST_CALL_ACTION_TOOL_NAME,
     HANG_UP_CALL_TOOL_NAME,
@@ -301,6 +302,102 @@ def test_ga_function_call_events_dispatch_once_with_buffered_name():
     ))
 
     assert state.post_call_actions == [{"action": "Email Dima", "details": ""}]
+
+
+def test_agent_consult_does_not_block_audio_pump():
+    # The consult tool runs the full main agent loop and can take seconds. It
+    # must be dispatched off the read loop so audio (and barge-in) keep flowing
+    # while the agent thinks — otherwise the caller hears dead air. Under the old
+    # inline-await behavior this test would deadlock: the pump would never read
+    # past the consult frame to forward the audio delta.
+
+    async def _run():
+        release = asyncio.Event()
+
+        async def _slow_consult(*_args, **_kwargs):
+            await release.wait()  # hold the consult open like a slow agent turn
+            return "Your balance is forty two dollars."
+
+        inkbox_ws = _FakeWS()
+        openai_ws = _FakeOpenAIWS([
+            # Model invokes the consult tool...
+            {
+                "type": "response.output_item.added",
+                "item": {
+                    "type": "function_call",
+                    "id": "item-c",
+                    "call_id": "consult-1",
+                    "name": AGENT_CONSULT_TOOL_NAME,
+                },
+            },
+            {
+                "type": "response.function_call_arguments.done",
+                "item_id": "item-c",
+                "call_id": "consult-1",
+                "arguments": '{"query":"what is my balance"}',
+            },
+            # ...and audio arrives WHILE the consult is still running. The pump
+            # must forward this without waiting for the consult to finish.
+            {"type": "response.output_audio.delta", "delta": "ONEMOMENT"},
+        ])
+        state = _BridgeState()
+        state.stream_id = "stream-c"
+
+        await _openai_to_inkbox_pump(
+            openai_ws=openai_ws,
+            inkbox_ws=inkbox_ws,
+            state=state,
+            config=RealtimeConfig(enabled=True, api_key="sk-test"),
+            meta=_meta(),
+            on_agent_consult=_slow_consult,
+        )
+
+        # Audio that arrived during the consult reached Inkbox even though the
+        # consult has not returned yet.
+        assert any(
+            frame.get("event") == "media"
+            and frame["media"]["payload"] == "ONEMOMENT"
+            for frame in inkbox_ws.sent
+        )
+        # The consult was handed off to a background task, not awaited inline.
+        assert len(state.consult_tasks) == 1
+        # The slow consult result has NOT been submitted to OpenAI yet.
+        assert [
+            frame for frame in openai_ws.sent
+            if frame["type"] == "conversation.item.create"
+        ] == []
+
+        # Release the consult and let the background task finish; its result is
+        # then recorded for post-call follow-up.
+        release.set()
+        for task in list(state.consult_tasks):
+            await task
+        assert state.consult_results
+        assert state.consult_results[0].result == "Your balance is forty two dollars."
+
+    asyncio.run(_run())
+
+
+def test_inflight_consult_is_cancelled_when_call_tears_down():
+    # If the call ends with a consult still running, the bridge cancels the
+    # background task instead of leaking it.
+    async def _run():
+        state = _BridgeState()
+        never = asyncio.Event()
+
+        async def _hang():
+            await never.wait()
+
+        task = asyncio.create_task(_hang())
+        state.consult_tasks.add(task)
+
+        from inkbox_plugin.realtime import _cancel_consult_tasks
+        await _cancel_consult_tasks(state)
+
+        assert task.cancelled()
+        assert state.consult_tasks == set()
+
+    asyncio.run(_run())
 
 
 def test_edit_and_delete_post_call_actions_by_index():


### PR DESCRIPTION
## Problem

On realtime voice calls, the agent **goes silent** whenever it uses `hermes_agent_consult` to ask the main Hermes agent for something (look up an email, check history, hit an API, etc.). The caller hears dead air for the whole consult, then the answer arrives all at once.

## Root cause

The bridge reads OpenAI's websocket in a single loop — `_openai_to_inkbox_pump` — and **awaited every tool call inline** in that loop:

```python
await _dispatch_tool_call(...)   # for a consult, this awaits the full agent loop
```

For `hermes_agent_consult`, that inline `await` runs the entire main agent turn, bounded only by `consult_timeout_s` (60s). While it runs, the loop **stops reading OpenAI**, so:

- no `response.audio.delta` frames are forwarded to the caller — **including the "one moment" filler** the consult branch emits right before the agent call, so even that mitigation never reaches the caller;
- barge-in (`speech_started` → `clear`) is frozen.

The result is dead air that looks like the agent stopped talking.

This also defeats `gpt-realtime`'s native async-tool behavior. Per OpenAI's docs, the model will happily keep the conversation fluid while a tool runs — but only if the client keeps pumping audio. A blocking read loop takes that away.

## Fix

Dispatch `hermes_agent_consult` as a **background task** instead of awaiting it inline, so the read loop keeps streaming audio (filler, small talk, barge-in) while the main agent thinks. The task submits the `function_call_output` + `response.create` when the agent returns, exactly as before — only now it's off the audio path. Every other tool is an instant in-memory op and stays inline.

In-flight consult tasks are tracked on the bridge state and cancelled on call teardown, so nothing leaks if the call ends mid-consult.

## How others handle this

- **gpt-realtime native async tool calls** — the model continues the conversation while a tool runs; the only requirement is a non-blocking client. (This bridge already runs `gpt-realtime-2`, so the fix simply stops getting in the model's way.)
- **Filler / preamble phrases** ("let me check that…") — already present here as "one moment"; it only becomes audible once the pump is unblocked.
- **Barge-in / interruption** — likewise restored once the loop keeps reading.

## Changes

- `realtime.py` — background the consult dispatch in `_finalize_fn_call`; track tasks on `_BridgeState.consult_tasks`; add `_cancel_consult_tasks` and call it on teardown; update the module docstring.
- `tests/test_realtime_bridge_parity.py` — add a regression test proving audio is forwarded while a consult is still in flight (this test deadlocks under the old inline-await behavior), plus a teardown-cancellation test.

All 62 tests pass.