### PR TITLE
Add iMessage support: wizard onboarding, gateway routing, and agent tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ iMessage works differently from SMS: the agent does not get its own iMessage num
 3. Inkbox texts back from the number assigned to that conversation. Send any first message there — the agent can only reply after you message it first (recipient-first; there is no cold outreach over iMessage).
 4. The setup wizard waits for that first message and replies with a welcome confirming the channel. From then on, the gateway routes the thread into the same contact-keyed Hermes session as email/SMS/voice, and the agent replies over iMessage by default to whoever last reached it there.
 
-If a person disconnects the agent, outbound sends to that conversation fail until they reconnect through the router and message the agent again.
+If a person disconnects the agent, outbound sends to that conversation fail until they reconnect through the router and message the agent again. Conversation rows expose `assignment_status` (`active`/`released`) so the agent can see this, and `inkbox_list_imessage_assignments` lists who is currently connected. Outbound delivery transitions (`imessage.sent`, `imessage.delivered`, `imessage.delivery_failed`) arrive as webhooks and are logged by the gateway without waking the agent, matching the SMS lifecycle handling.
 
 ## CLI
 
@@ -234,6 +234,7 @@ Hermes direct tools:
 - `inkbox_mark_text_conversation_read`
 - `inkbox_imessage_triage_number`
 - `inkbox_send_imessage`
+- `inkbox_list_imessage_assignments`
 - `inkbox_list_imessage_conversations`
 - `inkbox_get_imessage_conversation`
 - `inkbox_send_imessage_reaction`

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Hermes Agent Inkbox Plugin
 
-[Inkbox](https://inkbox.ai) platform plugin for [Hermes Agent](https://github.com/NousResearch/hermes-agent). It gives a Hermes agent its own Inkbox identity: mailbox, phone number, SMS/MMS, voice calls, contact rules, an Inkbox tunnel, realtime phone calls, and bundled Inkbox skills without forking Hermes.
+[Inkbox](https://inkbox.ai) platform plugin for [Hermes Agent](https://github.com/NousResearch/hermes-agent). It gives a Hermes agent its own Inkbox identity: mailbox, phone number, SMS/MMS, iMessage, voice calls, contact rules, an Inkbox tunnel, realtime phone calls, and bundled Inkbox skills without forking Hermes.
 
-Status: gateway platform adapter, setup wizard, doctor checks, SMS/MMS batching, 1:1 and group SMS conversations, inbound email/SMS/voice, OpenAI Realtime phone calls, post-call actions, SMS conversation tools, and package-included skills are implemented.
+Status: gateway platform adapter, setup wizard, doctor checks, SMS/MMS batching, 1:1 and group SMS conversations, inbound email/SMS/iMessage/voice, OpenAI Realtime phone calls, post-call actions, SMS and iMessage conversation tools, and package-included skills are implemented.
 
 ## Prerequisites
 
@@ -47,7 +47,7 @@ Start the gateway:
 hermes gateway run
 ```
 
-Keep that process running. On startup the plugin opens an Inkbox tunnel, configures mail/text webhook subscriptions and the incoming-call URL, and routes inbound email, SMS, and calls into Hermes sessions.
+Keep that process running. On startup the plugin opens an Inkbox tunnel, configures mail/text/iMessage webhook subscriptions and the incoming-call URL, and routes inbound email, SMS, iMessage, and calls into Hermes sessions.
 
 To update an existing install:
 
@@ -60,14 +60,15 @@ hermes gateway restart
 
 `hermes inkbox setup` walks the active Hermes install through Inkbox configuration:
 
-1. Installs or upgrades `inkbox>=0.4.6` and `aiohttp>=3.9` in the Hermes Python environment when needed.
+1. Installs or upgrades `inkbox>=0.4.7` and `aiohttp>=3.9` in the Hermes Python environment when needed.
 2. Authenticates to Inkbox, or starts self-signup if you do not have an API key yet.
 3. Resolves or creates the Inkbox agent identity for this Hermes gateway.
 4. Optionally provisions a local US phone number so SMS and voice are available.
 5. Offers OpenAI Realtime for calls when a phone number exists, validates the OpenAI API key, and stores `INKBOX_REALTIME_*` settings only when validation succeeds.
-6. Stores `INKBOX_API_KEY`, `INKBOX_IDENTITY`, `INKBOX_SIGNING_KEY`, and related settings in `~/.hermes/.env`.
-7. Points the identity's mailbox and phone number at the agent-owned Inkbox tunnel.
-8. Prints the final mailbox/phone summary and next commands.
+6. Offers to enable iMessage for the agent (existing or freshly created), then walks you through connecting your iPhone: text the connect command to the Inkbox iMessage router, message the agent once, and receive a welcome reply confirming the channel.
+7. Stores `INKBOX_API_KEY`, `INKBOX_IDENTITY`, `INKBOX_SIGNING_KEY`, and related settings in `~/.hermes/.env`.
+8. Points the identity's mailbox, phone number, and iMessage events at the agent-owned Inkbox tunnel.
+9. Prints the final mailbox/phone summary and next commands.
 
 If setup provisions a new local phone number, it waits for an inbound SMS `START` to that number before finishing. Text `START` from every phone that should receive outbound SMS from the agent.
 
@@ -80,13 +81,13 @@ The setup wizard installs dependencies into the Python environment that runs Her
 If the wizard prints a missing-SDK warning, use the exact command it prints. It will look like this:
 
 ```bash
-/path/to/hermes/venv/bin/python3 -m pip install 'inkbox>=0.4.6' 'aiohttp>=3.9'
+/path/to/hermes/venv/bin/python3 -m pip install 'inkbox>=0.4.7' 'aiohttp>=3.9'
 ```
 
 When `uv` is available, the wizard prefers:
 
 ```bash
-uv pip install --python /path/to/hermes/venv/bin/python3 'inkbox>=0.4.6' 'aiohttp>=3.9'
+uv pip install --python /path/to/hermes/venv/bin/python3 'inkbox>=0.4.7' 'aiohttp>=3.9'
 ```
 
 Do not use plain `pip install inkbox aiohttp` unless the wizard tells you to; plain `pip` may point at pyenv, Homebrew, system Python, or another virtualenv.
@@ -146,6 +147,17 @@ Realtime calls receive the agent's Inkbox handle, mailbox, phone number, caller 
 
 When Realtime is enabled, the plugin preflights the OpenAI Realtime websocket before accepting the Inkbox call in raw-media mode. If that preflight fails, calls fall back to Inkbox STT/TTS by default. Set `INKBOX_REALTIME_FALLBACK_TO_INKBOX_STT_TTS=false` to fail the call instead.
 
+## iMessage
+
+iMessage works differently from SMS: the agent does not get its own iMessage number. People connect to the agent through the Inkbox iMessage router, and each connected person gets a dedicated thread with the agent.
+
+1. Enable iMessage for the agent during `hermes inkbox setup` (or later by rerunning it). Enablement is stored on the Inkbox identity, not in local config.
+2. From an iPhone, text the connect command (for example `connect @my-agent-handle`) to the Inkbox iMessage router number. The wizard prints both, and the agent can also share them via the `inkbox_imessage_triage_number` tool.
+3. Inkbox texts back from the number assigned to that conversation. Send any first message there — the agent can only reply after you message it first (recipient-first; there is no cold outreach over iMessage).
+4. The setup wizard waits for that first message and replies with a welcome confirming the channel. From then on, the gateway routes the thread into the same contact-keyed Hermes session as email/SMS/voice, and the agent replies over iMessage by default to whoever last reached it there.
+
+If a person disconnects the agent, outbound sends to that conversation fail until they reconnect through the router and message the agent again.
+
 ## CLI
 
 ```bash
@@ -181,8 +193,9 @@ After the gateway starts:
 3. Send the agent an SMS and verify it replies in the same SMS thread.
 4. Add the agent to a group SMS/MMS conversation and verify it stays silent for unrelated chatter, then replies in the same conversation when addressed.
 5. Send the agent an email and verify it replies from its Inkbox mailbox.
-6. Call the agent phone number and ask for its handle, email, and phone.
-7. Ask during a call for a post-call SMS or email follow-up, then verify it sends after hangup.
+6. If iMessage is enabled, connect via the iMessage router, message the agent, and verify it replies in the same iMessage thread.
+7. Call the agent phone number and ask for its handle, email, and phone.
+8. Ask during a call for a post-call SMS or email follow-up, then verify it sends after hangup.
 
 ## Config Reference
 
@@ -190,7 +203,7 @@ After the gateway starts:
 |---|---|---|---|
 | `INKBOX_API_KEY` | yes | - | Agent-scoped Inkbox API key. Admin keys are accepted by setup so it can create or choose an identity. |
 | `INKBOX_IDENTITY` | yes | - | Inkbox agent identity handle. |
-| `INKBOX_SIGNING_KEY` | inbound | - | Webhook HMAC secret. Required for signed inbound email, SMS, and calls. |
+| `INKBOX_SIGNING_KEY` | inbound | - | Webhook HMAC secret. Required for signed inbound email, SMS, iMessage, and calls. |
 | `INKBOX_REQUIRE_SIGNATURE` | no | `true` | Refuse unsigned inbound webhooks unless set to `false`. |
 | `INKBOX_BASE_URL` | no | `https://inkbox.ai` | Override Inkbox API base URL. |
 | `INKBOX_PUBLIC_URL` | no | - | Public Hermes gateway URL. If omitted, the plugin opens an Inkbox tunnel. |
@@ -219,6 +232,12 @@ Hermes direct tools:
 - `inkbox_get_text`
 - `inkbox_mark_text_read`
 - `inkbox_mark_text_conversation_read`
+- `inkbox_imessage_triage_number`
+- `inkbox_send_imessage`
+- `inkbox_list_imessage_conversations`
+- `inkbox_get_imessage_conversation`
+- `inkbox_send_imessage_reaction`
+- `inkbox_mark_imessage_conversation_read`
 - `inkbox_place_call`
 
 Realtime-only call tools:
@@ -238,6 +257,7 @@ The plugin registers all `skills/*/SKILL.md` files with Hermes.
 | `inkbox-troubleshooting` | Runtime/config errors, failed tools, readiness issues |
 | `inkbox-email-triage` | Checking or replying to Inkbox email |
 | `inkbox-sms-responder` | Sending, replying to, or triaging SMS |
+| `inkbox-imessage-responder` | Sending, replying to, or triaging iMessage |
 | `inkbox-outbound-calling` | Placing calls to numbers or contacts |
 | `inkbox-call-review` | Reviewing calls and transcripts |
 | `inkbox-contact-lookup` | Resolving, creating, or updating contacts |
@@ -257,7 +277,7 @@ python -m pytest tests/test_realtime_auth.py tests/test_realtime_bridge_parity.p
 ## Architecture Notes
 
 - Agent-scoped: runtime should use an Inkbox agent-scoped API key.
-- Tunnel-first inbound: with a signing key, gateway opens an Inkbox tunnel, creates mail/text webhook subscriptions, and wires the incoming-call URL.
+- Tunnel-first inbound: with a signing key, gateway opens an Inkbox tunnel, creates mail/text webhook subscriptions (plus an identity-owned iMessage subscription when enabled), and wires the incoming-call URL.
 - Voice: Inkbox STT/TTS fallback path and realtime raw-media path both route through the same call WebSocket.
 - Post-call actions: realtime calls can register, edit, delete, and dispatch work for the main Hermes agent after hangup.
 - Identity-aware calls: call prompts include agent handle/mailbox/phone/tunnel and known caller contact metadata.

--- a/__init__.py
+++ b/__init__.py
@@ -158,11 +158,11 @@ def register(ctx) -> None:
         pii_safe=True,
         emoji="📨",
         platform_hint=(
-            "You are chatting through Inkbox email, SMS/MMS, or voice. "
-            "Inbound messages may start with an [inkbox:...] routing marker; "
-            "use it for channel/contact context and never echo it. During live "
-            "voice calls, answer conversationally in text; the adapter speaks "
-            "the response over the active call."
+            "You are chatting through Inkbox email, SMS/MMS, iMessage, or "
+            "voice. Inbound messages may start with an [inkbox:...] routing "
+            "marker; use it for channel/contact context and never echo it. "
+            "During live voice calls, answer conversationally in text; the "
+            "adapter speaks the response over the active call."
         ),
     )
     register_tools(ctx)

--- a/adapter.py
+++ b/adapter.py
@@ -183,14 +183,17 @@ _DESIRED_TEXT_EVENTS: tuple[str, ...] = (
 
 # iMessage: inbound plus the outbound delivery lifecycle, consumed by
 # _on_imessage_received / _on_imessage_lifecycle — same split as text.
-# Tapback reactions (``imessage.reaction_received``) are deliberately not
-# subscribed: waking the agent for every thumbs-up isn't worth a turn, and
-# live reactions are visible on message reads anyway.
+# Tapback reactions (``imessage.reaction_received``) are subscribed and
+# routed to _on_imessage_reaction, which enqueues a turn carrying the
+# reaction + a response policy: the agent decides whether to reply or emit
+# [SILENT] (a "?" tapback usually warrants a reply, a "love" usually does
+# not). The agent can also send its own tapbacks via inkbox_send_imessage_reaction.
 _DESIRED_IMESSAGE_EVENTS: tuple[str, ...] = (
     "imessage.received",
     "imessage.sent",
     "imessage.delivered",
     "imessage.delivery_failed",
+    "imessage.reaction_received",
 )
 
 
@@ -1185,6 +1188,11 @@ class InkboxAdapter(BasePlatformAdapter):
         self._identity_id: Optional[str] = None
         self._identity_email_addresses: set[str] = set()
         self._identity_email_addresses_loaded = False
+        # Background tasks that refresh the iMessage typing indicator while
+        # the agent processes an inbound message, keyed by conversation_id.
+        # Started in _start_imessage_typing, cancelled in _stop_imessage_typing
+        # (on send or on failure).
+        self._imessage_typing_tasks: Dict[str, "asyncio.Task"] = {}
         self._base_url = (
             extra.get("base_url") or os.getenv("INKBOX_BASE_URL") or INKBOX_BASE_URL_DEFAULT
         ).strip()
@@ -1422,6 +1430,17 @@ class InkboxAdapter(BasePlatformAdapter):
             )
         self._pending_sms_text_batch_tasks.clear()
         self._pending_sms_text_batches.clear()
+
+        # Cancel any iMessage typing pulses still running.
+        for task in list(self._imessage_typing_tasks.values()):
+            if not task.done():
+                task.cancel()
+        if self._imessage_typing_tasks:
+            await asyncio.gather(
+                *self._imessage_typing_tasks.values(),
+                return_exceptions=True,
+            )
+        self._imessage_typing_tasks.clear()
 
         # Close any live call WS so callers don't hang on a half-open socket.
         for ws in list(self._active_call_ws.values()):
@@ -1688,6 +1707,7 @@ class InkboxAdapter(BasePlatformAdapter):
                 "[Inkbox] Suppressed admin notice for chat %s: %s…",
                 chat_id, (content or "")[:60].replace("\n", " "),
             )
+            self._stop_imessage_typing_for_chat(chat_id)
             return SendResult(success=True, message_id="suppressed-admin-notice")
 
         # The [SILENT] marker is the cron scheduler's "I have nothing to
@@ -1702,6 +1722,7 @@ class InkboxAdapter(BasePlatformAdapter):
                 "[Inkbox] Suppressed [SILENT] sentinel for chat %s",
                 chat_id,
             )
+            self._stop_imessage_typing_for_chat(chat_id)
             return SendResult(success=True, message_id="suppressed-silent-marker")
 
         meta = metadata or {}
@@ -1824,6 +1845,9 @@ class InkboxAdapter(BasePlatformAdapter):
                     success=False,
                     error=f"No iMessage conversation or phone number for chat {chat_id}",
                 )
+            # The reply is going out now — stop the typing pulse for this
+            # conversation regardless of how the send below resolves.
+            self._stop_imessage_typing(conversation_id)
             send_imessage = getattr(identity, "send_imessage", None)
             if not callable(send_imessage):
                 return SendResult(
@@ -2144,6 +2168,8 @@ class InkboxAdapter(BasePlatformAdapter):
             return await self._on_text_lifecycle(envelope)
         if event_type == "imessage.received":
             return await self._on_imessage_received(envelope)
+        if event_type == "imessage.reaction_received":
+            return await self._on_imessage_reaction(envelope)
         if event_type and event_type.startswith("imessage."):
             return await self._on_imessage_lifecycle(envelope)
         if "phone_number_id" in envelope and "remote_phone_number" in envelope:
@@ -2710,7 +2736,13 @@ class InkboxAdapter(BasePlatformAdapter):
             source=source,
             raw_message=envelope,
             message_id=message_id,
-            auto_skill="inkbox:inkbox-troubleshooting" if message_type == MessageType.TEXT else None,
+            # Attach the iMessage-specific responder alongside the general
+            # Inkbox guide so the agent has the tapback/typing playbook for
+            # this channel on the first turn.
+            auto_skill=(
+                ["inkbox:inkbox-troubleshooting", "inkbox:inkbox-imessage-responder"]
+                if message_type == MessageType.TEXT else None
+            ),
             timestamp=timestamp,
             media_urls=list(media_urls or []),
             media_types=list(media_types or []),
@@ -2796,6 +2828,9 @@ class InkboxAdapter(BasePlatformAdapter):
             media_types=media_types,
             conversation_id=conversation_id,
         )
+        # Show the recipient a typing indicator while the agent works on the
+        # reply. The pulse is cancelled in send() once the response goes out.
+        self._start_imessage_typing(conversation_id)
         # iMessage users send fragment bursts just like SMS users — reuse
         # the quiet-window batcher (the burst marker rewrite understands
         # the [inkbox:imessage ...] prefix).
@@ -2823,6 +2858,194 @@ class InkboxAdapter(BasePlatformAdapter):
             redact_phone(remote),
             error_code or "",
         )
+        return web.Response(status=200, text="ok")
+
+    # ── iMessage typing indicator ──────────────────────────────────────────
+    #
+    # iMessage typing indicators auto-expire client-side after a short window,
+    # so a single send_imessage_typing() would fade while the agent is still
+    # thinking. We refresh every IMESSAGE_TYPING_REFRESH_SECONDS until the
+    # reply goes out (or the turn fails), mirroring the "…" a human would see.
+
+    IMESSAGE_TYPING_REFRESH_SECONDS = 2.0
+    # Safety cap so a turn that errors out before send() (and thus never
+    # cancels the pulse) can't leave the indicator pulsing indefinitely.
+    IMESSAGE_TYPING_MAX_SECONDS = 300.0
+
+    def _typing_tasks(self) -> Dict[str, "asyncio.Task"]:
+        """Lazily-initialized typing-task registry.
+
+        Tolerates adapter instances built via ``object.__new__`` (used in
+        unit tests and any path that skips ``__init__``).
+        """
+        tasks = getattr(self, "_imessage_typing_tasks", None)
+        if tasks is None:
+            tasks = {}
+            self._imessage_typing_tasks = tasks
+        return tasks
+
+    def _start_imessage_typing(self, conversation_id: str) -> None:
+        """Begin (or keep) showing a typing indicator for a conversation."""
+        if not conversation_id:
+            return
+        existing = self._typing_tasks().get(conversation_id)
+        if existing is not None and not existing.done():
+            return  # already pulsing for this conversation
+        self._typing_tasks()[conversation_id] = asyncio.create_task(
+            self._imessage_typing_loop(conversation_id)
+        )
+
+    def _stop_imessage_typing(self, conversation_id: str) -> None:
+        """Cancel the typing pulse for a conversation, if any."""
+        if not conversation_id:
+            return
+        task = self._typing_tasks().pop(conversation_id, None)
+        if task is not None and not task.done():
+            task.cancel()
+
+    def _stop_imessage_typing_for_chat(self, chat_id: Any) -> None:
+        """Stop the typing pulse tied to a chat's last inbound iMessage.
+
+        Used on send paths that return before resolving a conversation_id
+        (e.g. the [SILENT] sentinel and admin-notice suppression), so a
+        no-reply turn doesn't leave the indicator pulsing forever.
+        """
+        state = self._last_inbound_imessage.get(str(chat_id)) or {}
+        self._stop_imessage_typing(str(state.get("conversation_id") or ""))
+
+    async def _imessage_typing_loop(self, conversation_id: str) -> None:
+        """Pulse the iMessage typing indicator until cancelled."""
+        if self._inkbox is None or not self._identity_handle:
+            return
+        elapsed = 0.0
+        try:
+            while elapsed < self.IMESSAGE_TYPING_MAX_SECONDS:
+                try:
+                    identity = await asyncio.to_thread(
+                        self._inkbox.get_identity, self._identity_handle,
+                    )
+                    send_typing = getattr(identity, "send_imessage_typing", None)
+                    if not callable(send_typing):
+                        return  # SDK too old — nothing to pulse
+                    await asyncio.to_thread(send_typing, conversation_id)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    # A transient typing failure should never derail the turn;
+                    # log at debug and keep trying on the next tick.
+                    logger.debug(
+                        "[Inkbox] iMessage typing pulse failed for %s: %s",
+                        conversation_id, exc,
+                    )
+                await asyncio.sleep(self.IMESSAGE_TYPING_REFRESH_SECONDS)
+                elapsed += self.IMESSAGE_TYPING_REFRESH_SECONDS
+        except asyncio.CancelledError:
+            pass
+        finally:
+            # If we exited on the safety cap, our entry is stale — drop it.
+            # (When cancelled via _stop_imessage_typing the entry was already
+            # popped, and a *newer* pulse may now own the slot; only remove
+            # the mapping when it still points at this very task.)
+            current = asyncio.current_task()
+            tasks = self._typing_tasks()
+            if tasks.get(conversation_id) is current:
+                tasks.pop(conversation_id, None)
+
+    async def _on_imessage_reaction(self, envelope: Dict[str, Any]) -> "web.Response":
+        """Route an inbound tapback into the contact's Hermes session.
+
+        Unlike SMS/email there is no body — the signal is the reaction itself
+        plus which message it targets. We enqueue a turn that hands the agent
+        the reaction and a response policy: a "question" tapback usually wants
+        a reply, the rest usually don't, so the agent is told it may return
+        [SILENT] when no visible reply is warranted (the same sentinel the
+        group-SMS policy and send() suppression already understand).
+        """
+        reaction = (envelope.get("data") or {}).get("reaction") or {}
+        reaction_id = str(reaction.get("id") or "").strip()
+        if reaction_id and self._is_duplicate(f"imessage_reaction:{reaction_id}"):
+            return web.Response(status=200, text="duplicate")
+        direction = str(reaction.get("direction") or "").strip().lower()
+        if direction and direction != "inbound":
+            # The agent's own outbound tapbacks echo back as a webhook too.
+            return web.Response(status=200, text="ok")
+        remote = str(reaction.get("remote_number") or "").strip()
+        if not remote:
+            return web.Response(status=200, text="ok")
+        conversation_id = str(reaction.get("conversation_id") or "").strip()
+        target_message_id = str(reaction.get("target_message_id") or "").strip()
+        reaction_type = str(reaction.get("reaction") or "").strip().lower()
+        custom_emoji = str(reaction.get("custom_emoji") or "").strip()
+        reaction_label = (
+            f"{reaction_type}:{custom_emoji}"
+            if reaction_type == "custom" and custom_emoji
+            else reaction_type
+        ) or "unknown"
+        timestamp = _parse_inkbox_timestamp(reaction.get("created_at"))
+
+        contact = await self._resolve_contact_full(kind="phone", value=remote)
+        chat_id = (contact["id"] if contact else remote)
+        contact_name = contact["name"] if contact and contact.get("name") else None
+        contact_block = self._contact_marker(contact)
+
+        # Keep the reply target fresh so a follow-up send() lands in the right
+        # iMessage conversation, exactly like an inbound message would.
+        self._last_inbound_modality[str(chat_id)] = "imessage"
+        imessage_state = {
+            "conversation_id": conversation_id,
+            "remote_number": remote,
+            "message_id": target_message_id,
+        }
+        self._last_inbound_imessage[str(chat_id)] = imessage_state
+        if conversation_id:
+            self._last_inbound_imessage[
+                _sms_state_key(chat_id, f"imessage:{conversation_id}")
+            ] = imessage_state
+
+        conversation_part = (
+            f" conversation_id={conversation_id}" if conversation_id else ""
+        )
+        target_part = (
+            f" target_message_id={target_message_id}" if target_message_id else ""
+        )
+        marker = (
+            f"[inkbox:imessage_reaction from={remote} reaction={reaction_label}"
+            f"{conversation_part}{target_part} | {contact_block}]"
+        )
+        policy = "\n".join([
+            f"{contact_name or remote} reacted with a '{reaction_label}' tapback to your message.",
+            "A reaction is a lightweight signal, not always a request for a reply.",
+            "Reply only when the reaction plausibly warrants one — e.g. a 'question' "
+            "tapback usually asks for clarification or a follow-up, 'emphasize' may "
+            "invite one, while 'love'/'like'/'laugh'/'dislike' are usually just "
+            "acknowledgements that need no response.",
+            "If no visible reply is warranted, return exactly [SILENT].",
+        ])
+        text = f"{marker}\n{policy}"
+
+        source = self.build_source(
+            chat_id=str(chat_id),
+            chat_name=contact_name or remote,
+            chat_type="dm",
+            user_id=str(chat_id),
+            user_name=contact_name or remote,
+            user_id_alt=remote,
+            thread_id=f"imessage:{conversation_id}" if conversation_id else None,
+            message_id=target_message_id or reaction_id,
+        )
+        event = MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message=envelope,
+            message_id=reaction_id or target_message_id,
+            auto_skill=[
+                "inkbox:inkbox-troubleshooting",
+                "inkbox:inkbox-imessage-responder",
+            ],
+            timestamp=timestamp,
+        )
+        await self._enqueue(event)
         return web.Response(status=200, text="ok")
 
     async def _on_incoming_call(self, envelope: Dict[str, Any]) -> "web.Response":

--- a/adapter.py
+++ b/adapter.py
@@ -3,8 +3,9 @@
 Inkbox (https://inkbox.ai) is API-first communication infrastructure that
 gives an AI agent a stable email address, phone number, and persistent
 contact list scoped to one *agent identity*. This adapter routes the
-three Inkbox modalities — inbound email, inbound SMS, and live voice
-calls — into a single contact-keyed Hermes session per remote party.
+four Inkbox modalities — inbound email, inbound SMS, inbound iMessage,
+and live voice calls — into a single contact-keyed Hermes session per
+remote party.
 
 Architecture
 ------------
@@ -18,11 +19,14 @@ On ``connect()`` the adapter:
      directly. Production deployments can bypass tunneling entirely by
      setting ``INKBOX_PUBLIC_URL``.
   2. Registers webhook subscriptions for the configured identity's
-     mailbox (``message.*`` events) and phone number (``text.*``
-     events) pointing at the tunnel, and patches the phone number's
-     incoming-call webhook URL + WebSocket URL on the resource itself
-     (the call channel is a synchronous control-plane callback and is
-     not a fan-out subscription).
+     mailbox (``message.*`` events), phone number (``text.*``
+     events), and — when the identity is iMessage-enabled — the
+     identity itself (``imessage.*`` events; iMessage rides shared
+     Inkbox-managed numbers, so the subscription owner is the agent
+     identity rather than a phone number) pointing at the tunnel, and
+     patches the phone number's incoming-call webhook URL + WebSocket
+     URL on the resource itself (the call channel is a synchronous
+     control-plane callback and is not a fan-out subscription).
   3. Starts an aiohttp server with two routes:
         - ``POST /webhook`` — verifies the ``X-Inkbox-Signature`` HMAC
           via the SDK, parses the body into one of three event shapes
@@ -40,12 +44,13 @@ Session keys
 Every inbound event is mapped to ``chat_id = contact_id`` so that one
 Hermes session spans email + SMS + voice for the same remote party::
 
-    inbound mail   → chat_id=contact_id, thread_id=f"email:{tid}"
-    inbound SMS    → chat_id=contact_id, thread_id=None
-    inbound call   → chat_id=contact_id, thread_id=f"call:{call_id}"
-    outbound call  → chat_id=contact_id, thread_id=None  (joins the
-                     contact's main session so the agent inherits the
-                     conversation that decided to place the call)
+    inbound mail     → chat_id=contact_id, thread_id=f"email:{tid}"
+    inbound SMS      → chat_id=contact_id, thread_id=None
+    inbound iMessage → chat_id=contact_id, thread_id=f"imessage:{cid}"
+    inbound call     → chat_id=contact_id, thread_id=f"call:{call_id}"
+    outbound call    → chat_id=contact_id, thread_id=None  (joins the
+                       contact's main session so the agent inherits the
+                       conversation that decided to place the call)
 
 When ``inkbox.contacts.lookup()`` returns 0 or >1 contacts the adapter
 falls back to the raw email address / phone number as ``chat_id``, so
@@ -54,10 +59,14 @@ unknown senders still get a session — just not a contact-merged one.
 Outbound
 --------
 ``send()`` is mode-aware via ``metadata['mode']``:
-  - ``email`` → ``identity.send_email(to=..., subject=..., body_text=...)``
-  - ``sms``   → ``identity.send_text(conversation_id=..., text=...)``
-                for replies, falling back to ``to=...`` for legacy/new sends
-  - ``voice`` → push a ``text`` frame onto the contact's active call
+  - ``email``    → ``identity.send_email(to=..., subject=..., body_text=...)``
+  - ``sms``      → ``identity.send_text(conversation_id=..., text=...)``
+                   for replies, falling back to ``to=...`` for legacy/new sends
+  - ``imessage`` → ``identity.send_imessage(conversation_id=..., text=...)``.
+    iMessage is recipient-first: the remote party must have messaged the
+    agent at least once before outbound sends work, so replies always
+    target an existing conversation.
+  - ``voice``    → push a ``text`` frame onto the contact's active call
     WebSocket so Inkbox-managed TTS speaks it to the caller.
 
 When the agent streams (gateway calls ``edit_message()`` repeatedly),
@@ -172,6 +181,11 @@ _DESIRED_TEXT_EVENTS: tuple[str, ...] = (
     "text.delivery_unconfirmed",
 )
 
+# iMessage: inbound messages only. Tapback reactions fan out as
+# ``imessage.reaction_received`` but waking the agent for every thumbs-up
+# isn't worth a turn; live reactions are visible on message reads anyway.
+_DESIRED_IMESSAGE_EVENTS: tuple[str, ...] = ("imessage.received",)
+
 
 def _inkbox_state_path():
     """Return the on-disk path used for the Inkbox identity state file.
@@ -221,6 +235,22 @@ def _sms_conversation_target(raw: Any) -> Optional[str]:
     if match:
         return match.group(1).strip() or None
     match = re.match(r"^(?:sms:|text:|phone:)(.+)$", without_provider, flags=re.IGNORECASE)
+    if match:
+        candidate = match.group(1).strip()
+        return candidate if candidate and not candidate.startswith("+") else None
+    return None
+
+
+def _imessage_conversation_target(raw: Any) -> Optional[str]:
+    text = str(raw or "").strip()
+    if not text:
+        return None
+    without_provider = re.sub(r"^(inkbox:)", "", text, flags=re.IGNORECASE)
+    match = re.match(
+        r"^(?:imessage:conversation:|imessage:)(.+)$",
+        without_provider,
+        flags=re.IGNORECASE,
+    )
     if match:
         candidate = match.group(1).strip()
         return candidate if candidate and not candidate.startswith("+") else None
@@ -480,6 +510,28 @@ def _reconcile_text_subscription(
         client,
         owner_kwarg="phone_number_id",
         owner_id=phone_number_id,
+        desired_url=desired_url,
+        previous_webhook_url=previous_webhook_url,
+        desired_events=desired_events,
+    )
+
+
+def _reconcile_imessage_subscription(
+    client,
+    agent_identity_id,
+    desired_url: str,
+    previous_webhook_url: Optional[str],
+    desired_events: tuple[str, ...] = _DESIRED_IMESSAGE_EVENTS,
+):
+    """Reconcile the identity-owned iMessage webhook subscription.
+
+    iMessage traffic rides shared Inkbox-managed numbers, so the
+    subscription owner is the agent identity, not a phone number.
+    """
+    return _reconcile_subscription(
+        client,
+        owner_kwarg="agent_identity_id",
+        owner_id=agent_identity_id,
         desired_url=desired_url,
         previous_webhook_url=previous_webhook_url,
         desired_events=desired_events,
@@ -955,7 +1007,44 @@ def _sms_send_failure_dict(exc: Exception) -> Dict[str, Any]:
     }
 
 
-def _extract_text_media(text_msg: Dict[str, Any]) -> Tuple[list[str], list[str], list[str]]:
+def _format_inkbox_imessage_error(fields: Dict[str, Any]) -> str:
+    status = fields.get("status_code")
+    code = fields.get("error_code")
+    message = fields.get("message") or "send_imessage failed"
+    prefix = "Inkbox iMessage send failed"
+    if status:
+        prefix += f" (HTTP {status})"
+    if code:
+        prefix += f" [{code}]"
+    return f"{prefix}: {message}"
+
+
+def _imessage_send_failure(exc: Exception, *, target: str) -> SendResult:
+    # Same structured extraction as SMS — Inkbox error envelopes share one
+    # shape — but labelled as iMessage so logs and agent-visible errors
+    # point at the right channel. 409s carry the recipient-first /
+    # disconnected-assignment explanations from the server verbatim.
+    fields = _extract_inkbox_sms_error(exc)
+    logger.error(
+        "[Inkbox] iMessage send failed to %s: status=%s code=%s message=%s",
+        redact_phone(target),
+        fields.get("status_code"),
+        fields.get("error_code"),
+        fields.get("message"),
+    )
+    return SendResult(
+        success=False,
+        error=_format_inkbox_imessage_error(fields),
+        raw_response={"platform": "inkbox", "mode": "imessage", **fields},
+        retryable=bool(fields.get("retryable")),
+    )
+
+
+def _extract_text_media(
+    text_msg: Dict[str, Any],
+    *,
+    marker_label: str = "MMS",
+) -> Tuple[list[str], list[str], list[str]]:
     media_items = (
         text_msg.get("media")
         or text_msg.get("attachments")
@@ -994,7 +1083,7 @@ def _extract_text_media(text_msg: Dict[str, Any]) -> Tuple[list[str], list[str],
             urls.append(url)
         media_type = content_type or "unknown"
         types.append(media_type)
-        markers.append(f"[MMS attachment received: {media_type}]")
+        markers.append(f"[{marker_label} attachment received: {media_type}]")
     return urls, types, markers
 
 
@@ -1185,6 +1274,10 @@ class InkboxAdapter(BasePlatformAdapter):
         # instead of reconstructing a phone-number send. This is required for
         # group MMS and keeps 1:1 replies on the canonical server thread.
         self._last_inbound_sms: Dict[str, Dict[str, str]] = {}
+        # chat_id → metadata of the most-recent inbound iMessage for that
+        # chat. iMessage rides shared Inkbox numbers, so replies MUST target
+        # the conversation id (there is no agent-owned number to send from).
+        self._last_inbound_imessage: Dict[str, Dict[str, str]] = {}
         # chat_id → modality of the most-recent inbound message ('email',
         # 'sms', or 'voice').  Critical when chat_id is a Contact UUID (no
         # `+` or `@` to disambiguate) — without this, send() defaults the
@@ -1505,6 +1598,21 @@ class InkboxAdapter(BasePlatformAdapter):
                 identity.phone_number.number, webhook_url, ws_url,
             )
 
+        # iMessage: identity-owned subscription, only while the identity is
+        # enabled (the server rejects imessage.* subscriptions otherwise).
+        if getattr(identity, "imessage_enabled", False) and self._identity_id:
+            _reconcile_imessage_subscription(
+                self._inkbox,
+                self._identity_id,
+                desired_url=webhook_url,
+                previous_webhook_url=previous_webhook_url,
+                desired_events=_DESIRED_IMESSAGE_EVENTS,
+            )
+            logger.info(
+                "[Inkbox] Patched iMessage for identity %s → %s",
+                self._identity_handle, webhook_url,
+            )
+
         # Persist the resolved identity so non-Inkbox sessions (CLI, etc.) can
         # tell the agent which email + phone it can be reached on.  Read by
         # ``prompt_builder.build_inkbox_identity_hint``.
@@ -1532,6 +1640,7 @@ class InkboxAdapter(BasePlatformAdapter):
                     str(getattr(identity.phone_number, "id", ""))
                     if identity.phone_number else None
                 ),
+                "imessage_enabled": bool(getattr(identity, "imessage_enabled", False)),
                 "public_url": self._public_url,
                 "webhook_url": webhook_url,
                 "ws_url": ws_url,
@@ -1557,9 +1666,10 @@ class InkboxAdapter(BasePlatformAdapter):
         """Dispatch a message via the right Inkbox modality.
 
         ``metadata['mode']`` selects the channel: ``email`` (default for
-        contacts that have an email on file), ``sms``, or ``voice``. For
-        voice mode the message is pushed onto the contact's active call
-        WebSocket — the caller hears it through Inkbox-managed TTS.
+        contacts that have an email on file), ``sms``, ``imessage``, or
+        ``voice``. For voice mode the message is pushed onto the contact's
+        active call WebSocket — the caller hears it through Inkbox-managed
+        TTS.
 
         Hermes admin / status banners (session-reset notices, runtime info,
         home-channel prompt, update notifications) are silently dropped —
@@ -1680,6 +1790,71 @@ class InkboxAdapter(BasePlatformAdapter):
             )
         except Exception as exc:
             return SendResult(success=False, error=f"get_identity failed: {exc}")
+
+        if mode == "imessage":
+            thread_id = str(meta.get("thread_id") or "").strip()
+            imessage_meta = (
+                self._last_inbound_imessage.get(_sms_state_key(chat_id, thread_id))
+                or self._last_inbound_imessage.get(str(chat_id), {})
+            )
+            conversation_id = str(
+                meta.get("conversation_id")
+                or meta.get("conversationId")
+                or _imessage_conversation_target(thread_id)
+                or imessage_meta.get("conversation_id")
+                or ""
+            ).strip()
+            to_number = str(imessage_meta.get("remote_number") or "").strip()
+            if not conversation_id and not to_number:
+                if str(chat_id).startswith("+"):
+                    to_number = str(chat_id).strip()
+                else:
+                    to_number = await asyncio.to_thread(
+                        self._lookup_contact_phone, chat_id,
+                    ) or ""
+            if not conversation_id and not to_number:
+                return SendResult(
+                    success=False,
+                    error=f"No iMessage conversation or phone number for chat {chat_id}",
+                )
+            send_imessage = getattr(identity, "send_imessage", None)
+            if not callable(send_imessage):
+                return SendResult(
+                    success=False,
+                    error=(
+                        "Installed Inkbox SDK has no send_imessage; "
+                        "upgrade with: pip install -U inkbox"
+                    ),
+                )
+            try:
+                if conversation_id:
+                    msg = await asyncio.to_thread(
+                        send_imessage,
+                        conversation_id=conversation_id,
+                        text=content,
+                    )
+                    target_label = f"conversation:{conversation_id}"
+                else:
+                    msg = await asyncio.to_thread(
+                        send_imessage, to=to_number, text=content,
+                    )
+                    target_label = redact_phone(to_number)
+                raw_response = _text_message_metadata(msg, mode="imessage")
+                logger.info(
+                    "[Inkbox] iMessage queued to %s: id=%s status=%s",
+                    target_label,
+                    raw_response.get("message_id") or "",
+                    raw_response.get("status") or "",
+                )
+                return SendResult(
+                    success=True,
+                    message_id=str(getattr(msg, "id", "")),
+                    raw_response=raw_response,
+                )
+            except Exception as exc:
+                return _imessage_send_failure(
+                    exc, target=conversation_id or to_number,
+                )
 
         if mode == "sms":
             thread_id = str(meta.get("thread_id") or "").strip()
@@ -1823,7 +1998,7 @@ class InkboxAdapter(BasePlatformAdapter):
         modality = self._last_inbound_modality.get(str(chat_id), "")
         if modality == "email":
             return False
-        if modality == "sms":
+        if modality in ("sms", "imessage"):
             return True
         # Unknown modality (agent-initiated outbound, contact-keyed chat
         # we haven't seen inbound yet) — mirror send()'s default heuristic:
@@ -1855,7 +2030,7 @@ class InkboxAdapter(BasePlatformAdapter):
         modality = self._last_inbound_modality.get(str(chat_id), "")
         if modality == "email":
             return False
-        if modality == "sms":
+        if modality in ("sms", "imessage"):
             return True
         # Unknown modality — mirror send()'s E.164-or-email heuristic
         # (matches ``supports_progress_updates``): E.164-shaped chat_id
@@ -1960,6 +2135,11 @@ class InkboxAdapter(BasePlatformAdapter):
             return await self._on_text_received(envelope)
         if event_type and event_type.startswith("text."):
             return await self._on_text_lifecycle(envelope)
+        if event_type == "imessage.received":
+            return await self._on_imessage_received(envelope)
+        if event_type and event_type.startswith("imessage."):
+            # Reaction fan-out etc. — visible on message reads; no agent turn.
+            return web.Response(status=200, text="ok")
         if "phone_number_id" in envelope and "remote_phone_number" in envelope:
             return await self._on_incoming_call(envelope)
         return web.Response(status=200, text="ignored")
@@ -2213,6 +2393,8 @@ class InkboxAdapter(BasePlatformAdapter):
             or text.startswith("[inkbox:sms_burst ")
             or text.startswith("[inkbox:group_sms ")
             or text.startswith("[inkbox:group_sms_burst ")
+            or text.startswith("[inkbox:imessage ")
+            or text.startswith("[inkbox:imessage_burst ")
         ):
             return {"mode": "queue", "merge_text": True}
         return None
@@ -2306,6 +2488,16 @@ class InkboxAdapter(BasePlatformAdapter):
                     "[inkbox:group_sms ",
                     (
                         f"[inkbox:group_sms_burst messages={len(fragments)} "
+                        f"first_at={_format_inkbox_timestamp(first_at)} "
+                        f"last_at={_format_inkbox_timestamp(last_at)} "
+                    ),
+                    1,
+                )
+            elif str(batch["marker"]).startswith("[inkbox:imessage "):
+                burst_marker = batch["marker"].replace(
+                    "[inkbox:imessage ",
+                    (
+                        f"[inkbox:imessage_burst messages={len(fragments)} "
                         f"first_at={_format_inkbox_timestamp(first_at)} "
                         f"last_at={_format_inkbox_timestamp(last_at)} "
                     ),
@@ -2470,6 +2662,138 @@ class InkboxAdapter(BasePlatformAdapter):
             redact_phone(remote),
             error_code or "",
         )
+        return web.Response(status=200, text="ok")
+
+    def _build_imessage_event(
+        self,
+        *,
+        envelope: Dict[str, Any],
+        message_id: str,
+        remote: str,
+        contact: Optional[Dict[str, Any]],
+        chat_id: Any,
+        contact_name: Optional[str],
+        body: str,
+        timestamp: datetime,
+        text: Optional[str] = None,
+        message_type: MessageType = MessageType.TEXT,
+        media_urls: Optional[list[str]] = None,
+        media_types: Optional[list[str]] = None,
+        conversation_id: Optional[str] = None,
+    ) -> MessageEvent:
+        thread_id = f"imessage:{conversation_id}" if conversation_id else None
+        source = self.build_source(
+            chat_id=str(chat_id),
+            chat_name=contact_name or remote,
+            chat_type="dm",
+            user_id=str(chat_id),
+            user_name=contact_name or remote,
+            user_id_alt=remote,
+            thread_id=thread_id,
+            message_id=message_id,
+        )
+        if text is None:
+            contact_block = self._contact_marker(contact)
+            conversation_part = (
+                f" conversation_id={conversation_id}" if conversation_id else ""
+            )
+            text = f"[inkbox:imessage from={remote}{conversation_part} | {contact_block}]\n{body}"
+        return MessageEvent(
+            text=text,
+            message_type=message_type,
+            source=source,
+            raw_message=envelope,
+            message_id=message_id,
+            auto_skill="inkbox:inkbox-troubleshooting" if message_type == MessageType.TEXT else None,
+            timestamp=timestamp,
+            media_urls=list(media_urls or []),
+            media_types=list(media_types or []),
+        )
+
+    async def _on_imessage_received(self, envelope: Dict[str, Any]) -> "web.Response":
+        """Route an inbound iMessage into the contact's Hermes session.
+
+        Mirrors ``_on_text_received`` minus the SMS-only concerns: there is
+        no group support, no opt-in control words, and no local number —
+        iMessage rides a shared Inkbox-managed line, so the conversation id
+        is the only stable reply target and is stashed for ``send()``.
+        """
+        message = (envelope.get("data") or {}).get("message") or {}
+        message_id = str(message.get("id") or "").strip()
+        if message_id and self._is_duplicate(f"imessage:{message_id}"):
+            return web.Response(status=200, text="duplicate")
+        direction = str(message.get("direction") or "").strip().lower()
+        if direction and direction != "inbound":
+            return web.Response(status=200, text="ok")
+        remote = str(
+            message.get("remote_number") or message.get("remoteNumber") or ""
+        ).strip()
+        if not remote:
+            return web.Response(status=200, text="ok")
+        conversation_id = str(
+            message.get("conversation_id") or message.get("conversationId") or ""
+        ).strip()
+
+        contact = await self._resolve_contact_full(kind="phone", value=remote)
+        chat_id = (contact["id"] if contact else remote)
+        contact_name = contact["name"] if contact and contact.get("name") else None
+        raw_body = message.get("content") or ""
+        body = raw_body
+        media_urls, media_types, media_markers = _extract_text_media(
+            message, marker_label="iMessage",
+        )
+        if media_markers:
+            body = "\n".join(part for part in [body, *media_markers] if part)
+        timestamp = _parse_inkbox_timestamp(message.get("created_at"))
+
+        self._last_inbound_modality[str(chat_id)] = "imessage"
+        imessage_state = {
+            "conversation_id": conversation_id,
+            "remote_number": remote,
+            "message_id": message_id,
+        }
+        self._last_inbound_imessage[str(chat_id)] = imessage_state
+        if conversation_id:
+            self._last_inbound_imessage[
+                _sms_state_key(chat_id, f"imessage:{conversation_id}")
+            ] = imessage_state
+
+        if raw_body.lstrip().startswith("/"):
+            event = self._build_imessage_event(
+                envelope=envelope,
+                message_id=message_id,
+                remote=remote,
+                contact=contact,
+                chat_id=chat_id,
+                contact_name=contact_name,
+                body=body,
+                timestamp=timestamp,
+                text=raw_body.strip(),
+                message_type=MessageType.COMMAND,
+                media_urls=media_urls,
+                media_types=media_types,
+                conversation_id=conversation_id,
+            )
+            await self._enqueue(event)
+            return web.Response(status=200, text="ok")
+
+        event = self._build_imessage_event(
+            envelope=envelope,
+            message_id=message_id,
+            remote=remote,
+            contact=contact,
+            chat_id=chat_id,
+            contact_name=contact_name,
+            body=body,
+            timestamp=timestamp,
+            media_urls=media_urls,
+            media_types=media_types,
+            conversation_id=conversation_id,
+        )
+        # iMessage users send fragment bursts just like SMS users — reuse
+        # the quiet-window batcher (the burst marker rewrite understands
+        # the [inkbox:imessage ...] prefix).
+        await self._enqueue_sms_text_event(event)
         return web.Response(status=200, text="ok")
 
     async def _on_incoming_call(self, envelope: Dict[str, Any]) -> "web.Response":
@@ -3440,7 +3764,10 @@ async def send_inkbox_direct(
     )
     chosen_mode = (mode or "").lower().strip()
     if not chosen_mode:
-        chosen_mode = "sms" if str(chat_id).startswith("+") or _sms_conversation_target(chat_id) else "email"
+        if _imessage_conversation_target(chat_id):
+            chosen_mode = "imessage"
+        else:
+            chosen_mode = "sms" if str(chat_id).startswith("+") or _sms_conversation_target(chat_id) else "email"
     if chosen_mode == "sms" and len(message or "") > SMS_MAX_LENGTH:
         return _sms_too_long_failure_dict(message)
 
@@ -3498,6 +3825,48 @@ async def send_inkbox_direct(
                     "delivery_status": _plain_value(
                         getattr(msg, "delivery_status", None),
                     ),
+                }
+
+            if chosen_mode == "imessage":
+                send_imessage = getattr(identity, "send_imessage", None)
+                if not callable(send_imessage):
+                    return {
+                        "error": (
+                            "Installed Inkbox SDK has no send_imessage; "
+                            "upgrade with: pip install -U inkbox"
+                        ),
+                    }
+                conversation_id = _imessage_conversation_target(chat_id)
+                try:
+                    if conversation_id:
+                        msg = send_imessage(conversation_id=conversation_id, text=message)
+                    elif str(chat_id).startswith("+"):
+                        msg = send_imessage(to=str(chat_id).strip(), text=message)
+                    else:
+                        return {"error": f"No iMessage conversation target in {chat_id!r}"}
+                except Exception as exc:
+                    logger.error(
+                        "[Inkbox] Direct iMessage send failed to %s",
+                        conversation_id or redact_phone(str(chat_id)),
+                    )
+                    fields = _extract_inkbox_sms_error(exc)
+                    return {
+                        "success": False,
+                        "platform": "inkbox",
+                        "mode": "imessage",
+                        "error": _format_inkbox_imessage_error(fields),
+                        **fields,
+                    }
+                return {
+                    "success": True,
+                    "platform": "inkbox",
+                    "chat_id": chat_id,
+                    "message_id": str(getattr(msg, "id", "")),
+                    "mode": "imessage",
+                    "conversation_id": conversation_id or _plain_value(
+                        getattr(msg, "conversation_id", None),
+                    ),
+                    "status": _plain_value(getattr(msg, "status", None)),
                 }
 
             if chosen_mode == "email":

--- a/adapter.py
+++ b/adapter.py
@@ -181,10 +181,17 @@ _DESIRED_TEXT_EVENTS: tuple[str, ...] = (
     "text.delivery_unconfirmed",
 )
 
-# iMessage: inbound messages only. Tapback reactions fan out as
-# ``imessage.reaction_received`` but waking the agent for every thumbs-up
-# isn't worth a turn; live reactions are visible on message reads anyway.
-_DESIRED_IMESSAGE_EVENTS: tuple[str, ...] = ("imessage.received",)
+# iMessage: inbound plus the outbound delivery lifecycle, consumed by
+# _on_imessage_received / _on_imessage_lifecycle — same split as text.
+# Tapback reactions (``imessage.reaction_received``) are deliberately not
+# subscribed: waking the agent for every thumbs-up isn't worth a turn, and
+# live reactions are visible on message reads anyway.
+_DESIRED_IMESSAGE_EVENTS: tuple[str, ...] = (
+    "imessage.received",
+    "imessage.sent",
+    "imessage.delivered",
+    "imessage.delivery_failed",
+)
 
 
 def _inkbox_state_path():
@@ -2138,8 +2145,7 @@ class InkboxAdapter(BasePlatformAdapter):
         if event_type == "imessage.received":
             return await self._on_imessage_received(envelope)
         if event_type and event_type.startswith("imessage."):
-            # Reaction fan-out etc. — visible on message reads; no agent turn.
-            return web.Response(status=200, text="ok")
+            return await self._on_imessage_lifecycle(envelope)
         if "phone_number_id" in envelope and "remote_phone_number" in envelope:
             return await self._on_incoming_call(envelope)
         return web.Response(status=200, text="ignored")
@@ -2794,6 +2800,29 @@ class InkboxAdapter(BasePlatformAdapter):
         # the quiet-window batcher (the burst marker rewrite understands
         # the [inkbox:imessage ...] prefix).
         await self._enqueue_sms_text_event(event)
+        return web.Response(status=200, text="ok")
+
+    async def _on_imessage_lifecycle(self, envelope: Dict[str, Any]) -> "web.Response":
+        """Log iMessage delivery/status callbacks without enqueueing an agent turn.
+
+        Also the landing spot for any other ``imessage.*`` fan-out we don't
+        subscribe to (e.g. reactions, if a subscription drifts) — logged and
+        acknowledged, never a turn.
+        """
+        event_type = str(envelope.get("event_type") or "")
+        message = (envelope.get("data") or {}).get("message") or {}
+        message_id = str(message.get("id") or "").strip()
+        remote = str(message.get("remote_number") or "").strip()
+        status = _plain_value(message.get("status")) or ""
+        error_code = _plain_value(message.get("error_code"))
+        logger.info(
+            "[Inkbox] iMessage lifecycle event=%s id=%s status=%s remote=%s error=%s",
+            event_type,
+            message_id,
+            status,
+            redact_phone(remote),
+            error_code or "",
+        )
         return web.Response(status=200, text="ok")
 
     async def _on_incoming_call(self, envelope: Dict[str, Any]) -> "web.Response":

--- a/adapter.py
+++ b/adapter.py
@@ -775,6 +775,29 @@ def _parse_inkbox_timestamp(value: Any) -> datetime:
     return datetime.now(timezone.utc)
 
 
+def _reaction_is_removal(reaction: Dict[str, Any]) -> bool:
+    """Best-effort detection of a tapback *removal* on an inbound reaction.
+
+    The typed SDK ``IMessageWebhookReaction`` shape carries no removal flag
+    yet, so we look across the field names the backend might use and default
+    to False — an added tapback must never be misread as a removal. When the
+    wire shape settles on one field, this can be narrowed to it.
+    """
+    for key in ("removed", "is_removal", "is_removed", "deleted"):
+        value = reaction.get(key)
+        if isinstance(value, bool) and value:
+            return True
+        if isinstance(value, str) and value.strip().lower() in {"true", "1", "yes"}:
+            return True
+    for key in ("action", "event", "operation", "op", "change", "kind"):
+        value = reaction.get(key)
+        if isinstance(value, str) and value.strip().lower() in {
+            "removed", "remove", "removal", "deleted", "delete", "retract", "retracted",
+        }:
+            return True
+    return False
+
+
 def _format_inkbox_timestamp(value: datetime) -> str:
     return value.astimezone(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
 
@@ -2981,6 +3004,12 @@ class InkboxAdapter(BasePlatformAdapter):
             if reaction_type == "custom" and custom_emoji
             else reaction_type
         ) or "unknown"
+        # Whether the person ADDED a tapback or took one back (REMOVED). The
+        # typed SDK shape doesn't carry this yet, so detect it from whichever
+        # field the backend populates and default to "added" — a normal add
+        # must never be misread as a removal.
+        removed = _reaction_is_removal(reaction)
+        action = "removed" if removed else "added"
         timestamp = _parse_inkbox_timestamp(reaction.get("created_at"))
 
         contact = await self._resolve_contact_full(kind="phone", value=remote)
@@ -3010,17 +3039,27 @@ class InkboxAdapter(BasePlatformAdapter):
         )
         marker = (
             f"[inkbox:imessage_reaction from={remote} reaction={reaction_label}"
-            f"{conversation_part}{target_part} | {contact_block}]"
+            f" action={action}{conversation_part}{target_part} | {contact_block}]"
         )
-        policy = "\n".join([
-            f"{contact_name or remote} reacted with a '{reaction_label}' tapback to your message.",
-            "A reaction is a lightweight signal, not always a request for a reply.",
-            "Reply only when the reaction plausibly warrants one — e.g. a 'question' "
-            "tapback usually asks for clarification or a follow-up, 'emphasize' may "
-            "invite one, while 'love'/'like'/'laugh'/'dislike' are usually just "
-            "acknowledgements that need no response.",
-            "If no visible reply is warranted, return exactly [SILENT].",
-        ])
+        if removed:
+            policy = "\n".join([
+                f"{contact_name or remote} removed their '{reaction_label}' tapback from your message.",
+                "Taking a tapback back is almost always a quiet correction or a "
+                "change of mind, not a request for anything — it very rarely "
+                "warrants a reply.",
+                "Reply only if the removal clearly changes something actionable in "
+                "the conversation; otherwise return exactly [SILENT].",
+            ])
+        else:
+            policy = "\n".join([
+                f"{contact_name or remote} reacted with a '{reaction_label}' tapback to your message.",
+                "A reaction is a lightweight signal, not always a request for a reply.",
+                "Reply only when the reaction plausibly warrants one — e.g. a 'question' "
+                "tapback usually asks for clarification or a follow-up, 'emphasize' may "
+                "invite one, while 'love'/'like'/'laugh'/'dislike' are usually just "
+                "acknowledgements that need no response.",
+                "If no visible reply is warranted, return exactly [SILENT].",
+            ])
         text = f"{marker}\n{policy}"
 
         source = self.build_source(
@@ -3045,12 +3084,12 @@ class InkboxAdapter(BasePlatformAdapter):
             ],
             timestamp=timestamp,
         )
-        # A "question" tapback usually expects a reply, so show the typing
-        # indicator while the agent works on it (cancelled on send, or on the
-        # [SILENT] path if the agent decides no reply is warranted after all).
-        # Other reaction types most often resolve to [SILENT], so we don't
-        # promise a reply that isn't coming.
-        if reaction_type == "question":
+        # Adding a "question" tapback usually expects a reply, so show the
+        # typing indicator while the agent works on it (cancelled on send, or
+        # on the [SILENT] path if it decides no reply is warranted after all).
+        # Other reaction types — and any removal, which almost always resolves
+        # to [SILENT] — don't promise a reply that isn't coming.
+        if reaction_type == "question" and not removed:
             self._start_imessage_typing(conversation_id)
         await self._enqueue(event)
         return web.Response(status=200, text="ok")

--- a/adapter.py
+++ b/adapter.py
@@ -775,29 +775,6 @@ def _parse_inkbox_timestamp(value: Any) -> datetime:
     return datetime.now(timezone.utc)
 
 
-def _reaction_is_removal(reaction: Dict[str, Any]) -> bool:
-    """Best-effort detection of a tapback *removal* on an inbound reaction.
-
-    The typed SDK ``IMessageWebhookReaction`` shape carries no removal flag
-    yet, so we look across the field names the backend might use and default
-    to False — an added tapback must never be misread as a removal. When the
-    wire shape settles on one field, this can be narrowed to it.
-    """
-    for key in ("removed", "is_removal", "is_removed", "deleted"):
-        value = reaction.get(key)
-        if isinstance(value, bool) and value:
-            return True
-        if isinstance(value, str) and value.strip().lower() in {"true", "1", "yes"}:
-            return True
-    for key in ("action", "event", "operation", "op", "change", "kind"):
-        value = reaction.get(key)
-        if isinstance(value, str) and value.strip().lower() in {
-            "removed", "remove", "removal", "deleted", "delete", "retract", "retracted",
-        }:
-            return True
-    return False
-
-
 def _format_inkbox_timestamp(value: datetime) -> str:
     return value.astimezone(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
 
@@ -3004,12 +2981,6 @@ class InkboxAdapter(BasePlatformAdapter):
             if reaction_type == "custom" and custom_emoji
             else reaction_type
         ) or "unknown"
-        # Whether the person ADDED a tapback or took one back (REMOVED). The
-        # typed SDK shape doesn't carry this yet, so detect it from whichever
-        # field the backend populates and default to "added" — a normal add
-        # must never be misread as a removal.
-        removed = _reaction_is_removal(reaction)
-        action = "removed" if removed else "added"
         timestamp = _parse_inkbox_timestamp(reaction.get("created_at"))
 
         contact = await self._resolve_contact_full(kind="phone", value=remote)
@@ -3039,27 +3010,17 @@ class InkboxAdapter(BasePlatformAdapter):
         )
         marker = (
             f"[inkbox:imessage_reaction from={remote} reaction={reaction_label}"
-            f" action={action}{conversation_part}{target_part} | {contact_block}]"
+            f"{conversation_part}{target_part} | {contact_block}]"
         )
-        if removed:
-            policy = "\n".join([
-                f"{contact_name or remote} removed their '{reaction_label}' tapback from your message.",
-                "Taking a tapback back is almost always a quiet correction or a "
-                "change of mind, not a request for anything — it very rarely "
-                "warrants a reply.",
-                "Reply only if the removal clearly changes something actionable in "
-                "the conversation; otherwise return exactly [SILENT].",
-            ])
-        else:
-            policy = "\n".join([
-                f"{contact_name or remote} reacted with a '{reaction_label}' tapback to your message.",
-                "A reaction is a lightweight signal, not always a request for a reply.",
-                "Reply only when the reaction plausibly warrants one — e.g. a 'question' "
-                "tapback usually asks for clarification or a follow-up, 'emphasize' may "
-                "invite one, while 'love'/'like'/'laugh'/'dislike' are usually just "
-                "acknowledgements that need no response.",
-                "If no visible reply is warranted, return exactly [SILENT].",
-            ])
+        policy = "\n".join([
+            f"{contact_name or remote} reacted with a '{reaction_label}' tapback to your message.",
+            "A reaction is a lightweight signal, not always a request for a reply.",
+            "Reply only when the reaction plausibly warrants one — e.g. a 'question' "
+            "tapback usually asks for clarification or a follow-up, 'emphasize' may "
+            "invite one, while 'love'/'like'/'laugh'/'dislike' are usually just "
+            "acknowledgements that need no response.",
+            "If no visible reply is warranted, return exactly [SILENT].",
+        ])
         text = f"{marker}\n{policy}"
 
         source = self.build_source(
@@ -3084,12 +3045,12 @@ class InkboxAdapter(BasePlatformAdapter):
             ],
             timestamp=timestamp,
         )
-        # Adding a "question" tapback usually expects a reply, so show the
-        # typing indicator while the agent works on it (cancelled on send, or
-        # on the [SILENT] path if it decides no reply is warranted after all).
-        # Other reaction types — and any removal, which almost always resolves
-        # to [SILENT] — don't promise a reply that isn't coming.
-        if reaction_type == "question" and not removed:
+        # A "question" tapback usually expects a reply, so show the typing
+        # indicator while the agent works on it (cancelled on send, or on the
+        # [SILENT] path if the agent decides no reply is warranted after all).
+        # Other reaction types most often resolve to [SILENT], so we don't
+        # promise a reply that isn't coming.
+        if reaction_type == "question":
             self._start_imessage_typing(conversation_id)
         await self._enqueue(event)
         return web.Response(status=200, text="ok")

--- a/adapter.py
+++ b/adapter.py
@@ -3045,6 +3045,13 @@ class InkboxAdapter(BasePlatformAdapter):
             ],
             timestamp=timestamp,
         )
+        # A "question" tapback usually expects a reply, so show the typing
+        # indicator while the agent works on it (cancelled on send, or on the
+        # [SILENT] path if the agent decides no reply is warranted after all).
+        # Other reaction types most often resolve to [SILENT], so we don't
+        # promise a reply that isn't coming.
+        if reaction_type == "question":
+            self._start_imessage_typing(conversation_id)
         await self._enqueue(event)
         return web.Response(status=200, text="ok")
 

--- a/config.py
+++ b/config.py
@@ -96,6 +96,7 @@ def object_summary(obj: Any) -> Any:
         "type",
         "sms_status",
         "sms_error_code",
+        "imessage_enabled",
         "incoming_call_action",
         "client_websocket_url",
         "public_host",

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,8 +1,8 @@
 name: inkbox
 label: Inkbox
 kind: platform
-version: 0.1.5
-description: Inkbox email, SMS/MMS, and voice platform plugin for Hermes Agent.
+version: 0.2.0
+description: Inkbox email, SMS/MMS, iMessage, and voice platform plugin for Hermes Agent.
 author: Inkbox
 requires_env: []
 optional_env:
@@ -15,7 +15,7 @@ optional_env:
     prompt: "Inkbox identity handle"
     secret: false
   - name: INKBOX_SIGNING_KEY
-    description: "Webhook signing key for inbound email, SMS, and calls."
+    description: "Webhook signing key for inbound email, SMS, iMessage, and calls."
     prompt: "Inkbox signing key"
     secret: true
   - name: INKBOX_BASE_URL

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "hermes-agent-plugin"
-version = "0.1.5"
+version = "0.2.0"
 description = "Inkbox platform plugin for Hermes Agent"
 requires-python = ">=3.10"
 dependencies = [
   "aiohttp>=3.9",
-  "inkbox>=0.4.6",
+  "inkbox>=0.4.7",
 ]
 
 [tool.pytest.ini_options]

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -724,7 +724,7 @@ def _wait_for_imessage_first_message(client: Any, identity: Any, handle: str) ->
 
     print()
     print_info("  From your iPhone, in the Messages app:")
-    print(color(f"    1. Text \"{connect_command}\" to {triage.number}", Colors.BOLD))
+    print(color(f"      1. Text \"{connect_command}\" to {triage.number}", Colors.BOLD))
     print_info("    2. Inkbox texts you back from the number now assigned to this agent.")
     print_info("    3. Send any first message (e.g. \"hi\") in that NEW thread.")
     print_info("  The agent can only message you after you message it first.")
@@ -804,6 +804,8 @@ def _wait_for_imessage_first_message(client: Any, identity: Any, handle: str) ->
     except Exception:
         pass
     print_info("  Start the gateway (`hermes gateway run`) and keep chatting there.")
+    print_info("  If the gateway is already running, restart it (`hermes gateway restart`)")
+    print_info("  so it picks up this new iMessage connection.")
 
 
 def _self_signup_flow(base_url: str, Inkbox: Any, InkboxAPIError: Any) -> tuple[Any | None, str, bool]:

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -670,7 +670,28 @@ def _configure_imessage(api_key: str, base_url: str, handle: str, Inkbox: Any) -
             print_warning(f"  Could not refresh the identity after enabling: {exc}")
             return
 
-    if not prompt_yes_no("  Connect your iPhone to this agent now?", True):
+    # Surface phones already connected through the router so reruns don't
+    # read like a first-time setup, and default the walkthrough off when a
+    # connection already exists (connecting another phone is the rare case).
+    connected = []
+    list_assignments = getattr(identity, "list_imessage_assignments", None)
+    if callable(list_assignments):
+        try:
+            connected = list(list_assignments(limit=5))
+        except Exception:
+            connected = []
+        if connected:
+            numbers = ", ".join(
+                str(getattr(a, "remote_number", "") or "") for a in connected
+            )
+            print_success(f"  Already connected: {numbers}")
+
+    question = (
+        "  Connect another iPhone to this agent now?"
+        if connected
+        else "  Connect your iPhone to this agent now?"
+    )
+    if not prompt_yes_no(question, not connected):
         print_info("  You can connect anytime — rerun `hermes inkbox setup` for the walkthrough.")
         return
     _wait_for_imessage_first_message(client, identity, handle)

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -57,7 +57,7 @@ except Exception:  # pragma: no cover - local tests without Hermes
     masked_secret_prompt = None
 
 
-INKBOX_REQUIREMENTS = ("inkbox>=0.4.6", "aiohttp>=3.9")
+INKBOX_REQUIREMENTS = ("inkbox>=0.4.7", "aiohttp>=3.9")
 _BRACKETED_PASTE_PATTERN = re.compile(r"\x1b\[\s*200~|\x1b\[\s*201~")
 OPENAI_REALTIME_TEST_MODEL = "gpt-realtime-2"
 OPENAI_REALTIME_TEST_URL = "wss://api.openai.com/v1/realtime"
@@ -336,6 +336,7 @@ def _seed_identity_state(identity: Any) -> None:
             ),
             "phone_number": getattr(phone, "number", None) if phone else None,
             "phone_number_id": str(getattr(phone, "id", "")) if phone else None,
+            "imessage_enabled": bool(getattr(identity, "imessage_enabled", False)),
             "tunnel_public_host": getattr(tunnel, "public_host", None) if tunnel else None,
         }
         path = Path(get_hermes_home()) / "inkbox_identity_state.json"
@@ -615,6 +616,173 @@ def _wait_for_sms_opt_in(api_key: str, base_url: str, phone: Any, Inkbox: Any) -
         sys.stdout.flush()
         print()
         print_warning(f"  Skipped. Text START to {phone.number} anytime to enable outbound SMS.")
+
+
+def _configure_imessage(api_key: str, base_url: str, handle: str, Inkbox: Any) -> None:
+    """Offer to enable iMessage for the agent and walk through connecting.
+
+    Args:
+        api_key (str): The agent-scoped Inkbox API key the wizard saved.
+        base_url (str): Inkbox API base URL.
+        handle (str): Agent identity handle being configured.
+        Inkbox (Any): The Inkbox SDK client class.
+
+    Returns:
+        None: Prints progress; failures degrade to a warning and return.
+    """
+    print()
+    print(color("  --- iMessage ---", Colors.CYAN))
+    print_info("  Inkbox can make this agent reachable over iMessage from your iPhone.")
+    print_info("  No number to provision — you connect through the Inkbox iMessage router.")
+
+    try:
+        client = Inkbox(api_key=api_key, base_url=base_url)
+        identity = client.get_identity(handle)
+    except Exception as exc:
+        print_warning(f"  Could not load the identity for iMessage setup: {exc}")
+        return
+
+    # Old SDKs predate iMessage entirely — detect by surface, not version.
+    if not hasattr(client, "imessages") or not hasattr(identity, "imessage_enabled"):
+        print_warning("  The installed Inkbox SDK does not support iMessage yet.")
+        print_info("  Upgrade it and rerun setup:")
+        print_info(f"    {_install_command_text()}")
+        return
+
+    if identity.imessage_enabled:
+        print_success("  iMessage is already enabled for this agent.")
+    else:
+        if not prompt_yes_no("  Enable iMessage for this agent?", True):
+            print_info("  Skipped. Rerun `hermes inkbox setup` anytime to enable iMessage.")
+            return
+        try:
+            identity.update(imessage_enabled=True)
+        except Exception as exc:
+            print_error(f"  Could not enable iMessage: {exc}")
+            print_info("  You can enable it later from the Inkbox console and rerun setup.")
+            return
+        print_success("  iMessage enabled for this agent.")
+        try:
+            # Re-fetch so the local object reflects the new flag (the SDK
+            # gates its iMessage helpers on it).
+            identity = client.get_identity(handle)
+        except Exception as exc:
+            print_warning(f"  Could not refresh the identity after enabling: {exc}")
+            return
+
+    if not prompt_yes_no("  Connect your iPhone to this agent now?", True):
+        print_info("  You can connect anytime — rerun `hermes inkbox setup` for the walkthrough.")
+        return
+    _wait_for_imessage_first_message(client, identity, handle)
+
+
+def _wait_for_imessage_first_message(client: Any, identity: Any, handle: str) -> None:
+    """Walk the user through the iMessage connect flow and greet them back.
+
+    Args:
+        client (Any): Authenticated Inkbox SDK client (agent-scoped key).
+        identity (Any): The iMessage-enabled agent identity object.
+        handle (str): Agent identity handle, used in the welcome message.
+
+    Returns:
+        None: Polls until the first inbound iMessage arrives (Ctrl+C skips),
+        then sends the channel-introduction reply into that conversation.
+    """
+    from datetime import datetime, timezone
+
+    try:
+        triage = client.imessages.get_triage_number()
+    except Exception as exc:
+        print_warning(f"  Could not fetch the iMessage router number: {exc}")
+        print_info("  Rerun `hermes inkbox setup` later to finish connecting.")
+        return
+
+    connect_command = str(getattr(triage, "connect_command", "") or "").strip()
+    if not connect_command or "your-handle" in connect_command:
+        connect_command = f"connect @{handle}"
+
+    print()
+    print_info("  From your iPhone, in the Messages app:")
+    print(color(f"    1. Text \"{connect_command}\" to {triage.number}", Colors.BOLD))
+    print_info("    2. Inkbox texts you back from the number now assigned to this agent.")
+    print_info("    3. Send any first message (e.g. \"hi\") in that NEW thread.")
+    print_info("  The agent can only message you after you message it first.")
+
+    print()
+    print(color("  --- Waiting for your first iMessage ---", Colors.YELLOW))
+    print_info("  Polling every 3s for an inbound iMessage to this agent.")
+    print_info("  Press Ctrl+C to skip; you can connect anytime.")
+
+    started_at = datetime.now(timezone.utc)
+
+    def find_first_inbound(messages: Any) -> Any | None:
+        for message in messages:
+            direction = (_enum_value(getattr(message, "direction", "")) or "").lower()
+            if direction != "inbound":
+                continue
+            created_at = getattr(message, "created_at", None)
+            # Ignore traffic from a connection that predates this run.
+            # Naive timestamps can't be compared to the aware cutoff —
+            # accept those rather than crash the poll loop.
+            if (
+                created_at is not None
+                and created_at.tzinfo is not None
+                and created_at < started_at
+            ):
+                continue
+            return message
+        return None
+
+    spinner = "|/-\\"
+    idx = 0
+    next_poll_at = time.monotonic()
+    clear_line = "\r" + " " * 72 + "\r"
+    match = None
+
+    try:
+        while match is None:
+            now = time.monotonic()
+            if now >= next_poll_at:
+                try:
+                    messages = identity.list_imessages(limit=10)
+                except Exception:
+                    messages = []
+                match = find_first_inbound(messages)
+                next_poll_at = now + 3.0
+            if match is None:
+                sys.stdout.write(f"\r  {spinner[idx]} Listening for your first iMessage...  ")
+                sys.stdout.flush()
+                idx = (idx + 1) % len(spinner)
+                time.sleep(0.25)
+    except KeyboardInterrupt:
+        sys.stdout.write(clear_line)
+        sys.stdout.flush()
+        print()
+        print_warning("  Skipped. The agent replies over iMessage once you connect and message it.")
+        return
+
+    sys.stdout.write(clear_line)
+    sys.stdout.flush()
+    remote = getattr(match, "remote_number", "") or "your phone"
+    print_success(f"  Got it. First iMessage received from {remote}.")
+
+    conversation_id = getattr(match, "conversation_id", None)
+    welcome = (
+        f"You're connected! This is your iMessage channel to your Hermes agent "
+        f"@{handle}. Anything you send here goes straight to the agent, and its "
+        f"replies will show up right in this thread."
+    )
+    try:
+        identity.send_imessage(conversation_id=conversation_id, text=welcome)
+        print_success("  Sent a welcome message back on that thread.")
+    except Exception as exc:
+        print_warning(f"  Could not send the welcome message: {exc}")
+    try:
+        # Clear the unread flag the walkthrough message left behind.
+        identity.mark_imessage_conversation_read(conversation_id)
+    except Exception:
+        pass
+    print_info("  Start the gateway (`hermes gateway run`) and keep chatting there.")
 
 
 def _self_signup_flow(base_url: str, Inkbox: Any, InkboxAPIError: Any) -> tuple[Any | None, str, bool]:
@@ -1165,6 +1333,8 @@ def interactive_setup() -> None:
 
     if did_provision_phone:
         _wait_for_sms_opt_in(api_key, base_url, getattr(identity, "phone_number", None), Inkbox)
+
+    _configure_imessage(api_key, base_url, identity.agent_handle, Inkbox)
 
     _setup_signing_key(api_key, base_url, Inkbox)
 

--- a/skills/inkbox-imessage-responder/SKILL.md
+++ b/skills/inkbox-imessage-responder/SKILL.md
@@ -48,11 +48,10 @@ While you compose a reply, the recipient automatically sees a typing indicator (
 
 ## Reacting to your messages (tapbacks)
 
-When someone puts a tapback on one of **your** messages, you receive a turn prefixed `[inkbox:imessage_reaction from=+1555… reaction=<type> action=<added|removed> conversation_id=… target_message_id=… | contact…]` followed by a short response policy. A reaction is a lightweight signal, not always a request for a reply:
+When someone puts a tapback on one of **your** messages, you receive a turn prefixed `[inkbox:imessage_reaction from=+1555… reaction=<type> conversation_id=… target_message_id=… | contact…]` followed by a short response policy. A reaction is a lightweight signal, not always a request for a reply:
 
-- A `question` tapback (`action=added`) usually asks for clarification or a follow-up — replying is normally warranted.
+- A `question` tapback usually asks for clarification or a follow-up — replying is normally warranted.
 - `emphasize` may invite a brief acknowledgement or follow-up.
 - `love` / `like` / `laugh` / `dislike` are usually just acknowledgements that need no response.
-- `action=removed` means they **took a tapback back** — almost always a quiet correction or change of mind, not a request for anything. Replying is very rarely warranted.
 
-Decide based on the reaction, the action, and the conversation. **If no visible reply is warranted, return exactly `[SILENT]`** — the adapter drops it and nothing is sent. Reply normally (via `inkbox_send_imessage`) only when a response genuinely adds value.
+Decide based on the reaction and the conversation. **If no visible reply is warranted, return exactly `[SILENT]`** — the adapter drops it and nothing is sent. Reply normally (via `inkbox_send_imessage`) only when a response genuinely adds value.

--- a/skills/inkbox-imessage-responder/SKILL.md
+++ b/skills/inkbox-imessage-responder/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: inkbox-imessage-responder
+description: Use when the user asks to send an iMessage, reply on iMessage, or explain how to reach the agent over iMessage — also use automatically when an inbound `imessage.received` event arrives from Inkbox. Handles the connect/router model, the recipient-first rule, and tapback reactions.
+user-invocable: false
+---
+
+# Inkbox iMessage responder
+
+The Inkbox plugin makes this agent reachable over iMessage. Unlike SMS, the agent does not own an iMessage number: people connect through the Inkbox iMessage router, and each connected person gets a dedicated conversation with this agent. Use this skill for any iMessage conversation — short, conversational, reply-driven.
+
+## How the channel works
+
+- A person texts the connect command (e.g. `connect @agent-handle`) to the Inkbox iMessage router number from their iPhone. Get both with `inkbox_imessage_triage_number`.
+- Inkbox texts them back from the number assigned to their conversation with this agent. All chat happens in that thread.
+- **Recipient-first:** the agent cannot message anyone over iMessage until that person has messaged it first. There is no cold outreach on this channel. If an outbound send returns a 409-style error saying the recipient hasn't messaged yet or is no longer connected, tell the user the person needs to (re)connect and send a message first.
+- If someone asks "how do I iMessage you?", answer with the router number and connect command from `inkbox_imessage_triage_number`.
+
+## Required tools
+
+- `inkbox_list_imessage_conversations` — start here for triage; returns conversation IDs, latest-message previews, unread counts
+- `inkbox_get_imessage_conversation` — pull message history (includes live tapback reactions on each message)
+- `inkbox_send_imessage` — outbound by `conversationId` (preferred) or `to` E.164
+
+## Optional (allowlist needed)
+
+- `inkbox_imessage_triage_number` — router number + connect command for onboarding new people
+- `inkbox_send_imessage_reaction` — tapback (love/like/dislike/laugh/emphasize/question) on a received message
+- `inkbox_mark_imessage_conversation_read` — send a read receipt and clear unread state
+
+## Workflow
+
+1. **Pull conversations.** Call `inkbox_list_imessage_conversations` (defaults: `limit: 25`). Each row shows `id`, `remote_number`, `latest_text`, `unread_count`, `total_count`.
+
+2. **Pick a conversation to handle.** If you need history, call `inkbox_get_imessage_conversation` with `conversationId: row.id`. Inbound messages may carry `reactions` — live tapbacks the person put on a message.
+
+3. **Compose and send.** Reply with `inkbox_send_imessage` using `conversationId`. Keep the tone conversational — iMessage is a chat thread, not email. A `sendStyle` (confetti, balloons, …) is available for celebratory moments; use sparingly.
+
+4. **React when a reply would be noise.** A tapback via `inkbox_send_imessage_reaction` (e.g. `like` on an acknowledgment) often beats a filler message.
+
+5. **Mark as handled** if you have the optional tool allowlisted: `inkbox_mark_imessage_conversation_read` with `conversationId` — this also shows the sender a read receipt.
+
+## Inbound markers
+
+Inbound iMessages arrive prefixed `[inkbox:imessage from=+1555… conversation_id=… | contact…]` (bursts arrive as `[inkbox:imessage_burst …]` with one line per fragment). Use the marker for routing context; never echo it back.

--- a/skills/inkbox-imessage-responder/SKILL.md
+++ b/skills/inkbox-imessage-responder/SKILL.md
@@ -48,10 +48,11 @@ While you compose a reply, the recipient automatically sees a typing indicator (
 
 ## Reacting to your messages (tapbacks)
 
-When someone puts a tapback on one of **your** messages, you receive a turn prefixed `[inkbox:imessage_reaction from=+1555… reaction=<type> conversation_id=… target_message_id=… | contact…]` followed by a short response policy. A reaction is a lightweight signal, not always a request for a reply:
+When someone puts a tapback on one of **your** messages, you receive a turn prefixed `[inkbox:imessage_reaction from=+1555… reaction=<type> action=<added|removed> conversation_id=… target_message_id=… | contact…]` followed by a short response policy. A reaction is a lightweight signal, not always a request for a reply:
 
-- A `question` tapback usually asks for clarification or a follow-up — replying is normally warranted.
+- A `question` tapback (`action=added`) usually asks for clarification or a follow-up — replying is normally warranted.
 - `emphasize` may invite a brief acknowledgement or follow-up.
 - `love` / `like` / `laugh` / `dislike` are usually just acknowledgements that need no response.
+- `action=removed` means they **took a tapback back** — almost always a quiet correction or change of mind, not a request for anything. Replying is very rarely warranted.
 
-Decide based on the reaction and the conversation. **If no visible reply is warranted, return exactly `[SILENT]`** — the adapter drops it and nothing is sent. Reply normally (via `inkbox_send_imessage`) only when a response genuinely adds value.
+Decide based on the reaction, the action, and the conversation. **If no visible reply is warranted, return exactly `[SILENT]`** — the adapter drops it and nothing is sent. Reply normally (via `inkbox_send_imessage`) only when a response genuinely adds value.

--- a/skills/inkbox-imessage-responder/SKILL.md
+++ b/skills/inkbox-imessage-responder/SKILL.md
@@ -17,19 +17,20 @@ The Inkbox plugin makes this agent reachable over iMessage. Unlike SMS, the agen
 
 ## Required tools
 
-- `inkbox_list_imessage_conversations` — start here for triage; returns conversation IDs, latest-message previews, unread counts
+- `inkbox_list_imessage_conversations` — start here for triage; returns conversation IDs, latest-message previews, unread counts, and `assignment_status`
 - `inkbox_get_imessage_conversation` — pull message history (includes live tapback reactions on each message)
 - `inkbox_send_imessage` — outbound by `conversationId` (preferred) or `to` E.164
 
 ## Optional (allowlist needed)
 
 - `inkbox_imessage_triage_number` — router number + connect command for onboarding new people
+- `inkbox_list_imessage_assignments` — who is actively connected to this agent right now (one row per recipient)
 - `inkbox_send_imessage_reaction` — tapback (love/like/dislike/laugh/emphasize/question) on a received message
 - `inkbox_mark_imessage_conversation_read` — send a read receipt and clear unread state
 
 ## Workflow
 
-1. **Pull conversations.** Call `inkbox_list_imessage_conversations` (defaults: `limit: 25`). Each row shows `id`, `remote_number`, `latest_text`, `unread_count`, `total_count`.
+1. **Pull conversations.** Call `inkbox_list_imessage_conversations` (defaults: `limit: 25`). Each row shows `id`, `remote_number`, `latest_text`, `unread_count`, `total_count`, and `assignment_status` — `released` means that person disconnected, so a reply will fail until they reconnect through the router; tell them how instead of retrying.
 
 2. **Pick a conversation to handle.** If you need history, call `inkbox_get_imessage_conversation` with `conversationId: row.id`. Inbound messages may carry `reactions` — live tapbacks the person put on a message.
 

--- a/skills/inkbox-imessage-responder/SKILL.md
+++ b/skills/inkbox-imessage-responder/SKILL.md
@@ -43,3 +43,15 @@ The Inkbox plugin makes this agent reachable over iMessage. Unlike SMS, the agen
 ## Inbound markers
 
 Inbound iMessages arrive prefixed `[inkbox:imessage from=+1555… conversation_id=… | contact…]` (bursts arrive as `[inkbox:imessage_burst …]` with one line per fragment). Use the marker for routing context; never echo it back.
+
+While you compose a reply, the recipient automatically sees a typing indicator (the adapter pulses it until your message sends), so there is no separate "I'm typing" tool to call.
+
+## Reacting to your messages (tapbacks)
+
+When someone puts a tapback on one of **your** messages, you receive a turn prefixed `[inkbox:imessage_reaction from=+1555… reaction=<type> conversation_id=… target_message_id=… | contact…]` followed by a short response policy. A reaction is a lightweight signal, not always a request for a reply:
+
+- A `question` tapback usually asks for clarification or a follow-up — replying is normally warranted.
+- `emphasize` may invite a brief acknowledgement or follow-up.
+- `love` / `like` / `laugh` / `dislike` are usually just acknowledgements that need no response.
+
+Decide based on the reaction and the conversation. **If no visible reply is warranted, return exactly `[SILENT]`** — the adapter drops it and nothing is sent. Reply normally (via `inkbox_send_imessage`) only when a response genuinely adds value.

--- a/tests/test_imessage.py
+++ b/tests/test_imessage.py
@@ -459,6 +459,7 @@ def test_inbound_reaction_enqueues_turn_with_silent_policy(monkeypatch):
     assert text.startswith(
         "[inkbox:imessage_reaction from=+15555550101 reaction=question"
     )
+    assert "action=added" in text
     assert "conversation_id=imconv-123" in text
     assert "target_message_id=im-target-9" in text
     assert "[SILENT]" in text  # the agent is told it may stay silent
@@ -509,6 +510,70 @@ def test_inbound_non_question_reaction_does_not_type(monkeypatch):
     assert response.status == 200
     assert len(enqueued) == 1
     # A 'love' tapback usually resolves to [SILENT]; don't promise a reply.
+    assert "imconv-123" not in adapter._typing_tasks()
+
+
+def test_reaction_is_removal_detection():
+    # Defaults to "added" when no removal field is present.
+    assert adapter_mod._reaction_is_removal({"reaction": "question"}) is False
+    # Boolean flags under any of the plausible names.
+    assert adapter_mod._reaction_is_removal({"removed": True}) is True
+    assert adapter_mod._reaction_is_removal({"is_removal": True}) is True
+    assert adapter_mod._reaction_is_removal({"removed": False}) is False
+    # String action/event fields.
+    assert adapter_mod._reaction_is_removal({"action": "removed"}) is True
+    assert adapter_mod._reaction_is_removal({"event": "retracted"}) is True
+    assert adapter_mod._reaction_is_removal({"action": "added"}) is False
+
+
+def test_inbound_reaction_removal_enqueues_silent_leaning_turn(monkeypatch):
+    identity = FakeIdentity()
+
+    async def _resolve_contact_full(**_kwargs):
+        return {"id": "contact-123", "name": "Alex"}
+
+    enqueued = []
+
+    async def _enqueue(event):
+        enqueued.append(event)
+
+    monkeypatch.setattr(
+        adapter_mod,
+        "web",
+        types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
+    )
+    adapter = object.__new__(InkboxAdapter)
+    adapter._inkbox = FakeInkboxClient(identity)
+    adapter._identity_handle = "agent"
+    adapter._seen_request_ids = {}
+    adapter._last_inbound_modality = {}
+    adapter._last_inbound_imessage = {}
+    adapter._resolve_contact_full = _resolve_contact_full
+    adapter._enqueue = _enqueue
+
+    response = asyncio.run(adapter._on_imessage_reaction({
+        "event_type": "imessage.reaction_received",
+        "data": {
+            "reaction": {
+                "id": "react-rm-1",
+                "direction": "inbound",
+                "remote_number": "+15555550101",
+                "conversation_id": "imconv-123",
+                "target_message_id": "im-target-9",
+                "reaction": "question",
+                "action": "removed",
+            },
+        },
+    }))
+
+    assert response.status == 200
+    assert len(enqueued) == 1
+    text = enqueued[0].text
+    # The agent is woken and explicitly told it was a removal.
+    assert "action=removed" in text
+    assert "removed their" in text
+    assert "[SILENT]" in text
+    # Even a removed 'question' tapback must NOT start typing.
     assert "imconv-123" not in adapter._typing_tasks()
 
 

--- a/tests/test_imessage.py
+++ b/tests/test_imessage.py
@@ -57,6 +57,9 @@ class FakeIdentity:
         self.calls.append(("send_imessage_reaction", kwargs))
         return types.SimpleNamespace(id="react-1", reaction="like")
 
+    def send_imessage_typing(self, conversation_id):
+        self.calls.append(("send_imessage_typing", conversation_id))
+
 
 class FakeInkboxClient:
     def __init__(self, identity):
@@ -340,6 +343,148 @@ def test_imessage_lifecycle_event_logs_without_agent_turn(monkeypatch):
                 "direction": "outbound",
                 "remote_number": "+15555550101",
                 "status": "delivered",
+            },
+        },
+    }))
+
+    assert response.status == 200
+    assert enqueued == []
+
+
+def test_reaction_received_is_subscribed():
+    # The agent must be woken for inbound tapbacks so it can decide whether
+    # to reply or stay [SILENT].
+    assert "imessage.reaction_received" in adapter_mod._DESIRED_IMESSAGE_EVENTS
+
+
+def test_inbound_imessage_starts_typing_pulse(monkeypatch):
+    identity = FakeIdentity()
+
+    async def _resolve_contact_full(**_kwargs):
+        return {"id": "contact-123", "name": "Alex"}
+
+    async def _enqueue_sms_text_event(event):
+        # The pulse is started right before enqueue in the real handler.
+        pass
+
+    monkeypatch.setattr(
+        adapter_mod,
+        "web",
+        types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
+    )
+
+    async def _run():
+        adapter = object.__new__(InkboxAdapter)
+        adapter._inkbox = FakeInkboxClient(identity)
+        adapter._identity_handle = "agent"
+        adapter._seen_request_ids = {}
+        adapter._last_inbound_modality = {}
+        adapter._last_inbound_imessage = {}
+        adapter._resolve_contact_full = _resolve_contact_full
+        adapter._enqueue_sms_text_event = _enqueue_sms_text_event
+
+        response = await adapter._on_imessage_received({
+            "event_type": "imessage.received",
+            "data": {
+                "message": {
+                    "id": "im-in",
+                    "direction": "inbound",
+                    "remote_number": "+15555550101",
+                    "conversation_id": "imconv-123",
+                    "content": "ping",
+                },
+            },
+        })
+        # A typing pulse task is now running for this conversation.
+        assert "imconv-123" in adapter._typing_tasks()
+        # Cancel it the way send() would, so the test loop exits cleanly.
+        adapter._stop_imessage_typing("imconv-123")
+        assert "imconv-123" not in adapter._typing_tasks()
+        return response
+
+    response = asyncio.run(_run())
+    assert response.status == 200
+
+
+def test_inbound_reaction_enqueues_turn_with_silent_policy(monkeypatch):
+    identity = FakeIdentity()
+
+    async def _resolve_contact_full(**_kwargs):
+        return {"id": "contact-123", "name": "Alex"}
+
+    enqueued = []
+
+    async def _enqueue(event):
+        enqueued.append(event)
+
+    monkeypatch.setattr(
+        adapter_mod,
+        "web",
+        types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
+    )
+    adapter = object.__new__(InkboxAdapter)
+    adapter._inkbox = FakeInkboxClient(identity)
+    adapter._identity_handle = "agent"
+    adapter._seen_request_ids = {}
+    adapter._last_inbound_modality = {}
+    adapter._last_inbound_imessage = {}
+    adapter._resolve_contact_full = _resolve_contact_full
+    adapter._enqueue = _enqueue
+
+    response = asyncio.run(adapter._on_imessage_reaction({
+        "event_type": "imessage.reaction_received",
+        "data": {
+            "reaction": {
+                "id": "react-in-1",
+                "direction": "inbound",
+                "remote_number": "+15555550101",
+                "conversation_id": "imconv-123",
+                "target_message_id": "im-target-9",
+                "reaction": "question",
+            },
+        },
+    }))
+
+    assert response.status == 200
+    assert len(enqueued) == 1
+    text = enqueued[0].text
+    assert text.startswith(
+        "[inkbox:imessage_reaction from=+15555550101 reaction=question"
+    )
+    assert "conversation_id=imconv-123" in text
+    assert "target_message_id=im-target-9" in text
+    assert "[SILENT]" in text  # the agent is told it may stay silent
+    # Reply target is stashed so a follow-up send lands in the right thread.
+    assert adapter._last_inbound_imessage["contact-123"]["conversation_id"] == "imconv-123"
+    assert adapter._last_inbound_modality["contact-123"] == "imessage"
+
+
+def test_inbound_reaction_ignores_outbound_echo(monkeypatch):
+    # The agent's own tapbacks echo back as reaction_received webhooks.
+    enqueued = []
+
+    async def _enqueue(event):
+        enqueued.append(event)
+
+    monkeypatch.setattr(
+        adapter_mod,
+        "web",
+        types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
+    )
+    adapter = object.__new__(InkboxAdapter)
+    adapter._seen_request_ids = {}
+    adapter._enqueue = _enqueue
+
+    response = asyncio.run(adapter._on_imessage_reaction({
+        "event_type": "imessage.reaction_received",
+        "data": {
+            "reaction": {
+                "id": "react-out-1",
+                "direction": "outbound",
+                "remote_number": "+15555550101",
+                "conversation_id": "imconv-123",
+                "target_message_id": "im-target-9",
+                "reaction": "like",
             },
         },
     }))

--- a/tests/test_imessage.py
+++ b/tests/test_imessage.py
@@ -1,0 +1,302 @@
+import asyncio
+import json
+import sys
+import types
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("inkbox_plugin")
+pkg.__path__ = [str(ROOT)]
+sys.modules.setdefault("inkbox_plugin", pkg)
+
+from inkbox_plugin import adapter as adapter_mod
+from inkbox_plugin import tools
+from inkbox_plugin.adapter import (
+    InkboxAdapter,
+    _imessage_conversation_target,
+    send_inkbox_direct,
+)
+
+
+class FakeIMessage:
+    id = "im-1"
+    conversation_id = "imconv-123"
+    service = "imessage"
+    status = "queued"
+
+
+class FakeIdentity:
+    def __init__(self):
+        self.sent_imessages = []
+        self.calls = []
+
+    def send_imessage(self, **kwargs):
+        self.sent_imessages.append(kwargs)
+        return FakeIMessage()
+
+    def list_imessage_conversations(self, **kwargs):
+        self.calls.append(("list_imessage_conversations", kwargs))
+        return [{
+            "id": "imconv-123",
+            "remote_number": "+15555550101",
+            "latest_text": "hi",
+            "unread_count": 1,
+            "total_count": 3,
+        }]
+
+    def list_imessages(self, **kwargs):
+        self.calls.append(("list_imessages", kwargs))
+        return [{"id": "im-1", "conversation_id": kwargs.get("conversation_id")}]
+
+    def mark_imessage_conversation_read(self, conversation_id):
+        self.calls.append(("mark_imessage_conversation_read", conversation_id))
+        return types.SimpleNamespace(updated_count=2)
+
+    def send_imessage_reaction(self, **kwargs):
+        self.calls.append(("send_imessage_reaction", kwargs))
+        return types.SimpleNamespace(id="react-1", reaction="like")
+
+
+class FakeInkboxClient:
+    def __init__(self, identity):
+        self.identity = identity
+        self.contacts = types.SimpleNamespace(get=lambda _contact_id: None)
+
+    def get_identity(self, _handle):
+        return self.identity
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+
+def test_imessage_conversation_target_parsing():
+    assert _imessage_conversation_target("imessage:conversation:imconv-1") == "imconv-1"
+    assert _imessage_conversation_target("imessage:imconv-1") == "imconv-1"
+    assert _imessage_conversation_target("inkbox:imessage:conversation:imconv-1") == "imconv-1"
+    assert _imessage_conversation_target("imessage:+15555550101") is None
+    assert _imessage_conversation_target("sms:conversation:conv-1") is None
+    assert _imessage_conversation_target("") is None
+
+
+def test_send_imessage_tool_prefers_conversation_id(monkeypatch):
+    identity = FakeIdentity()
+    monkeypatch.setattr(tools, "_client_and_identity", lambda: (None, None, identity))
+
+    out = json.loads(tools.inkbox_send_imessage({
+        "conversationId": "imconv-123",
+        "text": "hello",
+    }))
+
+    assert out["ok"] is True
+    assert identity.sent_imessages == [{"text": "hello", "conversation_id": "imconv-123"}]
+
+
+def test_send_imessage_tool_requires_exactly_one_target(monkeypatch):
+    identity = FakeIdentity()
+    monkeypatch.setattr(tools, "_client_and_identity", lambda: (None, None, identity))
+
+    both = json.loads(tools.inkbox_send_imessage({
+        "conversationId": "imconv-123",
+        "to": "+15555550101",
+        "text": "hello",
+    }))
+    neither = json.loads(tools.inkbox_send_imessage({"text": "hello"}))
+
+    assert "error" in both
+    assert "error" in neither
+    assert identity.sent_imessages == []
+
+
+def test_imessage_conversation_tools_use_conversation_id(monkeypatch):
+    identity = FakeIdentity()
+    monkeypatch.setattr(tools, "_client_and_identity", lambda: (None, None, identity))
+
+    conversations = json.loads(tools.inkbox_list_imessage_conversations({}))
+    history = json.loads(tools.inkbox_get_imessage_conversation({"conversationId": "imconv-123"}))
+    marked = json.loads(tools.inkbox_mark_imessage_conversation_read({"conversationId": "imconv-123"}))
+    reacted = json.loads(tools.inkbox_send_imessage_reaction({
+        "messageId": "im-1",
+        "reaction": "like",
+    }))
+
+    assert conversations["count"] == 1
+    assert history["messages"][0]["conversation_id"] == "imconv-123"
+    assert marked["updated_count"] == 2
+    assert reacted["ok"] is True
+    assert identity.calls == [
+        ("list_imessage_conversations", {"limit": 25, "offset": 0}),
+        ("list_imessages", {"conversation_id": "imconv-123", "limit": 50, "offset": 0}),
+        ("mark_imessage_conversation_read", "imconv-123"),
+        ("send_imessage_reaction", {"message_id": "im-1", "reaction": "like", "part_index": 0}),
+    ]
+
+
+def test_adapter_imessage_reply_uses_last_inbound_conversation_id(monkeypatch):
+    identity = FakeIdentity()
+
+    async def _inline_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(adapter_mod.asyncio, "to_thread", _inline_to_thread)
+    adapter = object.__new__(InkboxAdapter)
+    adapter._active_call_ws = {}
+    adapter._voice_recently_closed = {}
+    adapter._last_inbound_modality = {"contact-123": "imessage"}
+    adapter._last_inbound_imessage = {
+        "contact-123": {
+            "conversation_id": "imconv-123",
+            "remote_number": "+15555550101",
+            "message_id": "im-in",
+        },
+    }
+    adapter._inkbox = FakeInkboxClient(identity)
+    adapter._identity_handle = "agent"
+
+    # No explicit mode: the stashed inbound modality routes this to iMessage.
+    result = asyncio.run(adapter.send("contact-123", "reply"))
+
+    assert result.success is True
+    assert identity.sent_imessages == [{"conversation_id": "imconv-123", "text": "reply"}]
+
+
+def test_adapter_imessage_reply_uses_thread_conversation_id(monkeypatch):
+    identity = FakeIdentity()
+
+    async def _inline_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(adapter_mod.asyncio, "to_thread", _inline_to_thread)
+    adapter = object.__new__(InkboxAdapter)
+    adapter._active_call_ws = {}
+    adapter._voice_recently_closed = {}
+    adapter._last_inbound_modality = {"contact-123": "imessage"}
+    adapter._last_inbound_imessage = {
+        "contact-123": {
+            "conversation_id": "stale-conv",
+            "remote_number": "+15555550101",
+            "message_id": "im-old",
+        },
+    }
+    adapter._inkbox = FakeInkboxClient(identity)
+    adapter._identity_handle = "agent"
+
+    result = asyncio.run(adapter.send(
+        "contact-123",
+        "reply",
+        metadata={"mode": "imessage", "thread_id": "imessage:imconv-456"},
+    ))
+
+    assert result.success is True
+    assert identity.sent_imessages == [{"conversation_id": "imconv-456", "text": "reply"}]
+
+
+def test_inbound_imessage_builds_marker_and_stashes_state(monkeypatch):
+    identity = FakeIdentity()
+
+    async def _inline_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    async def _resolve_contact_full(**_kwargs):
+        return {"id": "contact-123", "name": "Alex"}
+
+    events = []
+
+    async def _enqueue_sms_text_event(event):
+        events.append(event)
+
+    monkeypatch.setattr(adapter_mod.asyncio, "to_thread", _inline_to_thread)
+    monkeypatch.setattr(
+        adapter_mod,
+        "web",
+        types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
+    )
+    adapter = object.__new__(InkboxAdapter)
+    adapter._inkbox = FakeInkboxClient(identity)
+    adapter._identity_handle = "agent"
+    adapter._seen_request_ids = {}
+    adapter._last_inbound_modality = {}
+    adapter._last_inbound_imessage = {}
+    adapter._resolve_contact_full = _resolve_contact_full
+    adapter._enqueue_sms_text_event = _enqueue_sms_text_event
+
+    response = asyncio.run(adapter._on_imessage_received({
+        "event_type": "imessage.received",
+        "data": {
+            "message": {
+                "id": "im-in",
+                "direction": "inbound",
+                "remote_number": "+15555550101",
+                "conversation_id": "imconv-123",
+                "content": "Dinner moved to 7.",
+            },
+        },
+    }))
+
+    assert response.status == 200
+    assert len(events) == 1
+    assert events[0].text.startswith("[inkbox:imessage from=+15555550101 conversation_id=imconv-123")
+    assert "Dinner moved to 7." in events[0].text
+    assert events[0].source.thread_id == "imessage:imconv-123"
+    assert adapter._last_inbound_modality["contact-123"] == "imessage"
+    assert adapter._last_inbound_imessage["contact-123"]["conversation_id"] == "imconv-123"
+    assert adapter._last_inbound_imessage["contact-123|imessage:imconv-123"]["remote_number"] == "+15555550101"
+
+
+def test_inbound_imessage_ignores_outbound_echo(monkeypatch):
+    events = []
+
+    async def _enqueue_sms_text_event(event):
+        events.append(event)
+
+    monkeypatch.setattr(
+        adapter_mod,
+        "web",
+        types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
+    )
+    adapter = object.__new__(InkboxAdapter)
+    adapter._seen_request_ids = {}
+    adapter._enqueue_sms_text_event = _enqueue_sms_text_event
+
+    response = asyncio.run(adapter._on_imessage_received({
+        "event_type": "imessage.received",
+        "data": {
+            "message": {
+                "id": "im-out",
+                "direction": "outbound",
+                "remote_number": "+15555550101",
+                "conversation_id": "imconv-123",
+                "content": "agent reply",
+            },
+        },
+    }))
+
+    assert response.status == 200
+    assert events == []
+
+
+def test_direct_send_accepts_imessage_conversation_target(monkeypatch):
+    identity = FakeIdentity()
+
+    def _fake_inkbox(**_kwargs):
+        return FakeInkboxClient(identity)
+
+    async def _inline_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(adapter_mod.asyncio, "to_thread", _inline_to_thread)
+    monkeypatch.setattr("inkbox_plugin.adapter.Inkbox", _fake_inkbox)
+    monkeypatch.setattr("inkbox_plugin.adapter.INKBOX_AVAILABLE", True)
+
+    out = asyncio.run(send_inkbox_direct(
+        {"api_key": "ApiKey_test", "identity": "agent"},
+        "imessage:conversation:imconv-123",
+        "cron says hi",
+    ))
+
+    assert out["success"] is True
+    assert out["mode"] == "imessage"
+    assert identity.sent_imessages == [{"conversation_id": "imconv-123", "text": "cron says hi"}]

--- a/tests/test_imessage.py
+++ b/tests/test_imessage.py
@@ -431,19 +431,27 @@ def test_inbound_reaction_enqueues_turn_with_silent_policy(monkeypatch):
     adapter._resolve_contact_full = _resolve_contact_full
     adapter._enqueue = _enqueue
 
-    response = asyncio.run(adapter._on_imessage_reaction({
-        "event_type": "imessage.reaction_received",
-        "data": {
-            "reaction": {
-                "id": "react-in-1",
-                "direction": "inbound",
-                "remote_number": "+15555550101",
-                "conversation_id": "imconv-123",
-                "target_message_id": "im-target-9",
-                "reaction": "question",
+    async def _run():
+        response = await adapter._on_imessage_reaction({
+            "event_type": "imessage.reaction_received",
+            "data": {
+                "reaction": {
+                    "id": "react-in-1",
+                    "direction": "inbound",
+                    "remote_number": "+15555550101",
+                    "conversation_id": "imconv-123",
+                    "target_message_id": "im-target-9",
+                    "reaction": "question",
+                },
             },
-        },
-    }))
+        })
+        # A "question" tapback usually warrants a reply — check the typing
+        # pulse started before the run loop tears down (and cancel it).
+        assert "imconv-123" in adapter._typing_tasks()
+        adapter._stop_imessage_typing("imconv-123")
+        return response
+
+    response = asyncio.run(_run())
 
     assert response.status == 200
     assert len(enqueued) == 1
@@ -457,6 +465,51 @@ def test_inbound_reaction_enqueues_turn_with_silent_policy(monkeypatch):
     # Reply target is stashed so a follow-up send lands in the right thread.
     assert adapter._last_inbound_imessage["contact-123"]["conversation_id"] == "imconv-123"
     assert adapter._last_inbound_modality["contact-123"] == "imessage"
+
+
+def test_inbound_non_question_reaction_does_not_type(monkeypatch):
+    identity = FakeIdentity()
+
+    async def _resolve_contact_full(**_kwargs):
+        return {"id": "contact-123", "name": "Alex"}
+
+    enqueued = []
+
+    async def _enqueue(event):
+        enqueued.append(event)
+
+    monkeypatch.setattr(
+        adapter_mod,
+        "web",
+        types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
+    )
+    adapter = object.__new__(InkboxAdapter)
+    adapter._inkbox = FakeInkboxClient(identity)
+    adapter._identity_handle = "agent"
+    adapter._seen_request_ids = {}
+    adapter._last_inbound_modality = {}
+    adapter._last_inbound_imessage = {}
+    adapter._resolve_contact_full = _resolve_contact_full
+    adapter._enqueue = _enqueue
+
+    response = asyncio.run(adapter._on_imessage_reaction({
+        "event_type": "imessage.reaction_received",
+        "data": {
+            "reaction": {
+                "id": "react-in-2",
+                "direction": "inbound",
+                "remote_number": "+15555550101",
+                "conversation_id": "imconv-123",
+                "target_message_id": "im-target-9",
+                "reaction": "love",
+            },
+        },
+    }))
+
+    assert response.status == 200
+    assert len(enqueued) == 1
+    # A 'love' tapback usually resolves to [SILENT]; don't promise a reply.
+    assert "imconv-123" not in adapter._typing_tasks()
 
 
 def test_inbound_reaction_ignores_outbound_echo(monkeypatch):

--- a/tests/test_imessage.py
+++ b/tests/test_imessage.py
@@ -300,3 +300,49 @@ def test_direct_send_accepts_imessage_conversation_target(monkeypatch):
     assert out["success"] is True
     assert out["mode"] == "imessage"
     assert identity.sent_imessages == [{"conversation_id": "imconv-123", "text": "cron says hi"}]
+
+
+def test_list_imessage_assignments_tool(monkeypatch):
+    identity = FakeIdentity()
+    identity.list_imessage_assignments = lambda **kwargs: (
+        identity.calls.append(("list_imessage_assignments", kwargs))
+        or [{"id": "assign-1", "remote_number": "+15555550101", "status": "active"}]
+    )
+    monkeypatch.setattr(tools, "_client_and_identity", lambda: (None, None, identity))
+
+    out = json.loads(tools.inkbox_list_imessage_assignments({}))
+
+    assert out["ok"] is True
+    assert out["count"] == 1
+    assert out["assignments"][0]["remote_number"] == "+15555550101"
+    assert identity.calls == [("list_imessage_assignments", {"limit": 25, "offset": 0})]
+
+
+def test_imessage_lifecycle_event_logs_without_agent_turn(monkeypatch):
+    enqueued = []
+
+    async def _enqueue(event):
+        enqueued.append(event)
+
+    monkeypatch.setattr(
+        adapter_mod,
+        "web",
+        types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
+    )
+    adapter = object.__new__(InkboxAdapter)
+    adapter._enqueue = _enqueue
+
+    response = asyncio.run(adapter._on_imessage_lifecycle({
+        "event_type": "imessage.delivered",
+        "data": {
+            "message": {
+                "id": "im-1",
+                "direction": "outbound",
+                "remote_number": "+15555550101",
+                "status": "delivered",
+            },
+        },
+    }))
+
+    assert response.status == 200
+    assert enqueued == []

--- a/tests/test_imessage.py
+++ b/tests/test_imessage.py
@@ -459,7 +459,6 @@ def test_inbound_reaction_enqueues_turn_with_silent_policy(monkeypatch):
     assert text.startswith(
         "[inkbox:imessage_reaction from=+15555550101 reaction=question"
     )
-    assert "action=added" in text
     assert "conversation_id=imconv-123" in text
     assert "target_message_id=im-target-9" in text
     assert "[SILENT]" in text  # the agent is told it may stay silent
@@ -510,70 +509,6 @@ def test_inbound_non_question_reaction_does_not_type(monkeypatch):
     assert response.status == 200
     assert len(enqueued) == 1
     # A 'love' tapback usually resolves to [SILENT]; don't promise a reply.
-    assert "imconv-123" not in adapter._typing_tasks()
-
-
-def test_reaction_is_removal_detection():
-    # Defaults to "added" when no removal field is present.
-    assert adapter_mod._reaction_is_removal({"reaction": "question"}) is False
-    # Boolean flags under any of the plausible names.
-    assert adapter_mod._reaction_is_removal({"removed": True}) is True
-    assert adapter_mod._reaction_is_removal({"is_removal": True}) is True
-    assert adapter_mod._reaction_is_removal({"removed": False}) is False
-    # String action/event fields.
-    assert adapter_mod._reaction_is_removal({"action": "removed"}) is True
-    assert adapter_mod._reaction_is_removal({"event": "retracted"}) is True
-    assert adapter_mod._reaction_is_removal({"action": "added"}) is False
-
-
-def test_inbound_reaction_removal_enqueues_silent_leaning_turn(monkeypatch):
-    identity = FakeIdentity()
-
-    async def _resolve_contact_full(**_kwargs):
-        return {"id": "contact-123", "name": "Alex"}
-
-    enqueued = []
-
-    async def _enqueue(event):
-        enqueued.append(event)
-
-    monkeypatch.setattr(
-        adapter_mod,
-        "web",
-        types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
-    )
-    adapter = object.__new__(InkboxAdapter)
-    adapter._inkbox = FakeInkboxClient(identity)
-    adapter._identity_handle = "agent"
-    adapter._seen_request_ids = {}
-    adapter._last_inbound_modality = {}
-    adapter._last_inbound_imessage = {}
-    adapter._resolve_contact_full = _resolve_contact_full
-    adapter._enqueue = _enqueue
-
-    response = asyncio.run(adapter._on_imessage_reaction({
-        "event_type": "imessage.reaction_received",
-        "data": {
-            "reaction": {
-                "id": "react-rm-1",
-                "direction": "inbound",
-                "remote_number": "+15555550101",
-                "conversation_id": "imconv-123",
-                "target_message_id": "im-target-9",
-                "reaction": "question",
-                "action": "removed",
-            },
-        },
-    }))
-
-    assert response.status == 200
-    assert len(enqueued) == 1
-    text = enqueued[0].text
-    # The agent is woken and explicitly told it was a removal.
-    assert "action=removed" in text
-    assert "removed their" in text
-    assert "[SILENT]" in text
-    # Even a removed 'question' tapback must NOT start typing.
     assert "imconv-123" not in adapter._typing_tasks()
 
 

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -72,6 +72,7 @@ def test_registers_inkbox_platform_tools_commands_and_skills():
         "inkbox_mark_text_conversation_read",
         "inkbox_imessage_triage_number",
         "inkbox_send_imessage",
+        "inkbox_list_imessage_assignments",
         "inkbox_list_imessage_conversations",
         "inkbox_get_imessage_conversation",
         "inkbox_send_imessage_reaction",

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -70,6 +70,12 @@ def test_registers_inkbox_platform_tools_commands_and_skills():
         "inkbox_get_text",
         "inkbox_mark_text_read",
         "inkbox_mark_text_conversation_read",
+        "inkbox_imessage_triage_number",
+        "inkbox_send_imessage",
+        "inkbox_list_imessage_conversations",
+        "inkbox_get_imessage_conversation",
+        "inkbox_send_imessage_reaction",
+        "inkbox_mark_imessage_conversation_read",
         "inkbox_place_call",
     }
 

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -345,3 +345,29 @@ def test_wait_for_imessage_first_message_greets_back(monkeypatch):
     assert identity.sent[0]["conversation_id"] == "imconv-123"
     assert "@agent" in identity.sent[0]["text"]
     assert identity.marked_read == ["imconv-123"]
+
+
+def test_configure_imessage_already_connected_defaults_to_skip(monkeypatch):
+    identity = _FakeIMessageIdentity(enabled=True)
+    identity.list_imessage_assignments = lambda **_kwargs: [
+        types.SimpleNamespace(remote_number="+15555550101"),
+    ]
+    client = _FakeIMessageClient(identity)
+    prompts = []
+
+    def _prompt_yes_no(question, default=True):
+        prompts.append((question.strip(), default))
+        return default
+
+    monkeypatch.setattr(setup_wizard, "prompt_yes_no", _prompt_yes_no)
+    monkeypatch.setattr(
+        setup_wizard,
+        "_wait_for_imessage_first_message",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("should not walk through connect")),
+    )
+
+    setup_wizard._configure_imessage(
+        "ApiKey_test", "https://inkbox.ai", "agent", lambda **_kwargs: client,
+    )
+
+    assert prompts == [("Connect another iPhone to this agent now?", False)]

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -21,7 +21,7 @@ def test_install_command_prefers_uv_when_available(monkeypatch):
         "install",
         "--python",
         "/tmp/hermes/venv/bin/python",
-        "inkbox>=0.4.6",
+        "inkbox>=0.4.7",
         "aiohttp>=3.9",
     ]]
 
@@ -31,10 +31,10 @@ def test_install_command_falls_back_to_pip_and_ensurepip(monkeypatch):
     monkeypatch.setattr(setup_wizard.shutil, "which", lambda _name: None)
 
     assert setup_wizard._install_commands() == [
-        [["/tmp/hermes/venv/bin/python", "-m", "pip", "install", "inkbox>=0.4.6", "aiohttp>=3.9"]],
+        [["/tmp/hermes/venv/bin/python", "-m", "pip", "install", "inkbox>=0.4.7", "aiohttp>=3.9"]],
         [
             ["/tmp/hermes/venv/bin/python", "-m", "ensurepip", "--upgrade"],
-            ["/tmp/hermes/venv/bin/python", "-m", "pip", "install", "inkbox>=0.4.6", "aiohttp>=3.9"],
+            ["/tmp/hermes/venv/bin/python", "-m", "pip", "install", "inkbox>=0.4.7", "aiohttp>=3.9"],
         ],
     ]
 
@@ -53,7 +53,7 @@ def test_missing_sdk_guidance_prints_hermes_python(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "/tmp/hermes/venv/bin/python" in out
     assert "uv pip install --python" in out
-    assert "inkbox>=0.4.6" in out
+    assert "inkbox>=0.4.7" in out
     assert "aiohttp>=3.9" in out
 
 
@@ -236,3 +236,112 @@ def test_configure_realtime_calls_without_phone_skips(monkeypatch):
     setup_wizard._configure_realtime_calls(types.SimpleNamespace(phone_number=None))
 
     assert saved == []
+
+
+class _FakeIMessageIdentity:
+    def __init__(self, enabled=False):
+        self.imessage_enabled = enabled
+        self.updates = []
+        self.sent = []
+        self.marked_read = []
+        self._inbox = []
+
+    def update(self, **kwargs):
+        self.updates.append(kwargs)
+        if "imessage_enabled" in kwargs:
+            self.imessage_enabled = kwargs["imessage_enabled"]
+        return self
+
+    def list_imessages(self, **_kwargs):
+        return list(self._inbox)
+
+    def send_imessage(self, **kwargs):
+        self.sent.append(kwargs)
+        return types.SimpleNamespace(id="im-1")
+
+    def mark_imessage_conversation_read(self, conversation_id):
+        self.marked_read.append(conversation_id)
+
+
+class _FakeIMessageClient:
+    def __init__(self, identity):
+        self._identity = identity
+        self.imessages = types.SimpleNamespace(
+            get_triage_number=lambda: types.SimpleNamespace(
+                number="+15550009999",
+                connect_command="connect @agent",
+            ),
+        )
+
+    def get_identity(self, _handle):
+        return self._identity
+
+
+def test_configure_imessage_enables_and_offers_connect(monkeypatch):
+    identity = _FakeIMessageIdentity(enabled=False)
+    client = _FakeIMessageClient(identity)
+    walked = []
+
+    monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        setup_wizard,
+        "_wait_for_imessage_first_message",
+        lambda _client, _identity, handle: walked.append(handle),
+    )
+
+    setup_wizard._configure_imessage(
+        "ApiKey_test", "https://inkbox.ai", "agent", lambda **_kwargs: client,
+    )
+
+    assert identity.updates == [{"imessage_enabled": True}]
+    assert walked == ["agent"]
+
+
+def test_configure_imessage_declined_leaves_identity_untouched(monkeypatch):
+    identity = _FakeIMessageIdentity(enabled=False)
+    client = _FakeIMessageClient(identity)
+
+    monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(
+        setup_wizard,
+        "_wait_for_imessage_first_message",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("should not walk through connect")),
+    )
+
+    setup_wizard._configure_imessage(
+        "ApiKey_test", "https://inkbox.ai", "agent", lambda **_kwargs: client,
+    )
+
+    assert identity.updates == []
+
+
+def test_wait_for_imessage_first_message_greets_back(monkeypatch):
+    from datetime import datetime, timedelta, timezone
+
+    identity = _FakeIMessageIdentity(enabled=True)
+    client = _FakeIMessageClient(identity)
+    identity._inbox = [
+        types.SimpleNamespace(
+            id="im-old",
+            direction="inbound",
+            conversation_id="imconv-old",
+            remote_number="+15555550101",
+            created_at=datetime.now(timezone.utc) - timedelta(days=1),
+        ),
+        types.SimpleNamespace(
+            id="im-new",
+            direction="inbound",
+            conversation_id="imconv-123",
+            remote_number="+15555550101",
+            created_at=datetime.now(timezone.utc) + timedelta(seconds=5),
+        ),
+    ]
+
+    monkeypatch.setattr(setup_wizard.time, "sleep", lambda _s: None)
+
+    setup_wizard._wait_for_imessage_first_message(client, identity, "agent")
+
+    assert len(identity.sent) == 1
+    assert identity.sent[0]["conversation_id"] == "imconv-123"
+    assert "@agent" in identity.sent[0]["text"]
+    assert identity.marked_read == ["imconv-123"]

--- a/tools.py
+++ b/tools.py
@@ -427,6 +427,20 @@ def inkbox_list_imessage_conversations(args: dict, **kwargs) -> str:
         return _json({"error": str(exc)})
 
 
+def inkbox_list_imessage_assignments(args: dict, **kwargs) -> str:
+    del kwargs
+    try:
+        _cfg, _client, identity = _client_and_identity()
+        options = {"limit": int(args.get("limit") or 25), "offset": int(args.get("offset") or 0)}
+        assignments = _call_with_kwargs_or_payload(
+            _identity_method(identity, "list_imessage_assignments", "listImessageAssignments"),
+            options,
+        )
+        return _json({"ok": True, "count": len(assignments or []), "assignments": _json_safe(assignments or [])})
+    except Exception as exc:
+        return _json({"error": str(exc)})
+
+
 def inkbox_get_imessage_conversation(args: dict, **kwargs) -> str:
     del kwargs
     try:
@@ -706,9 +720,21 @@ SEND_IMESSAGE_SCHEMA = {
     },
 }
 
+LIST_IMESSAGE_ASSIGNMENTS_SCHEMA = {
+    "name": "inkbox_list_imessage_assignments",
+    "description": "List the people actively connected to this agent over iMessage (one row per recipient, newest first). Released connections are not returned. Use to answer who the agent can currently iMessage.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "limit": {"type": "integer", "minimum": 1, "maximum": 200, "default": 25},
+            "offset": {"type": "integer", "minimum": 0, "default": 0},
+        },
+    },
+}
+
 LIST_IMESSAGE_CONVERSATIONS_SCHEMA = {
     "name": "inkbox_list_imessage_conversations",
-    "description": "List iMessage conversation summaries for the configured Inkbox identity. Returns conversation IDs for replies plus latest-message previews and unread counts.",
+    "description": "List iMessage conversation summaries for the configured Inkbox identity. Returns conversation IDs for replies, latest-message previews, unread counts, and assignment_status (released = that person disconnected; replies fail until they reconnect).",
     "parameters": {
         "type": "object",
         "properties": {
@@ -791,6 +817,7 @@ def register_tools(ctx) -> None:
     ctx.register_tool("inkbox_mark_text_conversation_read", "inkbox", MARK_TEXT_CONVERSATION_READ_SCHEMA, inkbox_mark_text_conversation_read, check_fn=_configured)
     ctx.register_tool("inkbox_imessage_triage_number", "inkbox", IMESSAGE_TRIAGE_NUMBER_SCHEMA, inkbox_imessage_triage_number, check_fn=_configured)
     ctx.register_tool("inkbox_send_imessage", "inkbox", SEND_IMESSAGE_SCHEMA, inkbox_send_imessage, check_fn=_configured)
+    ctx.register_tool("inkbox_list_imessage_assignments", "inkbox", LIST_IMESSAGE_ASSIGNMENTS_SCHEMA, inkbox_list_imessage_assignments, check_fn=_configured)
     ctx.register_tool("inkbox_list_imessage_conversations", "inkbox", LIST_IMESSAGE_CONVERSATIONS_SCHEMA, inkbox_list_imessage_conversations, check_fn=_configured)
     ctx.register_tool("inkbox_get_imessage_conversation", "inkbox", GET_IMESSAGE_CONVERSATION_SCHEMA, inkbox_get_imessage_conversation, check_fn=_configured)
     ctx.register_tool("inkbox_send_imessage_reaction", "inkbox", SEND_IMESSAGE_REACTION_SCHEMA, inkbox_send_imessage_reaction, check_fn=_configured)

--- a/tools.py
+++ b/tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import os
 import secrets
@@ -74,6 +75,22 @@ def _call_with_key_and_options(method, key: str, options: Dict[str, Any], camel_
             return method(key, camel_options or options)
         except TypeError:
             return method(key)
+
+
+def _json_safe(value: Any) -> Any:
+    """Convert SDK dataclasses (UUIDs, datetimes, enums) into JSON-safe data."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return {
+            field.name: _json_safe(getattr(value, field.name))
+            for field in dataclasses.fields(value)
+        }
+    return str(getattr(value, "value", value))
 
 
 def _text_conversation_key(args: dict) -> Tuple[str, str, Optional[str]]:
@@ -329,6 +346,174 @@ def inkbox_mark_text_conversation_read(args: dict, **kwargs) -> str:
         return _json({"error": str(exc)})
 
 
+def inkbox_imessage_triage_number(args: dict, **kwargs) -> str:
+    del args, kwargs
+    try:
+        _cfg, client, _identity = _client_and_identity()
+        imessages = getattr(client, "imessages", None)
+        if imessages is None:
+            return _json({"error": "Installed Inkbox SDK has no iMessage support; upgrade with: pip install -U inkbox"})
+        triage = imessages.get_triage_number()
+        return _json({
+            "ok": True,
+            "number": str(getattr(triage, "number", "")),
+            "connect_command": str(getattr(triage, "connect_command", "")),
+        })
+    except Exception as exc:
+        return _json({"error": str(exc)})
+
+
+def inkbox_send_imessage(args: dict, **kwargs) -> str:
+    del kwargs
+    try:
+        _cfg, _client, identity = _client_and_identity()
+        text = str(args.get("text") or "")
+        media_urls = _normalize_recipients(args.get("mediaUrls") or args.get("media_urls"))
+        if not text and not media_urls:
+            return _json({"error": "Provide `text`, `mediaUrls`, or both."})
+        if media_urls and len(media_urls) > 1:
+            return _json({"error": "Inkbox iMessage supports at most one media URL per message."})
+
+        conversation_id = str(args.get("conversationId") or args.get("conversation_id") or "").strip()
+        to = str(args.get("to") or "").strip()
+        if bool(conversation_id) == bool(to):
+            return _json({"error": "Specify exactly one of `to` or `conversationId`."})
+
+        payload: dict[str, Any] = {"text": text or None}
+        camel_payload: dict[str, Any] = {"text": text or None}
+        if conversation_id:
+            payload["conversation_id"] = conversation_id
+            camel_payload["conversationId"] = conversation_id
+        else:
+            payload["to"] = to
+            camel_payload["to"] = to
+        if media_urls:
+            payload["media_urls"] = media_urls
+            camel_payload["mediaUrls"] = media_urls
+        send_style = str(args.get("sendStyle") or args.get("send_style") or "").strip()
+        if send_style:
+            payload["send_style"] = send_style
+            camel_payload["sendStyle"] = send_style
+
+        msg = _call_with_kwargs_or_payload(
+            _identity_method(identity, "send_imessage", "sendImessage"),
+            payload,
+            camel_payload,
+        )
+        return _json({
+            "ok": True,
+            "message_id": str(getattr(msg, "id", "")),
+            "conversation_id": _json_safe(
+                getattr(msg, "conversation_id", None) or getattr(msg, "conversationId", None)
+            ),
+            "service": _json_safe(getattr(msg, "service", None)),
+            "status": _json_safe(getattr(msg, "status", None)),
+        })
+    except Exception as exc:
+        return _json({"error": str(exc)})
+
+
+def inkbox_list_imessage_conversations(args: dict, **kwargs) -> str:
+    del kwargs
+    try:
+        _cfg, _client, identity = _client_and_identity()
+        options = {"limit": int(args.get("limit") or 25), "offset": int(args.get("offset") or 0)}
+        convos = _call_with_kwargs_or_payload(
+            _identity_method(identity, "list_imessage_conversations", "listImessageConversations"),
+            options,
+        )
+        return _json({"ok": True, "count": len(convos or []), "conversations": _json_safe(convos or [])})
+    except Exception as exc:
+        return _json({"error": str(exc)})
+
+
+def inkbox_get_imessage_conversation(args: dict, **kwargs) -> str:
+    del kwargs
+    try:
+        _cfg, _client, identity = _client_and_identity()
+        conversation_id = str(args.get("conversationId") or args.get("conversation_id") or "").strip()
+        if not conversation_id:
+            return _json({"error": "`conversationId` is required"})
+        payload = {
+            "conversation_id": conversation_id,
+            "limit": int(args.get("limit") or 50),
+            "offset": int(args.get("offset") or 0),
+        }
+        camel_payload = {
+            "conversationId": conversation_id,
+            "limit": payload["limit"],
+            "offset": payload["offset"],
+        }
+        msgs = _call_with_kwargs_or_payload(
+            _identity_method(identity, "list_imessages", "listImessages"),
+            payload,
+            camel_payload,
+        )
+        return _json({
+            "ok": True,
+            "conversation_id": conversation_id,
+            "count": len(msgs or []),
+            "messages": _json_safe(msgs or []),
+        })
+    except Exception as exc:
+        return _json({"error": str(exc)})
+
+
+def inkbox_send_imessage_reaction(args: dict, **kwargs) -> str:
+    del kwargs
+    try:
+        _cfg, _client, identity = _client_and_identity()
+        message_id = str(args.get("messageId") or args.get("message_id") or "").strip()
+        reaction = str(args.get("reaction") or "").strip().lower()
+        if not message_id:
+            return _json({"error": "`messageId` is required"})
+        if not reaction:
+            return _json({"error": "`reaction` is required"})
+        payload = {
+            "message_id": message_id,
+            "reaction": reaction,
+            "part_index": int(args.get("partIndex") or args.get("part_index") or 0),
+        }
+        camel_payload = {
+            "messageId": message_id,
+            "reaction": reaction,
+            "partIndex": payload["part_index"],
+        }
+        result = _call_with_kwargs_or_payload(
+            _identity_method(identity, "send_imessage_reaction", "sendImessageReaction"),
+            payload,
+            camel_payload,
+        )
+        return _json({"ok": True, "reaction": _json_safe(result)})
+    except Exception as exc:
+        return _json({"error": str(exc)})
+
+
+def inkbox_mark_imessage_conversation_read(args: dict, **kwargs) -> str:
+    del kwargs
+    try:
+        _cfg, _client, identity = _client_and_identity()
+        conversation_id = str(args.get("conversationId") or args.get("conversation_id") or "").strip()
+        if not conversation_id:
+            return _json({"error": "`conversationId` is required"})
+        result = _identity_method(
+            identity,
+            "mark_imessage_conversation_read",
+            "markImessageConversationRead",
+        )(conversation_id)
+        updated = (
+            getattr(result, "updated_count", None)
+            or getattr(result, "updatedCount", None)
+        )
+        return _json({
+            "ok": True,
+            "conversation_id": conversation_id,
+            "updated_count": _json_safe(updated),
+        })
+    except Exception as exc:
+        return _json({"error": str(exc)})
+
+
 def inkbox_place_call(args: dict, **kwargs) -> str:
     del kwargs
     try:
@@ -496,6 +681,87 @@ MARK_TEXT_CONVERSATION_READ_SCHEMA = {
     },
 }
 
+IMESSAGE_TRIAGE_NUMBER_SCHEMA = {
+    "name": "inkbox_imessage_triage_number",
+    "description": "Return the Inkbox iMessage router number and the connect command a person texts to it (from an iPhone) to reach this agent over iMessage. Share these when someone asks how to iMessage the agent.",
+    "parameters": {"type": "object", "properties": {}},
+}
+
+SEND_IMESSAGE_SCHEMA = {
+    "name": "inkbox_send_imessage",
+    "description": "Send an iMessage from the configured Inkbox identity. Recipient-first channel: a person must have connected via the iMessage router and messaged this agent before outbound sends work, so prefer conversationId from an inbound message or inkbox_list_imessage_conversations.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "conversationId": {"type": "string", "description": "Existing Inkbox iMessage conversation UUID. Preferred for replies. Mutually exclusive with `to`."},
+            "to": {"type": "string", "description": "Recipient phone number in E.164 format. Only works after that person has messaged this agent. Mutually exclusive with `conversationId`."},
+            "text": {"type": "string", "description": "Message body."},
+            "mediaUrls": {"type": "array", "items": {"type": "string"}, "maxItems": 1, "description": "Optional media URL (at most one per message)."},
+            "sendStyle": {
+                "type": "string",
+                "enum": ["celebration", "shooting_star", "fireworks", "lasers", "love", "confetti", "balloons", "spotlight", "echo", "invisible", "gentle", "loud", "slam"],
+                "description": "Optional expressive iMessage send style.",
+            },
+        },
+    },
+}
+
+LIST_IMESSAGE_CONVERSATIONS_SCHEMA = {
+    "name": "inkbox_list_imessage_conversations",
+    "description": "List iMessage conversation summaries for the configured Inkbox identity. Returns conversation IDs for replies plus latest-message previews and unread counts.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "limit": {"type": "integer", "minimum": 1, "maximum": 200, "default": 25},
+            "offset": {"type": "integer", "minimum": 0, "default": 0},
+        },
+    },
+}
+
+GET_IMESSAGE_CONVERSATION_SCHEMA = {
+    "name": "inkbox_get_imessage_conversation",
+    "description": "Fetch messages in one iMessage conversation, newest first. Messages include any live tapback reactions.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "conversationId": {"type": "string", "description": "Inkbox iMessage conversation UUID from inkbox_list_imessage_conversations."},
+            "limit": {"type": "integer", "minimum": 1, "maximum": 200, "default": 50},
+            "offset": {"type": "integer", "minimum": 0, "default": 0},
+        },
+        "required": ["conversationId"],
+    },
+}
+
+SEND_IMESSAGE_REACTION_SCHEMA = {
+    "name": "inkbox_send_imessage_reaction",
+    "description": "Send a tapback reaction to an iMessage the agent received.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "messageId": {"type": "string", "description": "UUID of the iMessage being reacted to."},
+            "reaction": {
+                "type": "string",
+                "enum": ["love", "like", "dislike", "laugh", "emphasize", "question"],
+                "description": "Tapback kind.",
+            },
+            "partIndex": {"type": "integer", "minimum": 0, "default": 0, "description": "Part of a multi-part message to react to."},
+        },
+        "required": ["messageId", "reaction"],
+    },
+}
+
+MARK_IMESSAGE_CONVERSATION_READ_SCHEMA = {
+    "name": "inkbox_mark_imessage_conversation_read",
+    "description": "Send a read receipt and mark every inbound message in an iMessage conversation as read.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "conversationId": {"type": "string", "description": "Inkbox iMessage conversation UUID."},
+        },
+        "required": ["conversationId"],
+    },
+}
+
 PLACE_CALL_SCHEMA = {
     "name": "inkbox_place_call",
     "description": "Place an outbound call from the configured Inkbox identity phone number. Always include purpose.",
@@ -523,4 +789,10 @@ def register_tools(ctx) -> None:
     ctx.register_tool("inkbox_get_text", "inkbox", GET_TEXT_SCHEMA, inkbox_get_text, check_fn=_configured)
     ctx.register_tool("inkbox_mark_text_read", "inkbox", MARK_TEXT_READ_SCHEMA, inkbox_mark_text_read, check_fn=_configured)
     ctx.register_tool("inkbox_mark_text_conversation_read", "inkbox", MARK_TEXT_CONVERSATION_READ_SCHEMA, inkbox_mark_text_conversation_read, check_fn=_configured)
+    ctx.register_tool("inkbox_imessage_triage_number", "inkbox", IMESSAGE_TRIAGE_NUMBER_SCHEMA, inkbox_imessage_triage_number, check_fn=_configured)
+    ctx.register_tool("inkbox_send_imessage", "inkbox", SEND_IMESSAGE_SCHEMA, inkbox_send_imessage, check_fn=_configured)
+    ctx.register_tool("inkbox_list_imessage_conversations", "inkbox", LIST_IMESSAGE_CONVERSATIONS_SCHEMA, inkbox_list_imessage_conversations, check_fn=_configured)
+    ctx.register_tool("inkbox_get_imessage_conversation", "inkbox", GET_IMESSAGE_CONVERSATION_SCHEMA, inkbox_get_imessage_conversation, check_fn=_configured)
+    ctx.register_tool("inkbox_send_imessage_reaction", "inkbox", SEND_IMESSAGE_REACTION_SCHEMA, inkbox_send_imessage_reaction, check_fn=_configured)
+    ctx.register_tool("inkbox_mark_imessage_conversation_read", "inkbox", MARK_IMESSAGE_CONVERSATION_READ_SCHEMA, inkbox_mark_imessage_conversation_read, check_fn=_configured)
     ctx.register_tool("inkbox_place_call", "inkbox", PLACE_CALL_SCHEMA, inkbox_place_call, check_fn=_configured)


### PR DESCRIPTION
## What

Adds full iMessage support to the plugin. Depends on Inkbox SDK `>=0.4.7` (iMessage surface added in inkbox-ai/inkbox#68).

iMessage works differently from SMS: the agent does not own an iMessage number. A person connects by texting the connect command (e.g. `connect @agent-handle`) to the Inkbox iMessage router, gets a dedicated thread with the agent, and the agent can only reply after they message it first (recipient-first — no cold outreach on this channel).

## Setup wizard

- New iMessage step after SMS opt-in: offers to enable iMessage on the identity — for existing agents and freshly created ones alike (enablement lives on the Inkbox identity, not local config).
- If enabled, walks the user through connecting their iPhone:
  1. Text the connect command to the iMessage router number (both fetched live).
  2. Inkbox texts back from the number assigned to the agent.
  3. Send any first message in that new thread.
- The wizard polls (3s, Ctrl+C to skip, stale traffic from prior connections filtered out) for that first inbound iMessage, then sends a welcome reply — "You're connected! This is your iMessage channel to your Hermes agent @handle…" — into the conversation and marks it read.
- On reruns it lists phones already connected through the router and defaults the connect walkthrough off when one exists.
- SDKs without the iMessage surface get an upgrade hint instead of a crash.

## Gateway adapter

- Registers the **identity-owned** iMessage webhook subscription on connect (iMessage subscriptions are owned by the agent identity, not a phone number), reusing the existing reconcile/409-repair logic. Subscribed events: `imessage.received` plus the outbound delivery lifecycle (`imessage.sent`, `imessage.delivered`, `imessage.delivery_failed`) — lifecycle transitions are logged without waking the agent, matching the text-channel split.
- Inbound iMessages route into the same contact-keyed session as email/SMS/voice, tagged `[inkbox:imessage from=… conversation_id=… | contact…]`, with media markers and the SMS fragment batcher reused (`[inkbox:imessage_burst …]`).
- `send()` gains an `imessage` mode: replies target the conversation id stashed from the last inbound (falling back to thread id or recipient number), and the modality tracker makes iMessage the default reply channel for contacts who last reached the agent there. Standalone/cron sends accept `imessage:conversation:<id>` targets.
- Server-side gates (recipient hasn't messaged yet, disconnected thread, quotas) surface as structured send errors rather than being pre-checked client-side; conversation rows expose `assignment_status` so the agent can see a released connection before retrying.

## Tools + skill

- `inkbox_imessage_triage_number` — router number + connect command, so the agent can tell people how to reach it over iMessage
- `inkbox_send_imessage`, `inkbox_list_imessage_assignments`, `inkbox_list_imessage_conversations`, `inkbox_get_imessage_conversation`, `inkbox_send_imessage_reaction`, `inkbox_mark_imessage_conversation_read`
- New bundled skill `inkbox-imessage-responder` covering the connect model, recipient-first rule, released-connection handling, and tapback etiquette.

77 tests pass (15 new across adapter routing, send-mode resolution, lifecycle handling, tools, and the wizard flow).