### PR TITLE
Per-channel prompt and skill overrides for Inkbox channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,37 @@ After the gateway starts:
 | `INKBOX_REALTIME_CONNECT_TIMEOUT_S` | no | `8` | Seconds to wait for OpenAI Realtime preflight before falling back or failing. |
 | `INKBOX_REALTIME_FALLBACK_TO_INKBOX_STT_TTS` | no | `true` | Fall back to Inkbox STT/TTS if OpenAI Realtime connect/auth fails before call accept. |
 
+## Channel Overrides
+
+Two optional blocks under the `inkbox:` platform config tailor the agent per
+channel without editing `SOUL.md` or the bundled skills. Both are keyed by
+**modality** (`email`, `sms`, `imessage`, `voice`) or by a specific **Inkbox
+contact id**, with the contact id taking precedence.
+
+- `channel_prompts` — an ephemeral system prompt injected on that channel's turns
+  (e.g. an overview the agent should lead with, or a tone instruction).
+- `channel_skill_bindings` — extra skills auto-loaded on a new session for that
+  channel. These are **merged on top of** the built-in per-channel defaults, so
+  the responder/troubleshooting skills are never dropped.
+
+```yaml
+inkbox:
+  channel_prompts:
+    imessage: "You are the Inkbox concierge. Give a one-line overview of Inkbox
+      (email, phone, and identities for AI agents) and offer a quick live demo."
+    voice: "Keep replies to one short spoken sentence."
+  channel_skill_bindings:
+    - id: imessage
+      skills: ["inkbox:inkbox-outreach-sequence"]
+    - id: voice
+      skill: "inkbox:inkbox-outbound-calling"   # single-name shorthand
+```
+
+Built-in defaults that always load (before merge): `inkbox:inkbox-troubleshooting`
+on every channel, plus `inkbox:inkbox-imessage-responder` on iMessage and
+`inkbox:inkbox-call-review` on realtime call wrap-up. Skill names use the
+qualified `inkbox:<skill>` form.
+
 ## Tools
 
 Hermes direct tools:

--- a/__init__.py
+++ b/__init__.py
@@ -110,6 +110,12 @@ def _apply_yaml_config(yaml_cfg: dict, platform_cfg: dict) -> dict | None:
             extra[target] = platform_cfg[source]
     if "realtime" in platform_cfg and "realtime" not in extra:
         extra["realtime"] = platform_cfg["realtime"]
+    # Per-channel overrides: an ephemeral system prompt and/or extra skills to
+    # auto-load, keyed by Inkbox modality or contact id. Passed straight through
+    # to config.extra so the adapter can resolve them per inbound event.
+    for passthrough in ("channel_prompts", "channel_skill_bindings"):
+        if passthrough in platform_cfg and passthrough not in extra:
+            extra[passthrough] = platform_cfg[passthrough]
     return extra or None
 
 

--- a/adapter.py
+++ b/adapter.py
@@ -2288,18 +2288,110 @@ class InkboxAdapter(BasePlatformAdapter):
             f"{f' subject={subject!r}' if subject else ''}"
             f" | {contact_block}]\n{body_text}"
         )
+        # Built-in default plus any operator-configured email overrides
+        # (system prompt and/or extra skills) for this contact.
+        channel_prompt, auto_skill = self._resolve_channel_overrides(
+            "email", chat_id, "inkbox:inkbox-troubleshooting"
+        )
         event = MessageEvent(
             text=tagged,
             message_type=MessageType.TEXT,
             source=source,
             raw_message=envelope,
             message_id=rfc_message_id or str(message.get("id") or ""),
-            # Auto-load the plugin-provided Inkbox guide on the first turn of
-            # every new session. Plugin skills use qualified names.
-            auto_skill="inkbox:inkbox-troubleshooting",
+            channel_prompt=channel_prompt,
+            auto_skill=auto_skill,
         )
         await self._enqueue(event)
         return web.Response(status=200, text="ok")
+
+    def _resolve_channel_overrides(
+        self,
+        modality: str,
+        chat_id: Any,
+        default_skills: "str | list[str] | None",
+    ) -> "tuple[Optional[str], str | list[str] | None]":
+        """Resolve the per-channel system prompt and auto-loaded skills for an event.
+
+        Operators tailor how this agent behaves on each Inkbox channel with two
+        optional ``inkbox:`` config blocks — ``channel_prompts`` (an ephemeral
+        system prompt) and ``channel_skill_bindings`` (extra skills to load on a
+        new session). Both are keyed by either a modality or a specific Inkbox
+        contact id, contact id winning. Configured skills are merged on top of
+        the channel's built-in defaults so a binding never drops them.
+
+        Args:
+            modality (str): Inkbox channel for this event — ``email``, ``sms``,
+                ``imessage``, or ``voice``. The broad lookup key.
+            chat_id (Any): Inkbox contact id (or raw address) for this event.
+                The fine-grained lookup key, preferred over the modality.
+            default_skills (str | list[str] | None): Skills the channel always
+                auto-loads, before operator overrides are merged in.
+
+        Returns:
+            tuple[Optional[str], str | list[str] | None]: The resolved channel
+                prompt (or ``None``) and the merged ``auto_skill`` value.
+        """
+        config = getattr(self, "config", None)
+        extra = getattr(config, "extra", None) or {}
+        contact_key = str(chat_id or "")
+        prompt = self._lookup_channel_prompt(extra, contact_key, modality)
+        configured = self._lookup_channel_skills(extra, contact_key, modality)
+        return prompt, self._merge_auto_skills(default_skills, configured)
+
+    @staticmethod
+    def _lookup_channel_prompt(
+        extra: Dict[str, Any], contact_key: str, modality: str
+    ) -> Optional[str]:
+        """Return the operator channel prompt for this contact/modality, else None."""
+        prompts = extra.get("channel_prompts")
+        if not isinstance(prompts, dict):
+            return None
+        # Contact-specific prompt wins over the modality-wide default.
+        for key in (contact_key, modality):
+            if not key:
+                continue
+            value = prompts.get(key)
+            if value is None:
+                continue
+            value = str(value).strip()
+            if value:
+                return value
+        return None
+
+    @staticmethod
+    def _lookup_channel_skills(
+        extra: Dict[str, Any], contact_key: str, modality: str
+    ) -> "str | list[str] | None":
+        """Return operator-bound skills for this contact/modality, else None."""
+        bindings = extra.get("channel_skill_bindings")
+        if not isinstance(bindings, list):
+            return None
+        # Contact-specific binding wins over the modality-wide one.
+        for key in (contact_key, modality):
+            if not key:
+                continue
+            for entry in bindings:
+                if not isinstance(entry, dict) or str(entry.get("id") or "") != key:
+                    continue
+                skills = entry.get("skills")
+                if skills is None:
+                    skills = entry.get("skill")  # single-name shorthand
+                if skills:
+                    return skills
+        return None
+
+    @staticmethod
+    def _merge_auto_skills(default, configured):
+        """Union built-in defaults with configured skills, defaults first, deduped."""
+        merged: list = []
+        for group in (default, configured):
+            if not group:
+                continue
+            for name in [group] if isinstance(group, str) else group:
+                if name and name not in merged:
+                    merged.append(name)
+        return merged or None
 
     def _sms_text_batch_key(self, event: MessageEvent) -> str:
         from gateway.session import build_session_key
@@ -2404,13 +2496,21 @@ class InkboxAdapter(BasePlatformAdapter):
             else:
                 conversation_part = f" conversation_id={conversation_id}" if conversation_id else ""
                 text = f"[inkbox:sms from={remote}{conversation_part} | {contact_block}]\n{body}"
+        default_skills = (
+            "inkbox:inkbox-troubleshooting"
+            if message_type == MessageType.TEXT else None
+        )
+        channel_prompt, auto_skill = self._resolve_channel_overrides(
+            "sms", chat_id, default_skills
+        )
         return MessageEvent(
             text=text,
             message_type=message_type,
             source=source,
             raw_message=envelope,
             message_id=text_id,
-            auto_skill="inkbox:inkbox-troubleshooting" if message_type == MessageType.TEXT else None,
+            channel_prompt=channel_prompt,
+            auto_skill=auto_skill,
             timestamp=timestamp,
             media_urls=list(media_urls or []),
             media_types=list(media_types or []),
@@ -2730,19 +2830,23 @@ class InkboxAdapter(BasePlatformAdapter):
                 f" conversation_id={conversation_id}" if conversation_id else ""
             )
             text = f"[inkbox:imessage from={remote}{conversation_part} | {contact_block}]\n{body}"
+        # iMessage always carries the responder playbook alongside the general
+        # guide; operator overrides for this channel layer on top.
+        default_skills = (
+            ["inkbox:inkbox-troubleshooting", "inkbox:inkbox-imessage-responder"]
+            if message_type == MessageType.TEXT else None
+        )
+        channel_prompt, auto_skill = self._resolve_channel_overrides(
+            "imessage", chat_id, default_skills
+        )
         return MessageEvent(
             text=text,
             message_type=message_type,
             source=source,
             raw_message=envelope,
             message_id=message_id,
-            # Attach the iMessage-specific responder alongside the general
-            # Inkbox guide so the agent has the tapback/typing playbook for
-            # this channel on the first turn.
-            auto_skill=(
-                ["inkbox:inkbox-troubleshooting", "inkbox:inkbox-imessage-responder"]
-                if message_type == MessageType.TEXT else None
-            ),
+            channel_prompt=channel_prompt,
+            auto_skill=auto_skill,
             timestamp=timestamp,
             media_urls=list(media_urls or []),
             media_types=list(media_types or []),
@@ -3033,16 +3137,19 @@ class InkboxAdapter(BasePlatformAdapter):
             thread_id=f"imessage:{conversation_id}" if conversation_id else None,
             message_id=target_message_id or reaction_id,
         )
+        channel_prompt, auto_skill = self._resolve_channel_overrides(
+            "imessage",
+            chat_id,
+            ["inkbox:inkbox-troubleshooting", "inkbox:inkbox-imessage-responder"],
+        )
         event = MessageEvent(
             text=text,
             message_type=MessageType.TEXT,
             source=source,
             raw_message=envelope,
             message_id=reaction_id or target_message_id,
-            auto_skill=[
-                "inkbox:inkbox-troubleshooting",
-                "inkbox:inkbox-imessage-responder",
-            ],
+            channel_prompt=channel_prompt,
+            auto_skill=auto_skill,
             timestamp=timestamp,
         )
         # A "question" tapback usually expects a reply, so show the typing
@@ -3441,13 +3548,17 @@ class InkboxAdapter(BasePlatformAdapter):
                 chat_topic="voice_call",
                 message_id=f"call:{call_id}:opening",
             )
+            channel_prompt, auto_skill = self._resolve_channel_overrides(
+                "voice", contact_id, "inkbox:inkbox-troubleshooting"
+            )
             event = MessageEvent(
                 text=tagged,
                 message_type=MessageType.TEXT,
                 source=source,
                 raw_message={"synthetic": "outbound_call_opening"},
                 message_id=f"call:{call_id}:opening",
-                auto_skill="inkbox:inkbox-troubleshooting",
+                channel_prompt=channel_prompt,
+                auto_skill=auto_skill,
             )
             try:
                 await self._enqueue(event)
@@ -3517,13 +3628,17 @@ class InkboxAdapter(BasePlatformAdapter):
                         f"[inkbox:voice_call call_id={call_id} | {contact_block}]\n"
                         f"{purpose_block}{text}"
                     )
+                    channel_prompt, auto_skill = self._resolve_channel_overrides(
+                        "voice", contact_id, "inkbox:inkbox-troubleshooting"
+                    )
                     event = MessageEvent(
                         text=tagged,
                         message_type=MessageType.TEXT,
                         source=source,
                         raw_message=payload,
                         message_id=f"call:{call_id}:{payload.get('turn_id') or ''}",
-                        auto_skill="inkbox:inkbox-troubleshooting",
+                        channel_prompt=channel_prompt,
+                        auto_skill=auto_skill,
                     )
                     await self._enqueue(event)
                 elif ev == "stop":
@@ -3583,13 +3698,17 @@ class InkboxAdapter(BasePlatformAdapter):
                     chat_topic="voice_call",
                     message_id=f"call:{call_id}:ended",
                 )
+                channel_prompt, auto_skill = self._resolve_channel_overrides(
+                    "voice", contact_id, "inkbox:inkbox-troubleshooting"
+                )
                 event = MessageEvent(
                     text=tagged,
                     message_type=MessageType.TEXT,
                     source=source,
                     raw_message={"synthetic": "call_ended"},
                     message_id=f"call:{call_id}:ended",
-                    auto_skill="inkbox:inkbox-troubleshooting",
+                    channel_prompt=channel_prompt,
+                    auto_skill=auto_skill,
                 )
                 await self._enqueue(event)
                 logger.info(
@@ -3748,6 +3867,9 @@ class InkboxAdapter(BasePlatformAdapter):
             chat_topic="voice_call",
             message_id=f"call:{meta.call_id}:ended",
         )
+        channel_prompt, auto_skill = self._resolve_channel_overrides(
+            "voice", meta.contact_id, "inkbox:inkbox-call-review"
+        )
         event = MessageEvent(
             text=body,
             message_type=MessageType.TEXT,
@@ -3755,7 +3877,8 @@ class InkboxAdapter(BasePlatformAdapter):
             raw_message={"event": "realtime_call_ended", "transcript": transcript},
             message_id=f"call:{meta.call_id}:ended",
             reply_to_message_id=meta.call_id,
-            auto_skill="inkbox:inkbox-call-review",
+            channel_prompt=channel_prompt,
+            auto_skill=auto_skill,
         )
         try:
             await self._enqueue(event)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,8 @@ if "gateway.config" not in sys.modules:
         media_urls: list[str] = field(default_factory=list)
         media_types: list[str] = field(default_factory=list)
         metadata: dict[str, Any] = field(default_factory=dict)
-        auto_skill: str | None = None
+        auto_skill: "str | list[str] | None" = None
+        channel_prompt: str | None = None
         source: Any = None
         raw_message: dict[str, Any] | None = None
         reply_to_message_id: str | None = None

--- a/tests/test_channel_overrides.py
+++ b/tests/test_channel_overrides.py
@@ -1,0 +1,126 @@
+"""Tests for per-channel prompt + skill overrides on the Inkbox adapter."""
+
+import sys
+import types
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("inkbox_plugin")
+pkg.__path__ = [str(ROOT)]
+sys.modules.setdefault("inkbox_plugin", pkg)
+
+from inkbox_plugin.adapter import InkboxAdapter
+
+
+def _adapter(extra):
+    """Build a config-only adapter shell for exercising the resolver helpers."""
+    adapter = object.__new__(InkboxAdapter)
+    adapter.config = types.SimpleNamespace(extra=extra)
+    return adapter
+
+
+# ── _merge_auto_skills ──────────────────────────────────────────────────────
+
+
+def test_merge_defaults_only_normalizes_to_list():
+    assert InkboxAdapter._merge_auto_skills("inkbox:inkbox-troubleshooting", None) == [
+        "inkbox:inkbox-troubleshooting"
+    ]
+
+
+def test_merge_unions_defaults_and_configured_deduped_defaults_first():
+    merged = InkboxAdapter._merge_auto_skills(
+        ["inkbox:inkbox-troubleshooting", "inkbox:inkbox-imessage-responder"],
+        ["inkbox:inkbox-imessage-responder", "inkbox:inkbox-outreach-sequence"],
+    )
+    assert merged == [
+        "inkbox:inkbox-troubleshooting",
+        "inkbox:inkbox-imessage-responder",
+        "inkbox:inkbox-outreach-sequence",
+    ]
+
+
+def test_merge_all_empty_is_none():
+    assert InkboxAdapter._merge_auto_skills(None, None) is None
+
+
+# ── resolve: no config ──────────────────────────────────────────────────────
+
+
+def test_no_overrides_returns_defaults_only():
+    adapter = _adapter({})
+    prompt, skills = adapter._resolve_channel_overrides(
+        "imessage", "contact_1", "inkbox:inkbox-troubleshooting"
+    )
+    assert prompt is None
+    assert skills == ["inkbox:inkbox-troubleshooting"]
+
+
+# ── resolve: channel_prompts ────────────────────────────────────────────────
+
+
+def test_modality_prompt_applies_to_channel():
+    adapter = _adapter({"channel_prompts": {"imessage": "Inkbox iMessage concierge."}})
+    prompt, _ = adapter._resolve_channel_overrides("imessage", "contact_1", None)
+    assert prompt == "Inkbox iMessage concierge."
+
+
+def test_contact_prompt_wins_over_modality_prompt():
+    adapter = _adapter(
+        {
+            "channel_prompts": {
+                "imessage": "Inkbox iMessage concierge.",
+                "contact_1": "VIP Inkbox contact handling.",
+            }
+        }
+    )
+    prompt, _ = adapter._resolve_channel_overrides("imessage", "contact_1", None)
+    assert prompt == "VIP Inkbox contact handling."
+
+
+def test_blank_prompt_is_ignored():
+    adapter = _adapter({"channel_prompts": {"sms": "   "}})
+    prompt, _ = adapter._resolve_channel_overrides("sms", "contact_1", None)
+    assert prompt is None
+
+
+# ── resolve: channel_skill_bindings ─────────────────────────────────────────
+
+
+def test_configured_skills_merge_with_defaults():
+    adapter = _adapter(
+        {
+            "channel_skill_bindings": [
+                {"id": "imessage", "skills": ["inkbox:inkbox-outreach-sequence"]}
+            ]
+        }
+    )
+    _, skills = adapter._resolve_channel_overrides(
+        "imessage", "contact_1", "inkbox:inkbox-imessage-responder"
+    )
+    assert skills == [
+        "inkbox:inkbox-imessage-responder",
+        "inkbox:inkbox-outreach-sequence",
+    ]
+
+
+def test_single_skill_shorthand_accepted():
+    adapter = _adapter(
+        {"channel_skill_bindings": [{"id": "sms", "skill": "inkbox:inkbox-sms-responder"}]}
+    )
+    _, skills = adapter._resolve_channel_overrides("sms", "contact_1", None)
+    assert skills == ["inkbox:inkbox-sms-responder"]
+
+
+def test_contact_binding_wins_over_modality_binding():
+    adapter = _adapter(
+        {
+            "channel_skill_bindings": [
+                {"id": "voice", "skills": ["inkbox:inkbox-call-review"]},
+                {"id": "contact_1", "skills": ["inkbox:inkbox-outbound-calling"]},
+            ]
+        }
+    )
+    _, skills = adapter._resolve_channel_overrides("voice", "contact_1", None)
+    assert skills == ["inkbox:inkbox-outbound-calling"]

--- a/tests/test_realtime_bridge_parity.py
+++ b/tests/test_realtime_bridge_parity.py
@@ -694,7 +694,8 @@ def test_adapter_realtime_call_ended_enqueues_reflection():
     assert "[call_ended]" in events[0].text
     assert "Can you email me after this call?" in events[0].text
     assert events[0].raw_message["event"] == "realtime_call_ended"
-    assert events[0].auto_skill == "inkbox:inkbox-call-review"
+    # Channel-override resolution normalizes auto_skill to a deduped list.
+    assert events[0].auto_skill == ["inkbox:inkbox-call-review"]
 
 
 def test_adapter_realtime_post_call_actions_enqueues_without_auto_skill():


### PR DESCRIPTION
## What

Adds two optional `inkbox:` config blocks so operators can tailor the agent per channel without editing `SOUL.md` or the bundled skills:

- **`channel_prompts`** — an ephemeral system prompt injected on a channel's turns (e.g. a product overview the agent should lead with, or a tone instruction).
- **`channel_skill_bindings`** — extra skills auto-loaded on a new session, **merged on top of** the built-in per-channel defaults, so the responder/troubleshooting skills are never dropped.

Both resolve by **modality** (`email`/`sms`/`imessage`/`voice`) or by a specific **Inkbox contact id**, with the contact id winning.

## How

- New `_resolve_channel_overrides` + small lookup/merge helpers in `adapter.py`; all inbound `MessageEvent` sites (email, SMS, iMessage, iMessage reactions, and the four voice/call paths) route through it.
- `_apply_yaml_config` passes `channel_prompts` / `channel_skill_bindings` through into `config.extra`.
- `auto_skill` is normalized to a deduped list (the host treats a bare string and a list identically).

## Compatibility

With neither block configured, every channel behaves exactly as before. Resolution logic is self-contained in the plugin and relies only on the host's existing `MessageEvent.channel_prompt` / `auto_skill` fields and gateway consumption.

## Example

```yaml
inkbox:
  channel_prompts:
    imessage: "You are the Inkbox concierge. Lead with a one-line overview of Inkbox (email, phone, and identities for AI agents) and offer a quick live demo."
  channel_skill_bindings:
    - id: imessage
      skills: ["inkbox:inkbox-outreach-sequence"]
```