### PR TITLE
fix(realtime): end calls with stop event, not hangup

### DIFF
--- a/realtime.py
+++ b/realtime.py
@@ -1165,11 +1165,12 @@ async def _dispatch_tool_call(
 
         # Second attempt within the window → perform the real hangup.
         reason = (args.get("reason") or "").strip()
-        hangup_frame: Dict[str, Any] = {"event": "hangup"}
+        # Inkbox ends the call on a `stop` event; `hangup` is ignored server-side.
+        stop_frame: Dict[str, Any] = {"event": "stop"}
         if reason:
-            hangup_frame["reason"] = reason
+            stop_frame["reason"] = reason
         if state.stream_id:
-            hangup_frame["stream_id"] = state.stream_id
+            stop_frame["stream_id"] = state.stream_id
 
         await _submit_tool_result(
             openai_ws,
@@ -1183,7 +1184,7 @@ async def _dispatch_tool_call(
         )
         try:
             await asyncio.sleep(HANGUP_CLOSE_DELAY_S)
-            await inkbox_ws.send_str(json.dumps(hangup_frame))
+            await inkbox_ws.send_str(json.dumps(stop_frame))
         except Exception as exc:
             logger.debug("[Inkbox realtime] hangup frame send failed: %s", exc)
         state.closed = True

--- a/tests/test_realtime_bridge_parity.py
+++ b/tests/test_realtime_bridge_parity.py
@@ -527,7 +527,7 @@ def test_hangup_second_call_sleeps_then_sends_frame_and_closes_sockets(monkeypat
     assert len(tool_results) == 2
     assert json.loads(tool_results[-1]["item"]["output"])["status"] == "hangup_requested"
     assert inkbox_ws.sent == [{
-        "event": "hangup",
+        "event": "stop",
         "reason": "caller said goodbye",
         "stream_id": "stream-123",
     }]


### PR DESCRIPTION
The realtime voice bridge sent `{"event":"hangup"}` to end a call, but Inkbox only releases the carrier leg on a `stop` event (it sets `hangup_reason=local` and fires `CLIENT_HANGUP`). A `hangup` event is ignored server-side, so the agent went silent while the call stayed connected.

Switches the hangup path to send `{"event":"stop"}` (still carrying `reason`/`stream_id`) and updates the bridge tests to match.

Part of a 4-repo sweep fixing the same bug across the Inkbox realtime harnesses (claude-code-plugin, codex-plugin, hermes-agent-plugin, openclaw-plugin).