### PR TITLE
live: cross-channel voice — "call me" places a real call

### DIFF
--- a/.github/workflows/live-channels.yml
+++ b/.github/workflows/live-channels.yml
@@ -4,12 +4,15 @@ name: Live — agent channels (email + SMS)
 # remote Inkbox identity emails it and waits for a reply. Two matrix legs:
 #   mock — deterministic mock model; proves the pipe (no token spend).
 #   real — real OpenAI key; proves the agent actually reasons (spends tokens).
-# Runs on every PR into main AND on the 2x/day schedule; the repo-wide tunnel lock
-# below serializes them all. Ephemeral runner: gateway + mock torn down on job end.
+# This suite is expensive (real gateway + tunnel + OpenAI tokens), so on PRs it runs
+# only once the PR is READY (non-draft) — the job `if` gates on draft==false, and
+# `ready_for_review` makes flipping a draft to ready fire it. Also runs on the 2x/day
+# schedule; the repo-wide tunnel lock below serializes them all. Ephemeral runner:
+# gateway + mock torn down on job end.
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       timeout_s:
@@ -34,13 +37,14 @@ concurrency:
 jobs:
   live:
     runs-on: ubuntu-latest
-    # Two guards:
+    # Three guards:
     #  - Skip fork PRs: a public repo doesn't expose secrets to forks → can't auth.
+    #  - Skip DRAFT PRs: this suite is expensive — only spend on ready-for-review PRs.
     #  - When chained off the canary, only run if that canary PASSED. Never take the
     #    tunnel or burn tokens against a host we already know is broken.
-    # Same-repo PRs + dispatch + a green canary all run (and queue on the lock above).
+    # Ready same-repo PRs + dispatch + a green canary all run (and queue on the lock).
     if: >-
-      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
+      (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false)) &&
       (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,9 +11,9 @@ permissions:
 
 jobs:
   # Offline unit suite + lint. No Hermes host installed → conftest stubs gateway.*
-  # and the contract tests auto-skip. Fast signal on our own code.
+  # and the contract tests auto-skip. Fast signal on our own code — cheap enough to
+  # run on every push, including draft PRs (the heavy live suite is what we gate).
   unit:
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -49,7 +49,6 @@ jobs:
   # symbol, a dropped MessageEvent/SendResult field) before it reaches a user.
   # Same suite the canary runs on a schedule; this is the per-PR gate version.
   contract-pr:
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:

--- a/tests/live/test_cross_channel.py
+++ b/tests/live/test_cross_channel.py
@@ -8,7 +8,15 @@ the request.
   * email -> SMS : email asks for a text; we poll SMS for the token.
   * SMS  -> email: SMS asks for an email; we poll email for the token.
 
-More channels (iMessage, voice) get added here. Real-model only.
+Voice is the odd one out: an unanswered call carries no token, so instead of
+matching content we assert that a *new inbound call from the AUT's number* lands
+on the driver's number within the window — proof the request reasoned its way to
+``inkbox_place_call`` and Inkbox actually dialed the driver.
+
+  * email -> call: email asks the agent to call; we poll the driver's calls.
+  * SMS   -> call: SMS asks the agent to call; we poll the driver's calls.
+
+More channels (iMessage) get added here. Real-model only.
 """
 
 from __future__ import annotations
@@ -143,3 +151,46 @@ def test_sms_request_gets_email_response(xc):
                 return  # cross-channel confirmed: SMS request -> email response with the token
         time.sleep(POLL_EVERY_S)
     pytest.fail(f"agent did not send an email containing {token!r} within {TIMEOUT_S:.0f}s")
+
+
+def _inbound_calls_from_aut(remote, remote_pid: str, aut_phone: str):
+    """The driver's inbound calls originating from the AUT's number."""
+    tail = _digits(aut_phone)[-10:]
+    return [c for c in remote.calls.list(remote_pid, limit=30)
+            if (getattr(c, "direction", "") or "").lower() == "inbound"
+            and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == tail]
+
+
+def _wait_for_new_call(remote, remote_pid: str, aut_phone: str, before: set):
+    """Block until an inbound call from the AUT with an id not in ``before`` appears.
+
+    ``before`` is the pre-request snapshot, so a stale call can't satisfy the
+    assertion — same new-id correlation the SMS/email legs use. Fails on timeout.
+    """
+    deadline = time.monotonic() + TIMEOUT_S
+    while time.monotonic() < deadline:
+        for c in _inbound_calls_from_aut(remote, remote_pid, aut_phone):
+            if c.id not in before:
+                return  # a fresh call from the AUT landed on the driver's number
+        time.sleep(POLL_EVERY_S)
+    pytest.fail(f"agent did not place a call to the driver within {TIMEOUT_S:.0f}s")
+
+
+def test_email_request_gets_call(xc):
+    """Email asks the agent to CALL; a new inbound call must land on the driver."""
+    remote, remote_pid, aut_phone = xc["remote"], xc["remote_pid"], xc["aut_phone"]
+    # Snapshot BEFORE sending so a pre-existing call can't be mistaken for the reply.
+    before = {c.id for c in _inbound_calls_from_aut(remote, remote_pid, aut_phone)}
+    remote.messages.send(
+        xc["remote_email"], to=[xc["aut_email"]], subject="please call me",
+        body_text="Please place a phone call to my number now — I'd rather talk than type.",
+    )
+    _wait_for_new_call(remote, remote_pid, aut_phone, before)
+
+
+def test_sms_request_gets_call(xc):
+    """SMS asks the agent to CALL; a new inbound call must land on the driver."""
+    remote, remote_pid, aut_phone = xc["remote"], xc["remote_pid"], xc["aut_phone"]
+    before = {c.id for c in _inbound_calls_from_aut(remote, remote_pid, aut_phone)}
+    remote.texts.send(remote_pid, to=aut_phone, text="Call me please — give me a ring now.")
+    _wait_for_new_call(remote, remote_pid, aut_phone, before)


### PR DESCRIPTION
Extends the live cross-channel suite (set up in #21) with the voice channel: if the agent is **emailed** or **texted** "call me", does it actually place a call?

## What's added
Two real-model scenarios in `tests/live/test_cross_channel.py`:

| Request | Expect | Observed how |
|---|---|---|
| email "please call me" | agent calls the driver's number | poll the driver's `calls.list` for a new inbound call from the AUT |
| SMS "call me please" | agent calls the driver's number | same |

## How it works
- Voice is the odd channel out — an unanswered call carries no token, so we can't match on content like the email↔SMS legs do. Instead we correlate by **new-call id from the AUT's number**: snapshot the driver's inbound calls before the request, then wait for one we hadn't seen. Same robustness the SMS/email legs already use.
- The driver just polls `calls.list` on its own number — no answering side, no gateway needed on the driver. It proves the full chain: agent reasons → `inkbox_place_call` → Inkbox dials the driver.
- Both tests are gated `real`-only (need the OpenAI model to reason their way to the call tool), behind the existing `REMOTE_INKBOX_API_KEY` + `HERMES_INKBOX_API_KEY` skip guard. No new secrets, no workflow changes — they ride the existing `live-channels.yml` real leg.

Picks up the `place_call` coverage that was parked in the original CI plan (decision #9).