### PR TITLE
ci: only ping Google Chat on failed scheduled runs

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -34,11 +34,12 @@ jobs:
       - name: Contract tests vs real Hermes main
         run: uv run pytest tests/contract -v
 
-      # One message at run end, pass or fail (job.status reflects the contract step).
-      # Non-blocking (--retry + || true) so a flaky webhook can't flip the result.
-      - name: Notify Google Chat (canary result)
-        if: always()
+      # Alert only when an unattended (scheduled) run fails — no success pings,
+      # and manual dispatch stays silent (you're watching it). Non-blocking
+      # (--retry + || true) so a flaky webhook can't flip the result.
+      - name: Notify Google Chat on scheduled failure
+        if: failure() && github.event_name == 'schedule'
         run: |
           curl -sS --max-time 10 --retry 3 -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
             -H 'Content-Type: application/json' \
-            -d '{"text": "${{ job.status == 'success' && '✅ *PASSED*' || '🔴 *FAILED*' }} — Canary: contract suite vs Hermes `main`\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}' || true
+            -d '{"text": "⚠️ *FAILED* — Canary: contract suite vs Hermes `main`\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}' || true

--- a/.github/workflows/live-channels.yml
+++ b/.github/workflows/live-channels.yml
@@ -186,16 +186,20 @@ jobs:
             ${{ runner.temp }}/mock.log
           if-no-files-found: ignore
 
-  # One Chat message for the whole suite (needs.live.result is 'success' only if every
-  # matrix leg passed). Unattended runs only — on a PR the check is visible inline.
+  # Alert only when an unattended run fails — no success pings; PRs + manual
+  # dispatch stay silent (the check is visible inline there). This suite has no
+  # direct `schedule` trigger; its unattended cadence arrives as a `workflow_run`
+  # chained off the scheduled canary, so that event is the "scheduled failure"
+  # trigger here. `always()` lets this job run despite the failed `live`
+  # dependency; needs.live.result is 'failure' if any matrix leg failed.
   notify:
     needs: [live]
-    if: always() && needs.live.result != 'skipped' && github.event_name != 'pull_request'
+    if: always() && needs.live.result == 'failure' && github.event_name == 'workflow_run'
     runs-on: ubuntu-latest
     steps:
-      - name: Notify Google Chat (live suite result)
+      - name: Notify Google Chat on scheduled failure
         # Non-blocking: a flaky webhook must never flip the suite result.
         run: |
           curl -sS --max-time 10 --retry 3 -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
             -H 'Content-Type: application/json' \
-            -d '{"text": "${{ needs.live.result == 'success' && '✅ *PASSED*' || '🔴 *FAILED*' }} — Live channels (email + SMS) suite\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}' || true
+            -d '{"text": "⚠️ *FAILED* — Live channels (email + SMS) suite\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}' || true


### PR DESCRIPTION
The canary and live-channels suites posted a Google Chat message on **every** unattended run — pass or fail — which is noise. This switches both to alert **only when an unattended run fails**: never on success, and silent on PR + manual dispatch (the check is already visible inline there).

- **canary.yml** — `if: failure() && github.event_name == 'schedule'`.
- **live-channels.yml** — this suite has no direct `schedule` trigger; its unattended cadence arrives as a `workflow_run` chained off the scheduled canary, so the notify job is gated on `needs.live.result == 'failure' && github.event_name == 'workflow_run'`. `always()` keeps the job eligible despite the failed `live` dependency.

No behavior change to the test jobs themselves — only when/whether the Chat webhook fires.