### PR TITLE
Live voice-call tests: inbound Inkbox STT/TTS + outbound realtime

### DIFF
--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -1,0 +1,163 @@
+name: Live — voice calls (Inkbox TTS/STT + realtime)
+
+# Boots the agent-under-test (AUT) gateway plus a driver process that bridges the
+# other side of a real phone call over its own Inkbox tunnel. Two matrix legs:
+#   inbound_inkbox    — driver calls the agent; agent answers with Inkbox STT/TTS.
+#   outbound_realtime — driver texts "call me"; agent calls back via the realtime API.
+# Each leg verifies the stored call transcript shows the agent spoke to the caller.
+# Real model + real calls, so this runs only on ready (non-draft) PRs + dispatch, and
+# shares the AUT tunnel lock with the other live suites. During development it also
+# runs on pushes to its feature branch.
+on:
+  push:
+    branches: [feat/live-voice-calls]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      timeout_s:
+        description: "Seconds to wait for the call/transcript"
+        default: "220"
+
+permissions:
+  contents: read
+
+concurrency:
+  # Same group as the other live suites: only one holder of the AUT tunnel at a time.
+  group: inkbox-live-aut-tunnel
+  cancel-in-progress: false
+
+jobs:
+  voice:
+    runs-on: ubuntu-latest
+    # Skip fork PRs (no secrets) and draft PRs (expensive). Pushes + dispatch always run.
+    if: >-
+      (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false))
+    strategy:
+      fail-fast: false
+      max-parallel: 1          # legs share the AUT identity → one at a time
+      matrix:
+        scenario: [inbound_inkbox, outbound_realtime]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up env paths
+        run: |
+          echo "HERMES_HOME=$GITHUB_WORKSPACE/.hermes" >> "$GITHUB_ENV"
+          echo "GATEWAY_LOG=$RUNNER_TEMP/gateway.log" >> "$GITHUB_ENV"
+          echo "DRIVER_LOG=$RUNNER_TEMP/driver.log" >> "$GITHUB_ENV"
+          echo "DRIVER_STATE=$RUNNER_TEMP/driver_state.json" >> "$GITHUB_ENV"
+
+      - name: Install Hermes (non-interactive)
+        run: |
+          curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- --non-interactive
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install plugin into the gateway
+        run: |
+          mkdir -p "$HERMES_HOME/plugins"
+          ln -sfn "$GITHUB_WORKSPACE" "$HERMES_HOME/plugins/inkbox"
+          hermes plugins enable inkbox
+          "$HERMES_HOME/bin/uv" pip install --python "$HERMES_HOME/hermes-agent/venv/bin/python3" \
+            'inkbox>=0.4.7' 'aiohttp>=3.9' 'segno>=1.5' fastapi uvicorn
+
+      - name: Configure AUT identity + model + speech path (${{ matrix.scenario }})
+        env:
+          HERMES_INKBOX_API_KEY: ${{ secrets.HERMES_INKBOX_API_KEY }}
+          HERMES_INKBOX_SIGNING_KEY: ${{ secrets.HERMES_INKBOX_SIGNING_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          PY="$HERMES_HOME/hermes-agent/venv/bin/python3"
+          HANDLE="$("$PY" - <<'PYEOF'
+          import os
+          from inkbox import Inkbox
+          c = Inkbox(api_key=os.environ["HERMES_INKBOX_API_KEY"], base_url=os.environ.get("INKBOX_BASE_URL", "https://inkbox.ai"))
+          print(c.mailboxes.list()[0].email_address.split("@", 1)[0])
+          PYEOF
+          )"
+          echo "AUT handle: $HANDLE"
+          {
+            echo "INKBOX_API_KEY=$HERMES_INKBOX_API_KEY"
+            echo "INKBOX_IDENTITY=$HANDLE"
+            echo "INKBOX_SIGNING_KEY=$HERMES_INKBOX_SIGNING_KEY"
+            echo "INKBOX_ALLOW_ALL_USERS=true"
+            echo "OPENAI_API_KEY=$OPENAI_API_KEY"
+            echo "OPENAI_BASE_URL=https://api.openai.com/v1"
+          } >> "$HERMES_HOME/.env"
+          # The agent's reasoning (deciding to place a call, composing replies) uses
+          # the chat model; send it straight to OpenAI as-is.
+          hermes config set model.provider custom || true
+          hermes config set model.base_url https://api.openai.com/v1 || true
+          hermes config set model.default gpt-5.5 || true
+          if [ "${{ matrix.scenario }}" = "outbound_realtime" ]; then
+            echo "INKBOX_REALTIME_ENABLED=true" >> "$HERMES_HOME/.env"
+          else
+            echo "INKBOX_REALTIME_ENABLED=false" >> "$HERMES_HOME/.env"
+          fi
+
+      - name: Start gateway and wait for readiness
+        run: |
+          hermes gateway run > "$GATEWAY_LOG" 2>&1 &
+          echo $! > "$RUNNER_TEMP/gateway.pid"
+          echo "Waiting for the gateway (tunnel + webhooks)…"
+          for i in $(seq 1 36); do
+            if hermes inkbox doctor 2>/dev/null | grep -q '"ok": true'; then
+              echo "Gateway ready."; exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::gateway did not become ready"; cat "$GATEWAY_LOG"; exit 1
+
+      - name: Start voice driver and wait for its tunnel
+        env:
+          REMOTE_INKBOX_API_KEY: ${{ secrets.REMOTE_INKBOX_API_KEY }}
+        run: |
+          PY="$HERMES_HOME/hermes-agent/venv/bin/python3"
+          VOICE_DRIVER_STATE="$DRIVER_STATE" VOICE_DRIVER_PORT=8090 \
+            "$PY" "$GITHUB_WORKSPACE/tests/live/voice_driver.py" > "$DRIVER_LOG" 2>&1 &
+          echo $! > "$RUNNER_TEMP/driver.pid"
+          for i in $(seq 1 30); do      # up to ~90s
+            if [ -s "$DRIVER_STATE" ]; then echo "driver ready:"; cat "$DRIVER_STATE"; exit 0; fi
+            sleep 3
+          done
+          echo "::error::driver did not become ready"; cat "$DRIVER_LOG"; exit 1
+
+      - name: Run voice test (${{ matrix.scenario }})
+        env:
+          REMOTE_INKBOX_API_KEY: ${{ secrets.REMOTE_INKBOX_API_KEY }}
+          HERMES_INKBOX_API_KEY: ${{ secrets.HERMES_INKBOX_API_KEY }}
+          VOICE_SCENARIO: ${{ matrix.scenario }}
+          LIVE_VOICE_TIMEOUT: ${{ github.event.inputs.timeout_s || '220' }}
+        run: |
+          PY="$HERMES_HOME/hermes-agent/venv/bin/python3"
+          "$HERMES_HOME/bin/uv" pip install --python "$PY" pytest
+          LIVE_REAL_MODEL=1 VOICE_DRIVER_STATE="$DRIVER_STATE" \
+            "$PY" -m pytest tests/live/test_voice.py -v
+
+      # Failure-only: these logs carry live call content and this repo is public.
+      - name: Dump logs (on failure only)
+        if: failure()
+        run: |
+          echo "=== gateway.log ==="; cat "$GATEWAY_LOG" || true
+          echo "=== driver.log ==="; cat "$DRIVER_LOG" || true
+          echo "=== ~/.hermes/logs ==="; tail -n 200 "$HERMES_HOME"/logs/* 2>/dev/null || true
+
+      - name: Tear down (always)
+        if: always()
+        run: |
+          kill "$(cat "$RUNNER_TEMP/driver.pid" 2>/dev/null)" 2>/dev/null || true
+          kill "$(cat "$RUNNER_TEMP/gateway.pid" 2>/dev/null)" 2>/dev/null || true
+          sleep 3   # let the driver revert its number on exit
+
+  notify:
+    needs: [voice]
+    if: always() && needs.voice.result == 'failure' && github.event_name == 'workflow_run'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Google Chat on scheduled failure
+        run: |
+          curl -sS --max-time 10 --retry 3 -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
+            -H 'Content-Type: application/json' \
+            -d '{"text": "⚠️ *FAILED* — Live voice-call suite\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}' || true

--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -6,11 +6,8 @@ name: Live — voice calls (Inkbox TTS/STT + realtime)
 #   outbound_realtime — driver texts "call me"; agent calls back via the realtime API.
 # Each leg verifies the stored call transcript shows the agent spoke to the caller.
 # Real model + real calls, so this runs only on ready (non-draft) PRs + dispatch, and
-# shares the AUT tunnel lock with the other live suites. During development it also
-# runs on pushes to its feature branch.
+# shares the AUT tunnel lock with the other live suites.
 on:
-  push:
-    branches: [feat/live-voice-calls]
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -85,6 +85,21 @@ def _wait_for_two_way_call(remote, number_id, call_id):
     pytest.fail(f"agent never held a two-way call within {TIMEOUT_S:.0f}s ({last})")
 
 
+def _aut_speech_mode(aut, direction, driver_number):
+    """(use_inkbox_tts, use_inkbox_stt) of the agent's most recent answered call
+    in `direction` with the driver. Tells Inkbox STT/TTS (True/True) from realtime
+    (False/False), so each leg can prove it ran the speech path it claims."""
+    num_id = str(aut.phone_numbers.list()[0].id)
+    tail = _digits(driver_number)[-10:]
+    answered = [c for c in aut.calls.list(num_id, limit=10)
+                if (getattr(c, "direction", "") or "").lower() == direction
+                and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == tail
+                and c.use_inkbox_tts is not None]
+    assert answered, f"no answered {direction} agent call with the driver found"
+    c = answered[0]  # newest first
+    return c.use_inkbox_tts, c.use_inkbox_stt
+
+
 @pytest.mark.skipif(SCENARIO != "inbound_inkbox", reason="inbound Inkbox STT/TTS leg only")
 def test_inbound_call_inkbox_tts_stt():
     """Driver calls the agent; the agent answers via Inkbox STT/TTS and replies."""
@@ -98,6 +113,9 @@ def test_inbound_call_inkbox_tts_stt():
     )
     agent_said = _wait_for_two_way_call(remote, st["number_id"], call.id)
     assert agent_said, "agent produced no speech on the inbound call"
+
+    tts, stt = _aut_speech_mode(aut, "inbound", st["number"])
+    assert tts and stt, f"inbound call should run Inkbox STT/TTS, got tts={tts} stt={stt}"
 
 
 @pytest.mark.skipif(SCENARIO != "outbound_realtime", reason="outbound realtime leg only")
@@ -129,3 +147,7 @@ def test_outbound_call_realtime():
 
     agent_said = _wait_for_two_way_call(remote, st["number_id"], call_id)
     assert agent_said, "agent produced no speech on the outbound call"
+
+    tts, stt = _aut_speech_mode(aut, "outbound", st["number"])
+    assert tts is False and stt is False, \
+        f"outbound call must be powered by the realtime API (Inkbox speech off), got tts={tts} stt={stt}"

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -1,0 +1,131 @@
+"""Live voice-call suite — real phone calls, real model, transcript-verified.
+
+Two scenarios, each run against a gateway booted in the matching speech mode (the
+workflow sets that up and selects the scenario via VOICE_SCENARIO):
+
+  * inbound_inkbox   — the driver calls the agent; the agent answers with Inkbox
+                       STT/TTS and holds a turn.
+  * outbound_realtime — the driver texts "call me"; the agent places a call back,
+                       powered by the realtime API, and holds a turn.
+
+A companion driver process (voice_driver.py) bridges the driver's side of the call
+over an Inkbox tunnel and speaks one line. We then read the stored call transcript
+and assert both parties spoke — proving the agent reached the caller out loud.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+
+import pytest
+
+REMOTE_KEY = os.environ.get("REMOTE_INKBOX_API_KEY")
+AUT_KEY = os.environ.get("HERMES_INKBOX_API_KEY")
+BASE_URL = os.environ.get("INKBOX_BASE_URL", "https://inkbox.ai")
+REAL = os.environ.get("LIVE_REAL_MODEL") == "1"
+SCENARIO = os.environ.get("VOICE_SCENARIO", "")
+STATE_FILE = os.environ.get("VOICE_DRIVER_STATE", "/tmp/voice_driver_state.json")
+TIMEOUT_S = float(os.environ.get("LIVE_VOICE_TIMEOUT", "220"))
+POLL_EVERY_S = 6.0
+
+pytestmark = pytest.mark.skipif(
+    not (REMOTE_KEY and AUT_KEY and REAL),
+    reason="voice suite: needs both keys + LIVE_REAL_MODEL=1",
+)
+
+
+def _digits(s: str) -> str:
+    return re.sub(r"\D", "", s or "")
+
+
+def _client(key):
+    from inkbox import Inkbox
+
+    return Inkbox(api_key=key, base_url=BASE_URL)
+
+
+def _driver_state() -> dict:
+    with open(STATE_FILE) as fh:
+        return json.load(fh)
+
+
+def _aut_phone(aut) -> str:
+    nums = aut.phone_numbers.list()
+    assert nums, "AUT identity has no phone number"
+    return nums[0].number
+
+
+def _segments(remote, number_id, call_id):
+    """Transcript segments for a call, split by who spoke."""
+    segs = remote.transcripts.list(number_id, call_id)
+    rem = [s for s in segs if (getattr(s, "party", "") or "").lower() == "remote" and (s.text or "").strip()]
+    loc = [s for s in segs if (getattr(s, "party", "") or "").lower() == "local" and (s.text or "").strip()]
+    return segs, rem, loc
+
+
+def _wait_for_two_way_call(remote, number_id, call_id):
+    """Block until the call transcript shows BOTH the agent and the driver spoke."""
+    deadline = time.monotonic() + TIMEOUT_S
+    last = ""
+    while time.monotonic() < deadline:
+        try:
+            _all, rem, loc = _segments(remote, number_id, call_id)
+        except Exception as exc:  # transcripts may 404 until the call is set up
+            last = f"transcripts not ready: {exc!r}"
+            time.sleep(POLL_EVERY_S)
+            continue
+        if rem and loc:
+            agent_said = " | ".join(s.text.strip() for s in rem)
+            return agent_said  # the agent reached the caller out loud, in a two-way call
+        last = f"segments so far: remote={len(rem)} local={len(loc)}"
+        time.sleep(POLL_EVERY_S)
+    pytest.fail(f"agent never held a two-way call within {TIMEOUT_S:.0f}s ({last})")
+
+
+@pytest.mark.skipif(SCENARIO != "inbound_inkbox", reason="inbound Inkbox STT/TTS leg only")
+def test_inbound_call_inkbox_tts_stt():
+    """Driver calls the agent; the agent answers via Inkbox STT/TTS and replies."""
+    st = _driver_state()
+    remote, aut = _client(REMOTE_KEY), _client(AUT_KEY)
+    aut_phone = _aut_phone(aut)
+
+    # Place the call to the agent, handing Inkbox the driver's own media WS.
+    call = remote.calls.place(
+        from_number=st["number"], to_number=aut_phone, client_websocket_url=st["ws_url"],
+    )
+    agent_said = _wait_for_two_way_call(remote, st["number_id"], call.id)
+    assert agent_said, "agent produced no speech on the inbound call"
+
+
+@pytest.mark.skipif(SCENARIO != "outbound_realtime", reason="outbound realtime leg only")
+def test_outbound_call_realtime():
+    """Driver texts 'call me'; the agent places a realtime-powered call and replies."""
+    st = _driver_state()
+    remote, aut = _client(REMOTE_KEY), _client(AUT_KEY)
+    aut_phone = _aut_phone(aut)
+    tail = _digits(aut_phone)[-10:]
+
+    def _inbound_from_aut():
+        return [c for c in remote.calls.list(st["number_id"], limit=30)
+                if (getattr(c, "direction", "") or "").lower() == "inbound"
+                and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == tail]
+
+    before = {c.id for c in _inbound_from_aut()}
+    remote.texts.send(st["number_id"], to=aut_phone, text="Please call me right now by phone — give me a ring.")
+
+    # Wait for the agent to dial back, then verify the call transcript.
+    deadline = time.monotonic() + TIMEOUT_S
+    call_id = None
+    while time.monotonic() < deadline:
+        fresh = [c for c in _inbound_from_aut() if c.id not in before]
+        if fresh:
+            call_id = fresh[0].id
+            break
+        time.sleep(POLL_EVERY_S)
+    assert call_id, f"agent never placed a call back within {TIMEOUT_S:.0f}s"
+
+    agent_said = _wait_for_two_way_call(remote, st["number_id"], call_id)
+    assert agent_said, "agent produced no speech on the outbound call"

--- a/tests/live/voice_driver.py
+++ b/tests/live/voice_driver.py
@@ -49,6 +49,9 @@ LINE = os.environ.get(
 )
 # Speak shortly after the pipeline is ready so the agent's greeting lands first.
 SPEAK_AFTER_S = float(os.environ.get("VOICE_DRIVER_SPEAK_AFTER", "3"))
+# Then give the agent a turn and hang up — a dropped WS does NOT end the call, so we
+# must send an explicit stop or the leg lingers until the server max-duration cap.
+LISTEN_S = float(os.environ.get("VOICE_DRIVER_LISTEN", "12"))
 
 app = FastAPI()
 
@@ -69,19 +72,27 @@ async def phone_media_ws(ws: WebSocket) -> None:
         (b"x-use-inkbox-speech-to-text", b"true"),
     ])
     log.info("call WS accepted")
-    spoke = False
+    spoke = asyncio.Event()
+    convo: asyncio.Task | None = None
 
     async def _speak(text: str) -> None:
+        if spoke.is_set():
+            return
+        spoke.set()
         await ws.send_text(json.dumps({"event": "text", "delta": text}))
         await ws.send_text(json.dumps({"event": "text", "done": True}))
         log.info("spoke: %s", text)
 
-    async def _speak_after_delay() -> None:
+    async def _run_turn() -> None:
+        # Speak one line, give the agent a turn, then hang up so the call ends fast.
         await asyncio.sleep(SPEAK_AFTER_S)
-        nonlocal spoke
-        if not spoke:
-            spoke = True
-            await _speak(LINE)
+        await _speak(LINE)
+        await asyncio.sleep(LISTEN_S)
+        try:
+            await ws.send_text(json.dumps({"event": "stop"}))
+            log.info("sent stop (hangup)")
+        except Exception:
+            pass
 
     try:
         while True:
@@ -90,19 +101,18 @@ async def phone_media_ws(ws: WebSocket) -> None:
             kind = ev.get("event")
             if kind == "start":
                 log.info("call start: %s", ev.get("stream_id"))
-                asyncio.create_task(_speak_after_delay())
+                convo = asyncio.create_task(_run_turn())
             elif kind == "transcript" and ev.get("is_final"):
                 log.info("heard (final): %s", ev.get("text"))
-                # Make sure the agent got a turn even if the greeting was slow.
-                if not spoke:
-                    spoke = True
-                    await _speak(LINE)
+                await _speak(LINE)  # speak now if the greeting beat our timer
             elif kind == "stop":
                 log.info("call stop: %s", ev.get("reason"))
                 break
     except Exception as exc:  # noqa: BLE001 — never let the bridge crash the process
         log.info("WS loop ended: %r", exc)
     finally:
+        if convo:
+            convo.cancel()
         if ws.client_state != WebSocketState.DISCONNECTED:
             try:
                 await ws.close()

--- a/tests/live/voice_driver.py
+++ b/tests/live/voice_driver.py
@@ -1,0 +1,162 @@
+"""Live voice-call driver: the peer on the other end of a real phone call.
+
+Opens an Inkbox tunnel for the driver identity, serves the call-media WebSocket
+behind it, and bridges audio in Inkbox STT/TTS mode (text frames only — no local
+model). It speaks one scripted line so the agent under test gets a turn, and the
+call transcript (read separately by the test) proves the agent replied.
+
+Run as a standalone process alongside the gateway. On startup it writes a small
+JSON state file (its public WS URL + phone-number id) that the test reads to place
+or expect a call. Two call directions are supported by the same bridge:
+  * the test places a call to the agent and passes this driver's WS URL, or
+  * the agent calls this driver's number, which is set to auto-accept onto the
+    same WS URL.
+
+Env:
+  REMOTE_INKBOX_API_KEY   driver identity key (identity-scoped)
+  INKBOX_BASE_URL         API root (default https://inkbox.ai)
+  VOICE_DRIVER_PORT       local port the tunnel forwards to (default 8090)
+  VOICE_DRIVER_STATE      path to write the JSON state file
+  VOICE_DRIVER_LINE       the one line the driver speaks (default below)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from pathlib import Path
+
+import uvicorn
+from fastapi import FastAPI, WebSocket
+from starlette.websockets import WebSocketState
+
+from inkbox import Inkbox
+from inkbox.tunnels.client import connect as tunnel_connect
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s driver %(message)s")
+log = logging.getLogger("voice_driver")
+
+API_KEY = os.environ["REMOTE_INKBOX_API_KEY"]
+BASE_URL = os.environ.get("INKBOX_BASE_URL", "https://inkbox.ai")
+PORT = int(os.environ.get("VOICE_DRIVER_PORT", "8090"))
+STATE_FILE = os.environ.get("VOICE_DRIVER_STATE", "/tmp/voice_driver_state.json")
+LINE = os.environ.get(
+    "VOICE_DRIVER_LINE",
+    "Hi, this is a quick test call. Please reply out loud with one short sentence, then say goodbye.",
+)
+# Speak shortly after the pipeline is ready so the agent's greeting lands first.
+SPEAK_AFTER_S = float(os.environ.get("VOICE_DRIVER_SPEAK_AFTER", "3"))
+
+app = FastAPI()
+
+
+@app.get("/health")
+async def health() -> dict:
+    return {"ok": True}
+
+
+@app.websocket("/phone/media/ws")
+async def phone_media_ws(ws: WebSocket) -> None:
+    """Accept the call-media WS in Inkbox STT/TTS mode and run one scripted turn."""
+    import asyncio
+
+    # Opt into Inkbox-managed speech both ways → we exchange text, not audio.
+    await ws.accept(headers=[
+        (b"x-use-inkbox-text-to-speech", b"true"),
+        (b"x-use-inkbox-speech-to-text", b"true"),
+    ])
+    log.info("call WS accepted")
+    spoke = False
+
+    async def _speak(text: str) -> None:
+        await ws.send_text(json.dumps({"event": "text", "delta": text}))
+        await ws.send_text(json.dumps({"event": "text", "done": True}))
+        log.info("spoke: %s", text)
+
+    async def _speak_after_delay() -> None:
+        await asyncio.sleep(SPEAK_AFTER_S)
+        nonlocal spoke
+        if not spoke:
+            spoke = True
+            await _speak(LINE)
+
+    try:
+        while True:
+            raw = await ws.receive_text()
+            ev = json.loads(raw)
+            kind = ev.get("event")
+            if kind == "start":
+                log.info("call start: %s", ev.get("stream_id"))
+                asyncio.create_task(_speak_after_delay())
+            elif kind == "transcript" and ev.get("is_final"):
+                log.info("heard (final): %s", ev.get("text"))
+                # Make sure the agent got a turn even if the greeting was slow.
+                if not spoke:
+                    spoke = True
+                    await _speak(LINE)
+            elif kind == "stop":
+                log.info("call stop: %s", ev.get("reason"))
+                break
+    except Exception as exc:  # noqa: BLE001 — never let the bridge crash the process
+        log.info("WS loop ended: %r", exc)
+    finally:
+        if ws.client_state != WebSocketState.DISCONNECTED:
+            try:
+                await ws.close()
+            except Exception:
+                pass
+
+
+def _run_uvicorn() -> uvicorn.Server:
+    server = uvicorn.Server(uvicorn.Config(app, host="127.0.0.1", port=PORT, log_level="warning"))
+    threading.Thread(target=server.run, name="uvicorn", daemon=True).start()
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        if server.started:
+            return server
+        time.sleep(0.05)
+    raise RuntimeError("uvicorn did not start")
+
+
+def main() -> None:
+    client = Inkbox(api_key=API_KEY, base_url=BASE_URL)
+    handle = client.mailboxes.list()[0].email_address.split("@", 1)[0]   # tunnel name = handle
+    num = client.phone_numbers.list()[0]
+    log.info("driver identity %s number %s", handle, num.number)
+
+    server = _run_uvicorn()
+
+    listener = tunnel_connect(
+        client, name=handle, forward_to=f"http://127.0.0.1:{PORT}",
+        state_dir=f"/tmp/inkbox-tunnel-{handle}",
+    )
+    public_host = listener.tunnel.public_host
+    ws_url = f"wss://{public_host}/phone/media/ws"
+    log.info("tunnel ready: %s", ws_url)
+
+    # Auto-accept inbound calls (agent → driver) straight onto this WS.
+    prev_action = getattr(num, "incoming_call_action", None)
+    client.phone_numbers.update(num.id, incoming_call_action="auto_accept", client_websocket_url=ws_url)
+
+    Path(STATE_FILE).write_text(json.dumps({
+        "ws_url": ws_url, "number": num.number, "number_id": str(num.id), "handle": handle,
+    }))
+    log.info("state written to %s", STATE_FILE)
+
+    try:
+        listener.wait()
+    finally:
+        # Leave the number as we found it so other suites aren't affected.
+        try:
+            client.phone_numbers.update(num.id, incoming_call_action=prev_action or "auto_reject")
+        except Exception as exc:  # noqa: BLE001
+            log.info("number revert failed: %r", exc)
+        listener.close()
+        server.should_exit = True
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a live voice-call suite that proves the agent can hold a real phone call on both speech paths, without disturbing the existing cross-channel suite.

## Scenarios (matrix, one gateway boot each)
- **inbound_inkbox** — a driver places a real call to the agent; the agent answers with **Inkbox STT/TTS** and holds a turn.
- **outbound_realtime** — a driver texts "call me"; the agent places a call back, powered by the **realtime API**, and holds a turn.

## How
- `tests/live/voice_driver.py` — a standalone driver that opens its own tunnel, serves the call-media WS in Inkbox STT/TTS text mode, and speaks one scripted line so the agent gets a turn. Writes its public WS URL + number id to a state file for the test.
- `tests/live/test_voice.py` — places/receives the call and asserts the stored call transcript shows **both parties spoke** (the agent reached the caller out loud).
- `.github/workflows/live-voice.yml` — boots the gateway in the matching speech mode per leg + the driver, shares the AUT tunnel lock with the other live suites, gated to non-draft PRs + dispatch.

The voice tests are gated by `VOICE_SCENARIO`, so they **skip** in the email/SMS live suite — the cross-channel tests are untouched.