### PR TITLE
Reject unknown API key subtypes in setup

### DIFF
--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -1184,9 +1184,9 @@ def _api_key_flow(
     if subtype == _enum_value(ADMIN_SCOPED):
         return _pick_admin_scoped(client, api_key, IdentityPhoneNumberCreateOptions, InkboxAPIError)
 
-    print_warning(f"  Unrecognized API-key subtype: {subtype!r}.")
-    print_info("  Falling back to list_identities().")
-    return _pick_admin_scoped(client, api_key, IdentityPhoneNumberCreateOptions, InkboxAPIError)
+    print_error(f"  Unsupported API-key subtype: {subtype!r}.")
+    print_info("  Use an admin-scoped or agent-scoped Inkbox API key.")
+    return None, "", False
 
 
 def _pick_agent_scoped(client: Any, api_key: str) -> tuple[Any | None, str, bool]:

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -58,6 +58,38 @@ def test_missing_sdk_guidance_prints_hermes_python(monkeypatch, capsys):
     assert "aiohttp>=3.9" in out
 
 
+def test_api_key_flow_rejects_unknown_auth_subtype(monkeypatch, capsys):
+    class FakeWhoamiApiKeyResponse:
+        auth_subtype = "future_scope"
+        organization_id = "org_123"
+
+    class FakeInkbox:
+        def __init__(self, **_kwargs):
+            pass
+
+        def whoami(self):
+            return FakeWhoamiApiKeyResponse()
+
+        def list_identities(self):
+            raise AssertionError("unknown subtypes must not fall back to identity listing")
+
+    monkeypatch.setattr(setup_wizard, "prompt", lambda *_args, **_kwargs: "ApiKey_test")
+
+    result = setup_wizard._api_key_flow(
+        "https://inkbox.ai",
+        FakeInkbox,
+        Exception,
+        FakeWhoamiApiKeyResponse,
+        "admin_scoped",
+        "agent_scoped_claimed",
+        "agent_scoped_unclaimed",
+        object,
+    )
+
+    assert result == (None, "", False)
+    assert "Unsupported API-key subtype" in capsys.readouterr().out
+
+
 def test_plugin_install_does_not_prompt_for_inkbox_env():
     text = (ROOT / "plugin.yaml").read_text()
 


### PR DESCRIPTION
Summary:
- Reject unsupported whoami auth subtypes during BYO API-key setup
- Stop falling back to admin identity listing for unknown future scopes
- Add a setup wizard regression test

Testing:
- python3 -m pytest tests/test_setup_wizard.py