### PR TITLE
Live SMS: correlate replies to questions (fix Jane Doe flake)

### DIFF
--- a/tests/live/test_sms.py
+++ b/tests/live/test_sms.py
@@ -66,7 +66,15 @@ def sms():
 
 
 def _ask_sms(sms, text: str) -> str:
-    """Text the agent; return the reply body (lowercased), matched by new message id."""
+    """Text the agent; return the reply body (lowercased), matched by new message id.
+
+    The agent sometimes emits a trailing *second* SMS for the PREVIOUS question
+    (a duplicate "OK", or a masked + unmasked identity pair) that lands a few
+    seconds late. Matching on "any new inbound id after I sent" would let that
+    leftover leak into the next question's match. So before sending we first
+    drain the inbound conversation to a quiet state — polling until the id-set
+    stops growing — which folds any in-flight trailing reply into ``before``.
+    """
     remote, aut_phone, pid = sms["remote"], sms["aut_phone"], sms["remote_pid"]
     tail = _digits(aut_phone)[-10:]
 
@@ -78,7 +86,17 @@ def _ask_sms(sms, text: str) -> str:
                 out.append(m)
         return out
 
+    # Settle: wait until no new inbound arrives for one quiet poll, so a trailing
+    # reply to the prior question is captured in `before` instead of mis-matched.
     before = {m.id for m in _inbound_from_aut()}
+    quiet_deadline = time.monotonic() + 2 * POLL_EVERY_S
+    while time.monotonic() < quiet_deadline:
+        time.sleep(POLL_EVERY_S)
+        now_ids = {m.id for m in _inbound_from_aut()}
+        if now_ids == before:
+            break
+        before = now_ids
+
     remote.texts.send(pid, to=aut_phone, text=text)
 
     deadline = time.monotonic() + TIMEOUT_S


### PR DESCRIPTION
The live SMS smoke suite matched a reply by *"any new inbound message id that appears after I sent the question"* — there is nothing tying a reply to the question that produced it.

The agent occasionally emits a trailing **second** SMS for the **previous** question (a duplicate `OK`, or a masked + unmasked identity pair — confirmed in live transcripts). Because replies land with multi-second async latency, that leftover lands just after the next question's `before` snapshot and gets mis-attributed to it.

That is exactly what broke `test_sms_reports_sender_details`. The agent answered the question correctly:

```
09:26:51  inbound   Who am I to you? Tell me what you have on file about me.
09:26:59  outbound  You're Jane Doe in my Inkbox contacts. On file: - Email: hermes-plugin-penetrator@inkbox...
```

…but the assertion ran against the trailing reply to the *preceding* own-identity question:

```
09:26:44  outbound  hermes-plugin-smoke-agent@inkboxmail.com +192****3235
```

→ `AssertionError: reply missing sender name 'Jane Doe'`. Not an agent bug — a harness correlation bug. Verified against the live API that the `Jane Doe` contact resolves correctly by **both** email and phone, so the agent had the data and used it.

## Fix
Before sending a question, drain the inbound conversation to a quiet state (poll until the id-set stops growing) so any in-flight trailing reply is folded into `before` and cannot be mis-matched. This preserves the clock-skew-free id-set matching the suite was deliberately designed around.