### PR TITLE
Realtime: capability map + direct read-only contact tools

### DIFF
--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -1,9 +1,12 @@
 name: Live — voice calls (Inkbox TTS/STT + realtime)
 
 # Boots the agent-under-test (AUT) gateway plus a driver process that bridges the
-# other side of a real phone call over its own Inkbox tunnel. Two matrix legs:
+# other side of a real phone call over its own Inkbox tunnel. Three matrix legs:
 #   inbound_inkbox    — driver calls the agent; agent answers with Inkbox STT/TTS.
 #   outbound_realtime — driver texts "call me"; agent calls back via the realtime API.
+#   outbound_realtime_contact — same call-back, but the driver asks for a seeded
+#                       contact's email; the agent must answer via a direct
+#                       contact-read tool and speak the details.
 # Each leg verifies the stored call transcript shows the agent spoke to the caller.
 # Real model + real calls, so this runs only on ready (non-draft) PRs + dispatch, and
 # shares the AUT tunnel lock with the other live suites.
@@ -35,7 +38,7 @@ jobs:
       fail-fast: false
       max-parallel: 1          # legs share the AUT identity → one at a time
       matrix:
-        scenario: [inbound_inkbox, outbound_realtime]
+        scenario: [inbound_inkbox, outbound_realtime, outbound_realtime_contact]
 
     steps:
       - uses: actions/checkout@v4
@@ -88,10 +91,10 @@ jobs:
           hermes config set model.provider custom || true
           hermes config set model.base_url https://api.openai.com/v1 || true
           hermes config set model.default gpt-5.5 || true
-          if [ "${{ matrix.scenario }}" = "outbound_realtime" ]; then
-            echo "INKBOX_REALTIME_ENABLED=true" >> "$HERMES_HOME/.env"
-          else
+          if [ "${{ matrix.scenario }}" = "inbound_inkbox" ]; then
             echo "INKBOX_REALTIME_ENABLED=false" >> "$HERMES_HOME/.env"
+          else
+            echo "INKBOX_REALTIME_ENABLED=true" >> "$HERMES_HOME/.env"
           fi
 
       - name: Start gateway and wait for readiness
@@ -112,6 +115,11 @@ jobs:
           REMOTE_INKBOX_API_KEY: ${{ secrets.REMOTE_INKBOX_API_KEY }}
         run: |
           PY="$HERMES_HOME/hermes-agent/venv/bin/python3"
+          if [ "${{ matrix.scenario }}" = "outbound_realtime_contact" ]; then
+            # Must name the contact the test seeds (see test_voice.py LOOKUP_CONTACT_*).
+            export VOICE_DRIVER_LINE="Hi! Quick question: what email address do you have on file for your contact Marigold Zebrawood? Please read the email out loud, then say goodbye."
+            export VOICE_DRIVER_LISTEN=25   # tool round-trip + spoken email needs more than the default turn
+          fi
           VOICE_DRIVER_STATE="$DRIVER_STATE" VOICE_DRIVER_PORT=8090 \
             "$PY" "$GITHUB_WORKSPACE/tests/live/voice_driver.py" > "$DRIVER_LOG" 2>&1 &
           echo $! > "$RUNNER_TEMP/driver.pid"

--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -117,7 +117,7 @@ jobs:
           PY="$HERMES_HOME/hermes-agent/venv/bin/python3"
           if [ "${{ matrix.scenario }}" = "outbound_realtime_contact" ]; then
             # Must name the contact the test seeds (see test_voice.py LOOKUP_CONTACT_*).
-            export VOICE_DRIVER_LINE="Hi! Quick question: what email address do you have on file for your contact Marigold Zebrawood? Please read the email out loud, then say goodbye."
+            export VOICE_DRIVER_LINE="Hi! Quick question: what email address do you have on file for your contact Olivia Parker? Please read the email out loud, then say goodbye."
             export VOICE_DRIVER_LISTEN=25   # tool round-trip + spoken email needs more than the default turn
           fi
           VOICE_DRIVER_STATE="$DRIVER_STATE" VOICE_DRIVER_PORT=8090 \

--- a/adapter.py
+++ b/adapter.py
@@ -3873,13 +3873,6 @@ class InkboxAdapter(BasePlatformAdapter):
                         or call_context.get("openingMessage")
                         or ""
                     ).strip() or None,
-                    outbound_reason=str(call_context.get("reason") or "").strip() or None,
-                    outbound_scheduled_by=str(
-                        call_context.get("scheduled_by") or ""
-                    ).strip() or None,
-                    outbound_conversation_summary=str(
-                        call_context.get("conversation_summary") or ""
-                    ).strip() or None,
                 )
                 realtime_bridge = await open_inkbox_realtime_bridge(
                     config=self._realtime_config,
@@ -4052,8 +4045,6 @@ class InkboxAdapter(BasePlatformAdapter):
                     "[Inkbox] Failed to enqueue outbound opener: %s", exc,
                 )
 
-        first_transcript_seen = False
-
         try:
             async for msg in ws:
                 if msg.type != WSMsgType.TEXT:
@@ -4087,28 +4078,9 @@ class InkboxAdapter(BasePlatformAdapter):
                     )
                     contact_block = self._contact_marker(meta.get("contact"))
 
-                    # On the FIRST transcript only, prepend the call-purpose
-                    # block (if any) so the in-call agent — which has no
-                    # memory of why it's calling — has authoritative context.
-                    purpose_block = ""
-                    if call_context and not first_transcript_seen:
-                        reason = (call_context.get("reason") or "").strip()
-                        scheduled_by = (call_context.get("scheduled_by") or "").strip()
-                        prior = (call_context.get("conversation_summary") or "").strip()
-                        lines = ["[outbound_call_context]"]
-                        if reason:
-                            lines.append(f"reason: {reason}")
-                        if scheduled_by:
-                            lines.append(f"scheduled_by: {scheduled_by}")
-                        if prior:
-                            lines.append(f"prior_conversation: {prior}")
-                        lines.append("[/outbound_call_context]")
-                        purpose_block = "\n".join(lines) + "\n"
-                    first_transcript_seen = True
-
                     tagged = (
                         f"[inkbox:voice_call call_id={call_id} | {contact_block}]\n"
-                        f"{purpose_block}{text}"
+                        f"{text}"
                     )
                     channel_prompt, auto_skill = self._resolve_channel_overrides(
                         "voice", contact_id, "inkbox:inkbox-troubleshooting"

--- a/adapter.py
+++ b/adapter.py
@@ -4256,9 +4256,23 @@ class InkboxAdapter(BasePlatformAdapter):
             f"Caller: {meta.contact_name}"
             + (f" ({meta.remote_phone_number})" if meta.remote_phone_number else ""),
             f"Call direction: {meta.direction}",
+        ]
+        # Trust context: the voice model relays whatever we return straight to
+        # the caller, so the disclosure policy has to be enforced here.
+        if meta.contact_known:
+            prompt_lines.append("The caller matched a known Inkbox contact.")
+        else:
+            prompt_lines.append(
+                "The caller did NOT match any known contact — treat them as "
+                "unverified. Do not disclose message history, contact details, "
+                "or other private data about third parties; only share what "
+                "this caller is already party to. When unsure, decline and "
+                "offer a follow-up after the call instead."
+            )
+        prompt_lines.extend([
             "",
             "Recent transcript:",
-        ]
+        ])
         for role, text in transcript[-10:]:
             prompt_lines.append(f"  {role}: {text}")
         post_call_actions = post_call_actions or []

--- a/realtime.py
+++ b/realtime.py
@@ -417,12 +417,6 @@ class RealtimeCallMeta:
     contact_notes: Optional[str] = None
     outbound_purpose: Optional[str] = None
     outbound_opening: Optional[str] = None
-    # Richer outbound-call context loaded from the call-context file. These
-    # are the keys the legacy text-mode call handler reads, so realtime calls
-    # keep the same "why we called" continuity.
-    outbound_reason: Optional[str] = None
-    outbound_scheduled_by: Optional[str] = None
-    outbound_conversation_summary: Optional[str] = None
 
 
 @dataclass
@@ -549,15 +543,6 @@ def build_realtime_instructions(
     if meta.direction == "outbound":
         if meta.outbound_purpose:
             lines.append(f"This is an outbound call you placed. Purpose: {meta.outbound_purpose}")
-        if meta.outbound_reason:
-            lines.append(f"Reason for the call: {meta.outbound_reason}")
-        if meta.outbound_scheduled_by:
-            lines.append(f"This call was scheduled by: {meta.outbound_scheduled_by}")
-        if meta.outbound_conversation_summary:
-            lines.append(
-                f"Summary of the prior conversation that led to this call:\n"
-                f"{meta.outbound_conversation_summary}",
-            )
         if meta.outbound_opening:
             lines.append(
                 f"Preferred opening message (say this naturally as your first turn): "

--- a/realtime.py
+++ b/realtime.py
@@ -68,6 +68,26 @@ EDIT_POST_CALL_ACTION_TOOL_NAME = "edit_post_call_action"
 DELETE_POST_CALL_ACTION_TOOL_NAME = "delete_post_call_action"
 HANG_UP_CALL_TOOL_NAME = "hang_up_call"
 
+# Read-only contact tools exposed directly to the realtime model, so common
+# "who is X?" / "what's their email?" questions answer in one SDK round-trip
+# instead of a full consult_agent loop. Reads only, on purpose: writes stay
+# brokered through consult_agent / post-call actions, where the main agent
+# can apply judgment before anything mutates. No inkbox_get_contact here —
+# lookup and list already return full cards, so a by-id fetch adds nothing
+# mid-call. Names match the main-agent tools in plugin.yaml; the shared
+# implementations in tools.py do the work.
+CONTACT_LOOKUP_TOOL_NAME = "inkbox_lookup_contact"
+CONTACT_LIST_TOOL_NAME = "inkbox_list_contacts"
+REALTIME_CONTACT_READ_TOOLS: Tuple[str, ...] = (
+    CONTACT_LOOKUP_TOOL_NAME,
+    CONTACT_LIST_TOOL_NAME,
+)
+
+# Voice results must stay small — everything in the session competes with
+# audio for context. Cap matches and clip notes before submitting results.
+CONTACT_READ_MAX_RESULTS = 5
+CONTACT_READ_NOTES_MAX_CHARS = 200
+
 # How long to wait for the agent_consult tool to complete before giving up and
 # returning an error tool result. The realtime model is sitting idle while this
 # runs; longer values risk dead air, shorter values cut off legitimate work.
@@ -307,6 +327,65 @@ def _hang_up_call_tool_schema() -> Dict[str, Any]:
     }
 
 
+def _contact_lookup_tool_schema() -> Dict[str, Any]:
+    return {
+        "type": "function",
+        "name": CONTACT_LOOKUP_TOOL_NAME,
+        "description": (
+            "Look up an Inkbox contact by exactly ONE filter: email, phone, "
+            "emailContains, or phoneContains. Fast direct read; returns full "
+            "contact cards. Use this when the caller gives you an email "
+            "address or phone number. To search by NAME, use "
+            f"{CONTACT_LIST_TOOL_NAME} instead."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string",
+                    "description": "Exact email address.",
+                },
+                "phone": {
+                    "type": "string",
+                    "description": "Exact phone number, E.164 preferred.",
+                },
+                "emailContains": {
+                    "type": "string",
+                    "description": "Substring of the email address.",
+                },
+                "phoneContains": {
+                    "type": "string",
+                    "description": "Substring of the phone number.",
+                },
+            },
+            "required": [],
+        },
+    }
+
+
+def _contact_list_tool_schema() -> Dict[str, Any]:
+    return {
+        "type": "function",
+        "name": CONTACT_LIST_TOOL_NAME,
+        "description": (
+            "Search the Inkbox contact book by name or free text. Fast direct "
+            f"read; returns up to {CONTACT_READ_MAX_RESULTS} full contact "
+            "cards. Use this when the caller asks who someone is or what "
+            "email/phone is on file for a person, mentioning them by name."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "q": {
+                    "type": "string",
+                    "description": "Name or free-text search query.",
+                },
+            },
+            "required": [],
+        },
+    }
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Data types
 # ─────────────────────────────────────────────────────────────────────────────
@@ -496,6 +575,15 @@ def build_realtime_instructions(
         + "; ".join(_capability_summaries()) + ".",
         f"Do not promise work outside that list. If you are not sure something is "
         f"possible, call {AGENT_CONSULT_TOOL_NAME} and ask instead of guessing.",
+        f"Exception — quick contact questions (who someone is, what email or "
+        f"phone is on file): answer those yourself with {CONTACT_LIST_TOOL_NAME} "
+        f"(search by name via q) or {CONTACT_LOOKUP_TOOL_NAME} (exact "
+        f"email/phone), NOT {AGENT_CONSULT_TOOL_NAME}; the direct tools answer "
+        f"instantly. Contact changes still go through {AGENT_CONSULT_TOOL_NAME} "
+        f"or after-call actions.",
+        "Never recite contact details or message history involving third "
+        "parties to a caller you have not recognized; offer a follow-up after "
+        "the call instead.",
         f"If the caller explicitly asks for work to happen after the call, or accepts "
         f"an after-call deferral, call {POST_CALL_ACTION_TOOL_NAME}. Tell the caller "
         f"the action is queued for after the call; do not claim it has already been "
@@ -897,6 +985,8 @@ async def _send_session_update(
                 _edit_post_call_action_tool_schema(),
                 _delete_post_call_action_tool_schema(),
                 _hang_up_call_tool_schema(),
+                _contact_lookup_tool_schema(),
+                _contact_list_tool_schema(),
             ],
             "tool_choice": "auto",
         },
@@ -985,9 +1075,11 @@ async def _openai_to_inkbox_pump(
         # Dispatch it as a background task instead; the pump keeps streaming
         # audio while the agent thinks, and the task submits the tool result when
         # it finishes (this is exactly the async-tool flow gpt-realtime expects).
-        # Every other tool is an instant in-memory op, so it stays inline.
-        if name == AGENT_CONSULT_TOOL_NAME:
-            task = asyncio.create_task(coro, name=f"realtime-consult-{cid}")
+        # Direct contact reads are sync network I/O (~hundreds of ms), so they
+        # go to the background too. Every other tool is an instant in-memory
+        # op and stays inline.
+        if name == AGENT_CONSULT_TOOL_NAME or name in REALTIME_CONTACT_READ_TOOLS:
+            task = asyncio.create_task(coro, name=f"realtime-tool-{cid}")
             state.consult_tasks.add(task)
             task.add_done_callback(state.consult_tasks.discard)
         else:
@@ -1128,6 +1220,61 @@ async def _openai_to_inkbox_pump(
         # rate_limits.updated, …) are ignored.
 
 
+def _voice_trim_contact(raw: Any) -> Any:
+    """Cut a full contact card down to what is worth saying aloud."""
+    if not isinstance(raw, dict):
+        return raw
+    trimmed: Dict[str, Any] = {}
+    for key in ("id", "preferred_name", "given_name", "family_name", "company_name", "job_title"):
+        if raw.get(key):
+            trimmed[key] = raw[key]
+    # emails/phones arrive as [{value, is_primary, ...}] — flatten to values.
+    for key in ("emails", "phones"):
+        values = []
+        for entry in raw.get(key) or []:
+            value = entry.get("value") if isinstance(entry, dict) else entry
+            if value:
+                values.append(value)
+        if values:
+            trimmed[key] = values[:3]
+    notes = raw.get("notes")
+    if notes:
+        trimmed["notes"] = str(notes)[:CONTACT_READ_NOTES_MAX_CHARS]
+    return trimmed
+
+
+def _voice_trim_contact_result(payload: Any) -> Any:
+    """Shrink a contact tool's JSON payload before it enters the audio session."""
+    if not isinstance(payload, dict) or payload.get("error"):
+        return payload
+    contacts = payload.get("contacts")
+    if isinstance(contacts, list):
+        payload["contacts"] = [
+            _voice_trim_contact(entry) for entry in contacts[:CONTACT_READ_MAX_RESULTS]
+        ]
+        if len(contacts) > CONTACT_READ_MAX_RESULTS:
+            payload["truncated_to"] = CONTACT_READ_MAX_RESULTS
+    return payload
+
+
+def _run_contact_read_sync(name: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    """Execute one direct contact read via the shared tool implementations."""
+    try:
+        from . import tools as tools_mod
+    except ImportError:  # pragma: no cover - direct local import/test fallback
+        import tools as tools_mod
+    tool_fn = getattr(tools_mod, name, None)
+    if tool_fn is None:
+        return {"error": f"unknown contact tool: {name}"}
+    if name == CONTACT_LIST_TOOL_NAME:
+        args = {**args, "limit": CONTACT_READ_MAX_RESULTS}
+    try:
+        payload = json.loads(tool_fn(dict(args)))
+    except Exception as exc:
+        return {"error": f"contact read failed: {exc}"}
+    return _voice_trim_contact_result(payload)
+
+
 async def _dispatch_tool_call(
     *,
     openai_ws: Any,
@@ -1145,6 +1292,19 @@ async def _dispatch_tool_call(
         args = json.loads(arguments_json or "{}")
     except (TypeError, ValueError):
         args = {}
+
+    if name in REALTIME_CONTACT_READ_TOOLS:
+        # Runs as a background task (see _finalize_fn_call); the sync SDK call
+        # moves to a thread so the audio pump keeps streaming meanwhile.
+        output = await asyncio.to_thread(_run_contact_read_sync, name, args)
+        # Tool name only — args/results carry contact PII and live-suite logs
+        # can end up in CI output.
+        logger.info(
+            "[Inkbox realtime] direct contact read %s for call_id=%s",
+            name, meta.call_id,
+        )
+        await _submit_tool_result(openai_ws, call_id, output)
+        return
 
     if name == POST_CALL_ACTION_TOOL_NAME:
         action = (args.get("action") or "").strip()

--- a/realtime.py
+++ b/realtime.py
@@ -96,6 +96,74 @@ def _openai_realtime_ws_headers(bearer: str) -> Dict[str, str]:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Main-agent capability map
+# ─────────────────────────────────────────────────────────────────────────────
+
+# What the main Hermes agent can do on behalf of a live call, grouped for
+# speech. Single source of truth: rendered into both the session instructions
+# and the consult_agent tool description so the two lists can never drift
+# apart. Each entry is (group, spoken summary, plugin tool names backing it);
+# tests/test_realtime_capabilities.py asserts every tool in plugin.yaml maps
+# to exactly one group, so adding a tool without updating this map fails CI.
+# The "general" group covers host-level abilities with no plugin tool behind
+# them and stays empty on purpose.
+MAIN_AGENT_CAPABILITIES: Tuple[Tuple[str, str, Tuple[str, ...]], ...] = (
+    (
+        "contacts",
+        "look up, list, create, update, or delete contacts",
+        (
+            "inkbox_lookup_contact",
+            "inkbox_list_contacts",
+            "inkbox_get_contact",
+            "inkbox_create_contact",
+            "inkbox_update_contact",
+            "inkbox_delete_contact",
+        ),
+    ),
+    (
+        "sms",
+        "send SMS and read or manage past SMS conversations",
+        (
+            "inkbox_send_sms",
+            "inkbox_list_text_conversations",
+            "inkbox_get_text_conversation",
+            "inkbox_list_texts",
+            "inkbox_get_text",
+            "inkbox_mark_text_read",
+            "inkbox_mark_text_conversation_read",
+        ),
+    ),
+    (
+        "imessage",
+        "send iMessages and tapback reactions and read past iMessage conversations",
+        (
+            "inkbox_imessage_triage_number",
+            "inkbox_send_imessage",
+            "inkbox_list_imessage_assignments",
+            "inkbox_list_imessage_conversations",
+            "inkbox_get_imessage_conversation",
+            "inkbox_send_imessage_reaction",
+            "inkbox_mark_imessage_conversation_read",
+        ),
+    ),
+    ("email", "send email", ("inkbox_send_email",)),
+    ("calls", "place a separate outbound phone call", ("inkbox_place_call",)),
+    ("identity", "check its own Inkbox identity and numbers", ("inkbox_whoami",)),
+    (
+        "general",
+        "search session history and notes, check the calendar, do research or "
+        "computation, call external APIs, and draft long-form replies",
+        (),
+    ),
+)
+
+
+def _capability_summaries() -> List[str]:
+    """Spoken-friendly capability summaries, in map order."""
+    return [summary for _group, summary, _tools in MAIN_AGENT_CAPABILITIES]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Tool schema definitions
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -106,9 +174,8 @@ def _agent_consult_tool_schema() -> Dict[str, Any]:
         "name": AGENT_CONSULT_TOOL_NAME,
         "description": (
             "Pause the live voice conversation and ask the main Hermes agent to "
-            "do tool work that requires the full agent loop (look up an email, "
-            "search session history, check the calendar, hit an API, run a "
-            "computation, draft a long-form reply, etc.). The result you "
+            "do tool work that requires the full agent loop. The main agent can "
+            f"{'; '.join(_capability_summaries())}. The result you "
             "receive is the agent's spoken-friendly answer; read it back to "
             "the caller. Use this whenever the caller asks for something that "
             "needs current external data, persistent memory, or a tool call. "
@@ -425,9 +492,10 @@ def build_realtime_instructions(
         "Do not perform a context lookup before greeting the caller. Do not say you "
         "are waiting on a lookup or checking context.",
         f"If the caller asks for work to happen now during the live call and it needs "
-        f"Hermes/Inkbox tools, call {AGENT_CONSULT_TOOL_NAME}. This includes sending "
-        f"SMS/email, reading SMS/email/call history, creating notes, updating contacts, "
-        f"or checking current workspace/session data.",
+        f"Hermes/Inkbox tools, call {AGENT_CONSULT_TOOL_NAME}. The main agent can: "
+        + "; ".join(_capability_summaries()) + ".",
+        f"Do not promise work outside that list. If you are not sure something is "
+        f"possible, call {AGENT_CONSULT_TOOL_NAME} and ask instead of guessing.",
         f"If the caller explicitly asks for work to happen after the call, or accepts "
         f"an after-call deferral, call {POST_CALL_ACTION_TOOL_NAME}. Tell the caller "
         f"the action is queued for after the call; do not claim it has already been "

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -201,41 +201,51 @@ def test_outbound_call_realtime_direct_contact_lookup():
                     if (getattr(c, "direction", "") or "").lower() == "inbound"
                     and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == tail]
 
-        before = {c.id for c in _inbound_from_aut()}
-        remote.texts.send(st["number_id"], to=aut_phone,
-                          text="Please call me right now by phone — give me a ring.")
-
-        deadline = time.monotonic() + TIMEOUT_S
-        call_id = None
-        while time.monotonic() < deadline:
-            fresh = [c for c in _inbound_from_aut() if c.id not in before]
-            if fresh:
-                call_id = fresh[0].id
-                break
-            time.sleep(POLL_EVERY_S)
-        assert call_id, f"agent never placed a call back within {TIMEOUT_S:.0f}s"
-
-        # Poll until the ANSWER lands, not just any two-way exchange — the
-        # greeting alone already satisfies "both parties spoke". Transcript
-        # segments persist past hangup, so polling may finish after the call.
-        # The driver-leg transcript is STT of the agent's real voice; strip
-        # spaces so "zebra wood" still matches the surname.
-        deadline = time.monotonic() + TIMEOUT_S
+        # Outbound realtime calls occasionally collapse seconds in with no
+        # agent audio ever transcribed (media-path flake, also seen on the
+        # plain outbound leg) — so allow one fresh call before failing.
+        attempt_timeout = max(TIMEOUT_S / 2, 110.0)
+        found = False
         agent_said = ""
-        while time.monotonic() < deadline:
-            try:
-                _all, rem, _loc = _segments(remote, st["number_id"], call_id)
-            except Exception:  # transcripts may 404 until the call is set up
-                rem = []
-            agent_said = " | ".join(s.text.strip() for s in rem)
-            squashed = agent_said.lower().replace(" ", "")
-            if LOOKUP_CONTACT_FAMILY.lower() in squashed and "example" in squashed:
+        for attempt in (1, 2):
+            before = {c.id for c in _inbound_from_aut()}
+            remote.texts.send(st["number_id"], to=aut_phone,
+                              text="Please call me right now by phone — give me a ring.")
+
+            deadline = time.monotonic() + attempt_timeout
+            call_id = None
+            while time.monotonic() < deadline:
+                fresh = [c for c in _inbound_from_aut() if c.id not in before]
+                if fresh:
+                    call_id = fresh[0].id
+                    break
+                time.sleep(POLL_EVERY_S)
+            assert call_id, \
+                f"agent never placed a call back within {attempt_timeout:.0f}s (attempt {attempt})"
+
+            # Poll until the ANSWER lands, not just any two-way exchange — the
+            # greeting alone already satisfies "both parties spoke". Transcript
+            # segments persist past hangup, so polling may finish after the
+            # call. The driver-leg transcript is STT of the agent's real voice;
+            # strip spaces so "zebra wood" still matches the surname.
+            deadline = time.monotonic() + attempt_timeout
+            while time.monotonic() < deadline:
+                try:
+                    _all, rem, _loc = _segments(remote, st["number_id"], call_id)
+                except Exception:  # transcripts may 404 until the call is set up
+                    rem = []
+                agent_said = " | ".join(s.text.strip() for s in rem)
+                squashed = agent_said.lower().replace(" ", "")
+                if LOOKUP_CONTACT_FAMILY.lower() in squashed and "example" in squashed:
+                    found = True
+                    break
+                time.sleep(POLL_EVERY_S)
+            if found:
                 break
-            time.sleep(POLL_EVERY_S)
-        else:
+        if not found:
             pytest.fail(
-                f"agent speech never carried the seeded contact's details within "
-                f"{TIMEOUT_S:.0f}s; heard: {agent_said[:500]}"
+                "agent speech never carried the seeded contact's details in "
+                f"two calls; last heard: {agent_said[:500]}"
             )
 
         # Non-LLM proof the DIRECT tool served the answer (vs a consult loop).

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -118,6 +118,109 @@ def test_inbound_call_inkbox_tts_stt():
     assert tts and stt, f"inbound call should run Inkbox STT/TTS, got tts={tts} stt={stt}"
 
 
+# Fixed identifiers for the mid-call contact-lookup leg. Fixed (not uuid) so the
+# workflow can bake the matching question into VOICE_DRIVER_LINE; the test seeds
+# and deletes the card around the call, and the surname is one no real contact
+# would carry. STT writes it back as "zebrawood" or "zebra wood" — the assert
+# strips spaces before matching.
+LOOKUP_CONTACT_GIVEN = "Marigold"
+LOOKUP_CONTACT_FAMILY = "Zebrawood"
+LOOKUP_CONTACT_EMAIL = "marigold.zebrawood@example.com"
+GATEWAY_LOG = os.environ.get("GATEWAY_LOG", "")
+
+
+def _delete_contacts_by_email(client, email: str) -> None:
+    for contact in client.contacts.lookup(email=email) or []:
+        contact_id = str(getattr(contact, "id", "") or "")
+        if contact_id:
+            client.contacts.delete(contact_id)
+
+
+def _ensure_driver_is_a_known_contact(aut, driver_number: str) -> None:
+    """Seed the driver as a contact so the caller counts as recognized.
+
+    The realtime prompt forbids reciting third-party contact details to an
+    unrecognized caller, so this leg deliberately tests the allowed path:
+    a known caller asking about another contact.
+    """
+    if aut.contacts.lookup(phone=driver_number):
+        return
+    from inkbox.contacts.types import ContactPhone
+
+    aut.contacts.create(
+        given_name="Penny",
+        family_name="Tester",
+        phones=[ContactPhone(label="mobile", value=driver_number)],
+    )
+
+
+@pytest.mark.skipif(SCENARIO != "outbound_realtime_contact", reason="realtime contact-lookup leg only")
+def test_outbound_call_realtime_direct_contact_lookup():
+    """Mid-call, the realtime agent answers a contact question with details.
+
+    The driver (a recognized contact) texts "call me"; the agent dials back on
+    the realtime path and the driver asks for the email on file for a seeded
+    contact. Proves utility end to end: the spoken answer must carry the seeded
+    card's distinctive details, and the gateway log must show the direct
+    contact-read tool ran (not a consult_agent round-trip).
+    """
+    from inkbox.contacts.types import ContactEmail
+
+    st = _driver_state()
+    remote, aut = _client(REMOTE_KEY), _client(AUT_KEY)
+    aut_phone = _aut_phone(aut)
+    tail = _digits(aut_phone)[-10:]
+
+    _ensure_driver_is_a_known_contact(aut, st["number"])
+    _delete_contacts_by_email(aut, LOOKUP_CONTACT_EMAIL)
+    aut.contacts.create(
+        given_name=LOOKUP_CONTACT_GIVEN,
+        family_name=LOOKUP_CONTACT_FAMILY,
+        emails=[ContactEmail(label="work", value=LOOKUP_CONTACT_EMAIL)],
+    )
+    try:
+        def _inbound_from_aut():
+            return [c for c in remote.calls.list(st["number_id"], limit=30)
+                    if (getattr(c, "direction", "") or "").lower() == "inbound"
+                    and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == tail]
+
+        before = {c.id for c in _inbound_from_aut()}
+        remote.texts.send(st["number_id"], to=aut_phone,
+                          text="Please call me right now by phone — give me a ring.")
+
+        deadline = time.monotonic() + TIMEOUT_S
+        call_id = None
+        while time.monotonic() < deadline:
+            fresh = [c for c in _inbound_from_aut() if c.id not in before]
+            if fresh:
+                call_id = fresh[0].id
+                break
+            time.sleep(POLL_EVERY_S)
+        assert call_id, f"agent never placed a call back within {TIMEOUT_S:.0f}s"
+
+        agent_said = _wait_for_two_way_call(remote, st["number_id"], call_id)
+        # The driver-leg transcript is STT of the agent's real voice; strip
+        # spaces so "zebra wood" still matches the surname.
+        squashed = agent_said.lower().replace(" ", "")
+        assert LOOKUP_CONTACT_FAMILY.lower() in squashed, \
+            f"agent speech never mentioned the seeded contact: {agent_said[:500]}"
+        assert "example" in squashed, \
+            f"agent speech never carried the email details: {agent_said[:500]}"
+
+        # Non-LLM proof the DIRECT tool served the answer (vs a consult loop).
+        if GATEWAY_LOG and os.path.exists(GATEWAY_LOG):
+            with open(GATEWAY_LOG, encoding="utf-8", errors="replace") as fh:
+                log_text = fh.read()
+            assert "direct contact read inkbox_" in log_text, \
+                "gateway log shows no direct contact read during the call"
+
+        tts, stt = _aut_speech_mode(aut, "outbound", st["number"])
+        assert tts is False and stt is False, \
+            f"call must be on the realtime path (Inkbox speech off), got tts={tts} stt={stt}"
+    finally:
+        _delete_contacts_by_email(aut, LOOKUP_CONTACT_EMAIL)
+
+
 @pytest.mark.skipif(SCENARIO != "outbound_realtime", reason="outbound realtime leg only")
 def test_outbound_call_realtime():
     """Driver texts 'call me'; the agent places a realtime-powered call and replies."""

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -198,7 +198,7 @@ def test_outbound_call_realtime_direct_contact_lookup():
     )
     try:
         def _inbound_from_aut():
-            return [c for c in remote.calls.list(st["number_id"], limit=30)
+            return [c for c in remote.calls.list(limit=30)
                     if (getattr(c, "direction", "") or "").lower() == "inbound"
                     and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == tail]
 

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -221,8 +221,16 @@ def test_outbound_call_realtime_direct_contact_lookup():
                     call_id = fresh[0].id
                     break
                 time.sleep(POLL_EVERY_S)
-            assert call_id, \
-                f"agent never placed a call back within {attempt_timeout:.0f}s (attempt {attempt})"
+            if call_id is None:
+                # place_call can succeed API-side yet the PSTN leg never
+                # materializes (bad carrier window) — same class of flake as a
+                # collapsed call, so let the second attempt run too.
+                if attempt == 2:
+                    pytest.fail(
+                        f"agent never placed a call back within "
+                        f"{attempt_timeout:.0f}s in two attempts"
+                    )
+                continue
 
             # Poll until the ANSWER lands, not just any two-way exchange — the
             # greeting alone already satisfies "both parties spoke". Transcript

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -198,14 +198,28 @@ def test_outbound_call_realtime_direct_contact_lookup():
             time.sleep(POLL_EVERY_S)
         assert call_id, f"agent never placed a call back within {TIMEOUT_S:.0f}s"
 
-        agent_said = _wait_for_two_way_call(remote, st["number_id"], call_id)
+        # Poll until the ANSWER lands, not just any two-way exchange — the
+        # greeting alone already satisfies "both parties spoke". Transcript
+        # segments persist past hangup, so polling may finish after the call.
         # The driver-leg transcript is STT of the agent's real voice; strip
         # spaces so "zebra wood" still matches the surname.
-        squashed = agent_said.lower().replace(" ", "")
-        assert LOOKUP_CONTACT_FAMILY.lower() in squashed, \
-            f"agent speech never mentioned the seeded contact: {agent_said[:500]}"
-        assert "example" in squashed, \
-            f"agent speech never carried the email details: {agent_said[:500]}"
+        deadline = time.monotonic() + TIMEOUT_S
+        agent_said = ""
+        while time.monotonic() < deadline:
+            try:
+                _all, rem, _loc = _segments(remote, st["number_id"], call_id)
+            except Exception:  # transcripts may 404 until the call is set up
+                rem = []
+            agent_said = " | ".join(s.text.strip() for s in rem)
+            squashed = agent_said.lower().replace(" ", "")
+            if LOOKUP_CONTACT_FAMILY.lower() in squashed and "example" in squashed:
+                break
+            time.sleep(POLL_EVERY_S)
+        else:
+            pytest.fail(
+                f"agent speech never carried the seeded contact's details within "
+                f"{TIMEOUT_S:.0f}s; heard: {agent_said[:500]}"
+            )
 
         # Non-LLM proof the DIRECT tool served the answer (vs a consult loop).
         if GATEWAY_LOG and os.path.exists(GATEWAY_LOG):

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -129,6 +129,23 @@ LOOKUP_CONTACT_EMAIL = "marigold.zebrawood@example.com"
 GATEWAY_LOG = os.environ.get("GATEWAY_LOG", "")
 
 
+def _gateway_log_text() -> str:
+    """All gateway log content we can find: stdout capture + hermes log files."""
+    from pathlib import Path
+
+    paths = [Path(GATEWAY_LOG)] if GATEWAY_LOG else []
+    hermes_home = os.environ.get("HERMES_HOME", "")
+    if hermes_home:
+        paths.extend(sorted(Path(hermes_home, "logs").glob("*")))
+    chunks = []
+    for path in paths:
+        try:
+            chunks.append(path.read_text(encoding="utf-8", errors="replace"))
+        except OSError:
+            continue
+    return "\n".join(chunks)
+
+
 def _delete_contacts_by_email(client, email: str) -> None:
     for contact in client.contacts.lookup(email=email) or []:
         contact_id = str(getattr(contact, "id", "") or "")
@@ -222,11 +239,12 @@ def test_outbound_call_realtime_direct_contact_lookup():
             )
 
         # Non-LLM proof the DIRECT tool served the answer (vs a consult loop).
-        if GATEWAY_LOG and os.path.exists(GATEWAY_LOG):
-            with open(GATEWAY_LOG, encoding="utf-8", errors="replace") as fh:
-                log_text = fh.read()
+        # The gateway writes almost nothing to stdout; the plugin's INFO lines
+        # land in the hermes log files, so search every log we can find.
+        log_text = _gateway_log_text()
+        if log_text:
             assert "direct contact read inkbox_" in log_text, \
-                "gateway log shows no direct contact read during the call"
+                "gateway logs show no direct contact read during the call"
 
         tts, stt = _aut_speech_mode(aut, "outbound", st["number"])
         assert tts is False and stt is False, \

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -120,12 +120,13 @@ def test_inbound_call_inkbox_tts_stt():
 
 # Fixed identifiers for the mid-call contact-lookup leg. Fixed (not uuid) so the
 # workflow can bake the matching question into VOICE_DRIVER_LINE; the test seeds
-# and deletes the card around the call, and the surname is one no real contact
-# would carry. STT writes it back as "zebrawood" or "zebra wood" — the assert
-# strips spaces before matching.
-LOOKUP_CONTACT_GIVEN = "Marigold"
-LOOKUP_CONTACT_FAMILY = "Zebrawood"
-LOOKUP_CONTACT_EMAIL = "marigold.zebrawood@example.com"
+# and deletes the card around the call. The name must survive TWO audio hops
+# (driver TTS → realtime ASR), so it has to be phonetically ordinary — an
+# invented surname came back as "Miracle Zibberwood" and the lookup rightly
+# found nothing. The assert still strips spaces before matching.
+LOOKUP_CONTACT_GIVEN = "Olivia"
+LOOKUP_CONTACT_FAMILY = "Parker"
+LOOKUP_CONTACT_EMAIL = "olivia.parker.livetest@example.com"
 GATEWAY_LOG = os.environ.get("GATEWAY_LOG", "")
 
 

--- a/tests/test_realtime_bridge_parity.py
+++ b/tests/test_realtime_bridge_parity.py
@@ -188,6 +188,8 @@ def test_session_update_exposes_post_call_edit_and_delete_tools():
         EDIT_POST_CALL_ACTION_TOOL_NAME,
         DELETE_POST_CALL_ACTION_TOOL_NAME,
         HANG_UP_CALL_TOOL_NAME,
+        "inkbox_lookup_contact",
+        "inkbox_list_contacts",
     ]
 
     instructions = ws.sent[0]["session"]["instructions"]

--- a/tests/test_realtime_bridge_parity.py
+++ b/tests/test_realtime_bridge_parity.py
@@ -120,9 +120,6 @@ def test_instructions_include_full_contact_and_outbound_context():
         contact_notes="Prefers SMS.",
         direction="outbound",
         outbound_purpose="Confirm the 3pm meeting",
-        outbound_reason="Follow up on the overdue invoice",
-        outbound_scheduled_by="billing workflow",
-        outbound_conversation_summary="Customer promised to pay by Friday.",
     ))
 
     assert "do NOT look them up" in text
@@ -130,9 +127,7 @@ def test_instructions_include_full_contact_and_outbound_context():
     assert "+15167251294" in text
     assert "Inkbox" in text
     assert "Prefers SMS." in text
-    assert "Follow up on the overdue invoice" in text
-    assert "billing workflow" in text
-    assert "Customer promised to pay by Friday." in text
+    assert "Confirm the 3pm meeting" in text
 
 
 def test_open_realtime_bridge_preflights_openai_before_inkbox_accept(monkeypatch):

--- a/tests/test_realtime_capabilities.py
+++ b/tests/test_realtime_capabilities.py
@@ -1,0 +1,71 @@
+import sys
+import types
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("inkbox_plugin")
+pkg.__path__ = [str(ROOT)]
+sys.modules.setdefault("inkbox_plugin", pkg)
+
+from inkbox_plugin.realtime import (
+    MAIN_AGENT_CAPABILITIES,
+    RealtimeCallMeta,
+    _agent_consult_tool_schema,
+    build_realtime_instructions,
+)
+
+
+def _manifest_provides_tools() -> set[str]:
+    # Same parse as test_registration.py; the manifest is asserted equal to
+    # runtime registration there, so it is a safe drift anchor here too.
+    tools: set[str] = set()
+    in_block = False
+    for raw_line in (ROOT / "plugin.yaml").read_text().splitlines():
+        if raw_line.startswith("provides_tools:"):
+            in_block = True
+            continue
+        if in_block and raw_line and not raw_line.startswith(" "):
+            break
+        if in_block:
+            line = raw_line.strip()
+            if line.startswith("- "):
+                tools.add(line[2:].strip())
+    return tools
+
+
+def _meta() -> RealtimeCallMeta:
+    return RealtimeCallMeta(
+        call_id="call-1",
+        contact_id="contact-1",
+        contact_name="unknown",
+        remote_phone_number="+15550001111",
+        direction="inbound",
+    )
+
+
+def test_every_plugin_tool_maps_to_exactly_one_capability_group():
+    manifest = _manifest_provides_tools()
+    mapped: list[str] = []
+    for _group, _summary, tool_names in MAIN_AGENT_CAPABILITIES:
+        mapped.extend(tool_names)
+
+    # Stale names would let the prompt promise tools that no longer exist.
+    stale = set(mapped) - manifest
+    assert not stale, f"capability map names tools the plugin no longer provides: {stale}"
+
+    # A new tool must land in some group or the voice model never hears of it.
+    unmapped = manifest - set(mapped)
+    assert not unmapped, f"plugin tools missing from MAIN_AGENT_CAPABILITIES: {unmapped}"
+
+    assert len(mapped) == len(set(mapped)), "a tool appears in more than one capability group"
+
+
+def test_instructions_and_consult_description_render_the_same_capabilities():
+    instructions = build_realtime_instructions(_meta())
+    description = _agent_consult_tool_schema()["description"]
+    # Both surfaces must carry every group summary verbatim so they can't
+    # drift back into two hand-maintained lists.
+    for _group, summary, _tool_names in MAIN_AGENT_CAPABILITIES:
+        assert summary in instructions
+        assert summary in description

--- a/tests/test_realtime_contact_tools.py
+++ b/tests/test_realtime_contact_tools.py
@@ -1,0 +1,176 @@
+import asyncio
+import json
+import sys
+import types
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("inkbox_plugin")
+pkg.__path__ = [str(ROOT)]
+sys.modules.setdefault("inkbox_plugin", pkg)
+
+from inkbox_plugin import tools as tools_mod
+from inkbox_plugin.adapter import InkboxAdapter
+from inkbox_plugin.realtime import (
+    CONTACT_LIST_TOOL_NAME,
+    CONTACT_LOOKUP_TOOL_NAME,
+    CONTACT_READ_MAX_RESULTS,
+    CONTACT_READ_NOTES_MAX_CHARS,
+    MAIN_AGENT_CAPABILITIES,
+    REALTIME_CONTACT_READ_TOOLS,
+    RealtimeCallMeta,
+    RealtimeConfig,
+    _BridgeState,
+    _dispatch_tool_call,
+    _send_session_update,
+    build_realtime_instructions,
+)
+
+
+class _FakeWS:
+    def __init__(self):
+        self.sent = []
+
+    async def send_str(self, payload):
+        self.sent.append(json.loads(payload))
+
+
+def _meta(**overrides) -> RealtimeCallMeta:
+    fields = {
+        "call_id": "call-1",
+        "contact_id": "contact-1",
+        "contact_name": "unknown",
+        "remote_phone_number": "+15550001111",
+        "direction": "inbound",
+    }
+    fields.update(overrides)
+    return RealtimeCallMeta(**fields)
+
+
+async def _noop_consult(*_args, **_kwargs):
+    return ""
+
+
+def _dispatch(name: str, arguments: dict) -> _FakeWS:
+    ws = _FakeWS()
+    asyncio.run(_dispatch_tool_call(
+        openai_ws=ws,
+        call_id="fn-1",
+        name=name,
+        arguments_json=json.dumps(arguments),
+        state=_BridgeState(),
+        config=RealtimeConfig(enabled=True, api_key="sk-test"),
+        meta=_meta(),
+        on_agent_consult=_noop_consult,
+    ))
+    return ws
+
+
+def _submitted_output(ws: _FakeWS) -> dict:
+    frame = ws.sent[0]
+    assert frame["type"] == "conversation.item.create"
+    assert frame["item"]["type"] == "function_call_output"
+    return json.loads(frame["item"]["output"])
+
+
+def test_session_update_includes_contact_read_tools():
+    ws = _FakeWS()
+    asyncio.run(_send_session_update(
+        ws, RealtimeConfig(enabled=True, api_key="sk-test"), _meta(),
+    ))
+    tool_names = {tool["name"] for tool in ws.sent[0]["session"]["tools"]}
+    assert set(REALTIME_CONTACT_READ_TOOLS) <= tool_names
+
+
+def test_contact_read_tools_are_a_subset_of_the_contacts_capability_group():
+    contacts_group_tools = next(
+        tool_names
+        for group, _summary, tool_names in MAIN_AGENT_CAPABILITIES
+        if group == "contacts"
+    )
+    assert set(REALTIME_CONTACT_READ_TOOLS) <= set(contacts_group_tools)
+
+
+def test_instructions_route_contact_questions_to_direct_tools():
+    instructions = build_realtime_instructions(_meta())
+    assert CONTACT_LIST_TOOL_NAME in instructions
+    assert CONTACT_LOOKUP_TOOL_NAME in instructions
+    assert "third" in instructions.lower()  # third-party disclosure guardrail
+
+
+def test_contact_list_dispatch_caps_results_and_trims_for_voice(monkeypatch):
+    seen_args = {}
+
+    def _fake_list(args, **_kwargs):
+        seen_args.update(args)
+        contacts = [
+            {
+                "id": f"c{i}",
+                "preferred_name": f"Contact {i}",
+                "emails": [{"value": f"c{i}@example.com", "is_primary": True}],
+                "phones": [{"value": f"+1555000{i:04d}"}],
+                "notes": "x" * 500,
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+            for i in range(7)
+        ]
+        return json.dumps({"ok": True, "count": 7, "contacts": contacts})
+
+    monkeypatch.setattr(tools_mod, CONTACT_LIST_TOOL_NAME, _fake_list)
+
+    ws = _dispatch(CONTACT_LIST_TOOL_NAME, {"q": "alex"})
+    output = _submitted_output(ws)
+
+    # The wrapper forces the small page size on the underlying tool call.
+    assert seen_args["limit"] == CONTACT_READ_MAX_RESULTS
+    assert len(output["contacts"]) == CONTACT_READ_MAX_RESULTS
+    assert output["truncated_to"] == CONTACT_READ_MAX_RESULTS
+    first = output["contacts"][0]
+    # Cards are flattened + clipped for speech: bare values, short notes,
+    # no incidental metadata.
+    assert first["emails"] == ["c0@example.com"]
+    assert first["phones"] == ["+15550000000"]
+    assert len(first["notes"]) == CONTACT_READ_NOTES_MAX_CHARS
+    assert "created_at" not in first
+    # The result frame is followed by response.create so the model speaks it.
+    assert ws.sent[1]["type"] == "response.create"
+
+
+def test_contact_lookup_dispatch_passes_errors_through(monkeypatch):
+    def _fake_lookup(args, **_kwargs):
+        return json.dumps({"error": "Specify exactly one of email, phone, ..."})
+
+    monkeypatch.setattr(tools_mod, CONTACT_LOOKUP_TOOL_NAME, _fake_lookup)
+
+    ws = _dispatch(CONTACT_LOOKUP_TOOL_NAME, {})
+    output = _submitted_output(ws)
+    assert output["error"].startswith("Specify exactly one")
+
+
+def test_consult_prompt_carries_caller_trust_context(monkeypatch):
+    captured = {}
+
+    async def _fake_exec(*cmd, **_kwargs):
+        captured["prompt"] = cmd[2]
+
+        class _Proc:
+            async def communicate(self):
+                return b"the answer", b""
+
+        return _Proc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+    adapter = object.__new__(InkboxAdapter)
+
+    asyncio.run(adapter._realtime_agent_consult(
+        _meta(contact_known=False), "who is alex?", [],
+    ))
+    assert "unverified" in captured["prompt"]
+    assert "third parties" in captured["prompt"]
+
+    asyncio.run(adapter._realtime_agent_consult(
+        _meta(contact_known=True, contact_name="Jane"), "who is alex?", [],
+    ))
+    assert "known Inkbox contact" in captured["prompt"]
+    assert "unverified" not in captured["prompt"]


### PR DESCRIPTION
## What

Two stacked changes to the realtime call surface:

### 1. Single-source capability map
The realtime session instructions and the `consult_agent` tool description each carried a different hand-written sample of what the main agent can do, and neither mentioned iMessage, placing outbound calls, or contact lookup. Now both render from one `MAIN_AGENT_CAPABILITIES` map (grouped, spoken-friendly one-liners), with a don't-overpromise line. `tests/test_realtime_capabilities.py` asserts every tool in `plugin.yaml` maps to exactly one capability group, so adding a tool without updating the map fails CI.

### 2. Direct read-only contact tools in realtime sessions (first step of #29)
- `inkbox_lookup_contact` (exact email/phone) and `inkbox_list_contacts` (name/free-text) are exposed directly to the realtime model — contact questions answer in one sub-second SDK round-trip instead of a full `consult_agent` loop. No `inkbox_get_contact`: lookup/list already return full cards, so a by-id fetch adds nothing mid-call.
- Reads dispatch as background tasks off the audio pump (sync SDK call moves to a thread); results are capped at 5 cards and trimmed for speech (bare email/phone values, clipped notes, no metadata).
- Writes stay brokered through `consult_agent` / post-call actions on purpose — the main agent applies judgment before anything mutates.
- Guardrails: the session prompt forbids reciting third-party contact details to unrecognized callers, and the consult prompt now tells the main agent whether the caller is a known contact or unverified, with an explicit disclosure policy.

### Live test (new `outbound_realtime_contact` leg in live-voice)
The driver — seeded as a recognized contact — texts "call me"; the agent dials back on the realtime path and the driver asks for the email on file for a seeded contact (`Marigold Zebrawood`). Asserts:
- the agent's spoken transcript carries the seeded card's details (space-squashed match, STT-tolerant),
- the gateway log shows a `direct contact read inkbox_*` dispatch (non-LLM proof the direct tool served it, not a consult),
- the call ran on the realtime path (Inkbox speech off).

172→184 unit tests + ruff pass locally; live legs run in the live-voice workflow once this leaves draft.