### PR TITLE
Pin inkbox SDK <0.4.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ description = "Inkbox platform plugin for Hermes Agent"
 requires-python = ">=3.11"
 dependencies = [
   "aiohttp>=3.9",
-  "inkbox>=0.4.10",
+  "inkbox>=0.4.10,<0.4.15",
   "segno>=1.5",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -501,7 +501,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9" },
-    { name = "inkbox", specifier = ">=0.4.10" },
+    { name = "inkbox", specifier = ">=0.4.10,<0.4.15" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
     { name = "ruff", marker = "extra == 'test'", specifier = ">=0.11.0" },
     { name = "segno", specifier = ">=1.5" },


### PR DESCRIPTION
Pins the Inkbox SDK below 0.4.15. That release reworks the phone/call surface around agent identities and removes the number-scoped call/transcript methods (inkbox-ai/inkbox#90), so it is source-breaking for open-ended `>=` / `^` ranges. This ceiling keeps installs and CI on 0.4.14 until the plugin migrates to the new surface (follow-up).