### PR TITLE
Shared iMessage-line calling + SDK 0.4.15

### DIFF
--- a/.github/workflows/live-channels.yml
+++ b/.github/workflows/live-channels.yml
@@ -72,7 +72,7 @@ jobs:
           ln -sfn "$GITHUB_WORKSPACE" "$HERMES_HOME/plugins/inkbox"
           hermes plugins enable inkbox
           "$HERMES_HOME/bin/uv" pip install --python "$HERMES_HOME/hermes-agent/venv/bin/python3" \
-            'inkbox>=0.4.15' 'aiohttp>=3.9' 'segno>=1.5'
+            'inkbox>=0.4.15,<1.0.0' 'aiohttp>=3.9' 'segno>=1.5'
 
       - name: Configure AUT identity + model (${{ matrix.mode }})
         env:

--- a/.github/workflows/live-external-events.yml
+++ b/.github/workflows/live-external-events.yml
@@ -51,7 +51,7 @@ jobs:
           ln -sfn "$GITHUB_WORKSPACE" "$HERMES_HOME/plugins/inkbox"
           hermes plugins enable inkbox
           "$HERMES_HOME/bin/uv" pip install --python "$HERMES_HOME/hermes-agent/venv/bin/python3" \
-            'inkbox>=0.4.15' 'aiohttp>=3.9' 'segno>=1.5'
+            'inkbox>=0.4.15,<1.0.0' 'aiohttp>=3.9' 'segno>=1.5'
 
       - name: Configure AUT identity + model
         env:

--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -58,7 +58,7 @@ jobs:
           ln -sfn "$GITHUB_WORKSPACE" "$HERMES_HOME/plugins/inkbox"
           hermes plugins enable inkbox
           "$HERMES_HOME/bin/uv" pip install --python "$HERMES_HOME/hermes-agent/venv/bin/python3" \
-            'inkbox>=0.4.15' 'aiohttp>=3.9' 'segno>=1.5' fastapi uvicorn
+            'inkbox>=0.4.15,<1.0.0' 'aiohttp>=3.9' 'segno>=1.5' fastapi uvicorn
 
       - name: Configure AUT identity + model + speech path (${{ matrix.scenario }})
         env:

--- a/README.md
+++ b/README.md
@@ -162,6 +162,15 @@ Realtime calls receive the agent's Inkbox handle, mailbox, phone number, caller 
 
 When Realtime is enabled, the plugin preflights the OpenAI Realtime websocket before accepting the Inkbox call in raw-media mode. If that preflight fails, calls fall back to Inkbox STT/TTS by default. Set `INKBOX_REALTIME_FALLBACK_TO_INKBOX_STT_TTS=false` to fail the call instead.
 
+### Two calling lines
+
+Calls — inbound and outbound — can run over either of two lines, and the agent picks the one that matches the channel it's talking on:
+
+- **The dedicated phone number.** The agent's own number (the same line SMS uses). Outbound calls present this number; inbound calls to it ring the agent.
+- **The shared Inkbox iMessage line.** The agent can also place and receive voice calls with a person it's connected to over iMessage, over the same shared line that person already messages. The underlying number is never surfaced — Inkbox resolves it from the iMessage connection — and it only works for people already connected over iMessage (an unknown caller is rejected; an outbound call with no connection is refused).
+
+Inbound answering is configured once per identity (`auto_accept` → open the call bridge WebSocket), so a single setting governs both lines. Outbound, the agent sets `origination` on `inkbox_place_call` (`dedicated_number` / `shared_imessage_number`), or omits it when only one line is available.
+
 ## iMessage
 
 iMessage works differently from SMS: the agent does not get its own iMessage number. People connect to the agent through the Inkbox iMessage router, and each connected person gets a dedicated thread with the agent.
@@ -172,6 +181,8 @@ iMessage works differently from SMS: the agent does not get its own iMessage num
 4. The setup wizard waits for that first message and replies with a welcome confirming the channel. From then on, the gateway routes the thread into the same contact-keyed Hermes session as email/SMS/voice, and the agent replies over iMessage by default to whoever last reached it there.
 
 If a person disconnects the agent, outbound sends to that conversation fail until they reconnect through the router and message the agent again. Conversation rows expose `assignment_status` (`active`/`released`) so the agent can see this, and `inkbox_list_imessage_assignments` lists who is currently connected. Outbound delivery transitions (`imessage.sent`, `imessage.delivered`, `imessage.delivery_failed`) arrive as webhooks and are logged by the gateway without waking the agent, matching the SMS lifecycle handling.
+
+Once someone is connected over iMessage, the agent can also place and receive **voice calls** with them over that same shared line — see [Two calling lines](#two-calling-lines). This works even for an agent that has no dedicated phone number.
 
 ## CLI
 

--- a/adapter.py
+++ b/adapter.py
@@ -1727,15 +1727,10 @@ class InkboxAdapter(BasePlatformAdapter):
                 identity.phone_number.number, webhook_url,
             )
 
-        # Inbound-call config is now IDENTITY-scoped (SDK 0.4.15+): a single
-        # row governs answering for BOTH the dedicated number and any shared
-        # iMessage line that routes to this identity.  ``auto_accept`` tells
-        # Inkbox to pick up the call itself and immediately open a WS to
-        # ``client_websocket_url`` without round-tripping a webhook first —
-        # lower setup latency than ``webhook`` mode, and the call context
-        # arrives on the WS itself via the ``x-call-context`` header (parsed
-        # in ``_handle_call_ws``).  We register whenever the identity can take
-        # a call at all: a dedicated number, iMessage enabled, or both.
+        # Inbound-call config is identity-scoped (SDK 0.4.15+): one row covers
+        # the dedicated number AND any shared iMessage line. ``auto_accept``
+        # skips the webhook round-trip and opens the WS directly (context in
+        # the ``x-call-context`` header). Register whenever calls can arrive.
         can_receive_calls = (
             identity.phone_number is not None
             or bool(getattr(identity, "imessage_enabled", False))

--- a/adapter.py
+++ b/adapter.py
@@ -1713,12 +1713,7 @@ class InkboxAdapter(BasePlatformAdapter):
                 identity.mailbox.email_address, webhook_url,
             )
 
-        # Phone number: text subscription + call channel on the resource.
-        # ``incoming_call_action="auto_accept"`` tells Inkbox to pick up the
-        # call itself and immediately open a WS to ``client_websocket_url``,
-        # without round-tripping a webhook first.  Lower setup latency than
-        # ``webhook`` mode, and the call context arrives on the WS itself
-        # via the ``x-call-context`` header (parsed in ``_handle_call_ws``).
+        # Phone number: register the inbound-text subscription on the number.
         if identity.phone_number is not None:
             _reconcile_text_subscription(
                 self._inkbox,
@@ -1727,15 +1722,43 @@ class InkboxAdapter(BasePlatformAdapter):
                 previous_webhook_url=previous_webhook_url,
                 desired_events=_DESIRED_TEXT_EVENTS,
             )
-            self._inkbox.phone_numbers.update(
-                identity.phone_number.id,
-                incoming_call_webhook_url=webhook_url,
-                incoming_call_action="auto_accept",
-                client_websocket_url=ws_url,
-            )
             logger.info(
-                "[Inkbox] Patched phone %s → %s + %s",
-                identity.phone_number.number, webhook_url, ws_url,
+                "[Inkbox] Patched phone %s text subscription → %s",
+                identity.phone_number.number, webhook_url,
+            )
+
+        # Inbound-call config is now IDENTITY-scoped (SDK 0.4.15+): a single
+        # row governs answering for BOTH the dedicated number and any shared
+        # iMessage line that routes to this identity.  ``auto_accept`` tells
+        # Inkbox to pick up the call itself and immediately open a WS to
+        # ``client_websocket_url`` without round-tripping a webhook first —
+        # lower setup latency than ``webhook`` mode, and the call context
+        # arrives on the WS itself via the ``x-call-context`` header (parsed
+        # in ``_handle_call_ws``).  We register whenever the identity can take
+        # a call at all: a dedicated number, iMessage enabled, or both.
+        can_receive_calls = (
+            identity.phone_number is not None
+            or bool(getattr(identity, "imessage_enabled", False))
+        )
+        if can_receive_calls:
+            if hasattr(identity, "set_incoming_call_action"):
+                identity.set_incoming_call_action(
+                    incoming_call_action="auto_accept",
+                    client_websocket_url=ws_url,
+                    incoming_call_webhook_url=webhook_url,
+                )
+            elif identity.phone_number is not None:
+                # Legacy SDKs (<0.4.15) only expose the number-scoped shim,
+                # which cannot configure a shared-iMessage-only identity.
+                self._inkbox.phone_numbers.update(
+                    identity.phone_number.id,
+                    incoming_call_webhook_url=webhook_url,
+                    incoming_call_action="auto_accept",
+                    client_websocket_url=ws_url,
+                )
+            logger.info(
+                "[Inkbox] Patched incoming-call action for identity %s → %s + %s",
+                self._identity_handle, webhook_url, ws_url,
             )
 
         # iMessage: identity-owned subscription, only while the identity is
@@ -3722,20 +3745,18 @@ class InkboxAdapter(BasePlatformAdapter):
             # stay isolated under their own thread.
             if call_id and self._inkbox is not None:
                 try:
-                    identity = await asyncio.to_thread(
-                        self._inkbox.get_identity, self._identity_handle,
+                    # Identity-centered call read (SDK 0.4.15+): a single
+                    # call-id lookup, no owning phone number required — so it
+                    # resolves shared iMessage-line calls too (those have no
+                    # ``phone_number`` on the identity).  Prefer the public
+                    # ``calls`` accessor, fall back to the private ``_calls``.
+                    calls_res = getattr(self._inkbox, "calls", None) or getattr(
+                        self._inkbox, "_calls", None,
                     )
-                    pn_id = getattr(identity.phone_number, "id", None)
-                    if pn_id:
-                        # ``_calls`` is the SDK's private call resource — same
-                        # accessor the legacy phone-bridge used.  Public
-                        # attribute is not yet exposed on Inkbox().
-                        call = await asyncio.to_thread(
-                            self._inkbox._calls.get, pn_id, call_id,
-                        )
-                        direction = (getattr(call, "direction", "") or "").strip().lower()
-                        if not remote:
-                            remote = (getattr(call, "remote_phone_number", "") or "").strip()
+                    call = await asyncio.to_thread(calls_res.get, call_id)
+                    direction = (getattr(call, "direction", "") or "").strip().lower()
+                    if not remote:
+                        remote = (getattr(call, "remote_phone_number", "") or "").strip()
                 except Exception as exc:
                     logger.warning(
                         "[Inkbox] Call lookup failed for call_id=%s: %s", call_id, exc,

--- a/adapter.py
+++ b/adapter.py
@@ -3863,6 +3863,9 @@ class InkboxAdapter(BasePlatformAdapter):
                         "number",
                         None,
                     ) if identity_for_meta is not None else None,
+                    agent_imessage_enabled=bool(
+                        getattr(identity_for_meta, "imessage_enabled", False),
+                    ) if identity_for_meta is not None else False,
                     contact_known=bool(meta.get("contact")),
                     contact_emails=list(rt_contact.get("emails") or []),
                     contact_phones=list(rt_contact.get("phones") or []),

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: inkbox
 label: Inkbox
 kind: platform
-version: 0.2.0
+version: 0.2.2
 description: Inkbox email, SMS/MMS, iMessage, and voice platform plugin for Hermes Agent.
 author: Inkbox
 requires_env: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ description = "Inkbox platform plugin for Hermes Agent"
 requires-python = ">=3.11"
 dependencies = [
   "aiohttp>=3.9",
-  "inkbox>=0.4.15",
+  "inkbox>=0.4.15,<1.0.0",
   "segno>=1.5",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hermes-agent-plugin"
-version = "0.2.1"
+version = "0.2.2"
 description = "Inkbox platform plugin for Hermes Agent"
 # inkbox>=0.4.7 requires Python 3.11+, so we can't claim 3.10 support.
 requires-python = ">=3.11"

--- a/realtime.py
+++ b/realtime.py
@@ -257,6 +257,9 @@ class RealtimeCallMeta:
     agent_identity_handle: Optional[str] = None
     agent_identity_email: Optional[str] = None
     agent_identity_phone: Optional[str] = None
+    # Whether the identity also has the shared Inkbox iMessage line enabled —
+    # lets the spoken prompt draw the dedicated-vs-shared-line distinction.
+    agent_imessage_enabled: bool = False
     # True only when a real Inkbox contact resolved. When false, contact_name
     # may be a raw phone number / "unknown" and must NOT be treated as known.
     contact_known: bool = False
@@ -363,7 +366,19 @@ def build_realtime_instructions(
     if meta.agent_identity_email:
         lines.append(f"Your Inkbox agent email address: {meta.agent_identity_email}.")
     if meta.agent_identity_phone:
-        lines.append(f"Your Inkbox agent phone number: {meta.agent_identity_phone}.")
+        lines.append(
+            f"Your dedicated phone line (your own number, for SMS and voice calls): "
+            f"{meta.agent_identity_phone}.",
+        )
+    if meta.agent_imessage_enabled:
+        lines.append(
+            "You also have a shared Inkbox iMessage line — voice calls and iMessage "
+            "with people connected to you over iMessage. Its number is managed by "
+            "Inkbox: never state or promise a number for it. The current call may be "
+            "running over either line; calls follow the conversation's channel "
+            "(iMessage contacts are called over the shared line, SMS/phone contacts "
+            "over your dedicated number).",
+        )
     if meta.remote_phone_number:
         lines.append(f"Caller is calling from: {meta.remote_phone_number}.")
     if meta.contact_known and meta.contact_name and meta.contact_name not in ("unknown", ""):

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -59,7 +59,7 @@ except Exception:  # pragma: no cover - local tests without Hermes
 
 
 INKBOX_MIN_VERSION = "0.4.15"
-INKBOX_REQUIREMENTS = (f"inkbox>={INKBOX_MIN_VERSION}", "aiohttp>=3.9", "segno>=1.5")
+INKBOX_REQUIREMENTS = (f"inkbox>={INKBOX_MIN_VERSION},<1.0.0", "aiohttp>=3.9", "segno>=1.5")
 _BRACKETED_PASTE_PATTERN = re.compile(r"\x1b\[\s*200~|\x1b\[\s*201~")
 _AVATAR_PATH = Path(__file__).resolve().parent / "assets" / "hermes_with_iphone.png"
 _RAW_AVATAR_BASE_URL_DEFAULT = "https://inkbox.ai"

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -1364,8 +1364,11 @@ def _offer_dedicated_number(client: Any, identity: Any) -> tuple[Any, bool]:
         provisioned = client.phone_numbers.provision(agent_handle=identity.agent_handle, type="local")
         print_success(f"  Provisioned: {provisioned.number}")
     except Exception as exc:
-        print_warning(f"  Phone provisioning failed: {exc}")
-        print_info("  You can provision a number later in the Inkbox console.")
+        # Graceful fallback — most rejections here are plan gating. Point at
+        # pricing and keep the wizard moving; nothing downstream needs a number.
+        print_info("  Dedicated phone numbers are available on Inkbox paid tiers —")
+        print_info("  see https://inkbox.ai/pricing for details.")
+        print_info(f"  (provisioning response: {exc})")
         return identity, False
 
     try:

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -58,7 +58,7 @@ except Exception:  # pragma: no cover - local tests without Hermes
     masked_secret_prompt = None
 
 
-INKBOX_MIN_VERSION = "0.4.10"
+INKBOX_MIN_VERSION = "0.4.15"
 INKBOX_REQUIREMENTS = (f"inkbox>={INKBOX_MIN_VERSION}", "aiohttp>=3.9", "segno>=1.5")
 _BRACKETED_PASTE_PATTERN = re.compile(r"\x1b\[\s*200~|\x1b\[\s*201~")
 _AVATAR_PATH = Path(__file__).resolve().parent / "assets" / "hermes_with_iphone.png"
@@ -1048,7 +1048,6 @@ def _self_signup_flow(base_url: str, Inkbox: Any, InkboxAPIError: Any) -> tuple[
 
     max_attempts = 3
     attempts_used = 0
-    verified = False
     while True:
         attempts_left = max_attempts - attempts_used
         if attempts_left <= 0:
@@ -1074,7 +1073,6 @@ def _self_signup_flow(base_url: str, Inkbox: Any, InkboxAPIError: Any) -> tuple[
                 **inkbox_base_url_kwargs(base_url),
             )
             print_success(f"  Verified - claim status: {verify.claim_status}")
-            verified = True
             break
         except InkboxAPIError as exc:
             attempts_used += 1
@@ -1087,40 +1085,20 @@ def _self_signup_flow(base_url: str, Inkbox: Any, InkboxAPIError: Any) -> tuple[
         except Exception as exc:
             print_error(f"  Verification failed: {exc}")
 
-    provisioned_phone = None
-    if verified:
-        print()
-        print_info("Phone number - optional, but unlocks SMS and voice.")
-        print_info("  We provision a local US number so SMS is supported.")
-        if prompt_yes_no("  Provision a phone number for this agent?", True):
-            try:
-                client = Inkbox(**inkbox_client_kwargs(resp.api_key, base_url))
-                provisioned_phone = client.phone_numbers.provision(agent_handle=resp.agent_handle, type="local")
-                print_success(f"  Provisioned: {provisioned_phone.number}")
-            except InkboxAPIError as exc:
-                print_warning(f"  Phone provisioning failed: HTTP {_error_status(exc)} {_error_detail(exc)}")
-                print_info("  You can provision a number later in the Inkbox console.")
-            except Exception as exc:
-                print_warning(f"  Phone provisioning failed: {exc}")
-
+    # Phone provisioning is decoupled from signup: the wizard offers a
+    # dedicated number as a standalone step AFTER iMessage setup (see
+    # ``interactive_setup``), so a fresh identity starts with no number here.
     class MailboxShim:
         email_address = resp.email_address
         display_name = None
-
-    class PhoneShim:
-        def __init__(self, phone: Any):
-            self.number = phone.number
-            self.type = getattr(phone, "type", "local")
-            self.sms_status = getattr(phone, "sms_status", None)
-            self.id = getattr(phone, "id", None)
 
     class SignupIdentityShim:
         agent_handle = resp.agent_handle
         email_address = resp.email_address
         mailbox = MailboxShim()
-        phone_number = PhoneShim(provisioned_phone) if provisioned_phone else None
+        phone_number = None
 
-    return SignupIdentityShim(), resp.api_key, provisioned_phone is not None
+    return SignupIdentityShim(), resp.api_key, False
 
 
 def _retry_or_abort(retry_label: str, *, error_context: str = "") -> bool:
@@ -1220,8 +1198,7 @@ def _pick_agent_scoped(client: Any, api_key: str) -> tuple[Any | None, str, bool
 
     print()
     print_info(f"  This API key is bound to identity: {identity.agent_handle}")
-    identity, did_provision_phone = _offer_phone_for_existing(client, identity)
-    return identity, api_key, did_provision_phone
+    return identity, api_key, False
 
 
 def _mint_agent_scoped_key(client: Any, identity: Any, InkboxAPIError: Any) -> str | None:
@@ -1285,11 +1262,10 @@ def _pick_admin_scoped(
                 except Exception as exc:
                     print_error(f"  get_identity failed: {exc}")
                     return None, "", False
-            identity, did_provision_phone = _offer_phone_for_existing(client, identity)
             agent_key = _mint_agent_scoped_key(client, identity, InkboxAPIError)
             if agent_key is None:
                 return None, "", False
-            return identity, agent_key, did_provision_phone
+            return identity, agent_key, False
     else:
         print_info("  No identities exist yet under this org. Let's create the first one.")
 
@@ -1333,14 +1309,11 @@ def _create_identity(
 
     display_name = prompt("  Display name for the identity (shown to recipients, optional)").strip()
 
-    print()
-    print_info("Phone number - optional, but unlocks SMS and voice.")
-    print_info("  We provision a local US number so SMS is supported.")
-    create_phone = prompt_yes_no("  Provision a phone number for this agent?", True)
-
-    phone_opts = None
-    if create_phone:
-        phone_opts = IdentityPhoneNumberCreateOptions(type="local", incoming_call_action="auto_reject")
+    # Phone provisioning is decoupled from creation: the wizard offers a
+    # dedicated number as a standalone step AFTER iMessage setup (see
+    # ``interactive_setup``).  ``IdentityPhoneNumberCreateOptions`` is kept in
+    # the signature for call-site compatibility but no longer used here.
+    del IdentityPhoneNumberCreateOptions
 
     print()
     print_info("Creating identity...")
@@ -1349,7 +1322,7 @@ def _create_identity(
             identity = client.create_identity(
                 handle,
                 display_name=display_name or None,
-                phone_number=phone_opts,
+                phone_number=None,
             )
             break
         except HandleUnavailableError as exc:
@@ -1366,18 +1339,25 @@ def _create_identity(
             return None, "", False
 
     print_success(f"  Created identity '{identity.agent_handle}'")
-    did_provision_phone = create_phone and getattr(identity, "phone_number", None) is not None
-    return identity, "", did_provision_phone
+    return identity, "", False
 
 
-def _offer_phone_for_existing(client: Any, identity: Any) -> tuple[Any, bool]:
+def _offer_dedicated_number(client: Any, identity: Any) -> tuple[Any, bool]:
+    """Offer to provision a dedicated phone number (SMS + voice).
+
+    Runs as a standalone step AFTER iMessage setup so the wizard walks
+    channels in a natural order: connect over iMessage first, then add a
+    dedicated number.  Returns ``(possibly-refreshed identity, provisioned?)``;
+    a no-op when the identity already has a number.
+    """
     if getattr(identity, "phone_number", None) is not None:
         return identity, False
 
     print()
-    print_info("  This agent has no phone number attached.")
-    print_info("  A local US number unlocks SMS and voice for this agent.")
-    if not prompt_yes_no("  Provision a local phone number now?", True):
+    print(color("  --- Dedicated phone number ---", Colors.CYAN))
+    print_info("  A local US number gives this agent its own line for SMS and voice.")
+    if not prompt_yes_no("  Provision a dedicated phone number now?", True):
+        print_info("  Skipped. Rerun `hermes inkbox setup` anytime to add a number.")
         return identity, False
 
     try:
@@ -1485,11 +1465,11 @@ def interactive_setup() -> None:
     has_key = prompt_yes_no("  Do you already have an Inkbox API key?", False)
 
     if not has_key:
-        identity, api_key, did_provision_phone = _self_signup_flow(base_url, Inkbox, InkboxAPIError)
+        identity, api_key, _ = _self_signup_flow(base_url, Inkbox, InkboxAPIError)
         if identity is None:
             return
     else:
-        identity, api_key, did_provision_phone = _api_key_flow(
+        identity, api_key, _ = _api_key_flow(
             base_url,
             Inkbox,
             InkboxAPIError,
@@ -1515,6 +1495,20 @@ def interactive_setup() -> None:
     print_info("  https://console.inkbox.ai -> Mailboxes / Phone Numbers -> Contact Rules")
     print_info("Anyone Inkbox lets through reaches the agent. No second allowlist to maintain.")
 
+    # Channels, in the order we want operators to think about them: connect
+    # over iMessage FIRST (no number to provision — you reach the agent through
+    # the shared Inkbox iMessage router), THEN offer a dedicated phone number
+    # for SMS + voice.  Provisioning is decoupled from identity creation so this
+    # ordering holds across every entry path (signup, admin, agent-scoped).
+    _configure_imessage(api_key, base_url, identity.agent_handle, Inkbox)
+
+    did_provision_phone = False
+    try:
+        dedicated_client = Inkbox(**inkbox_client_kwargs(api_key, base_url))
+        identity, did_provision_phone = _offer_dedicated_number(dedicated_client, identity)
+    except Exception as exc:
+        print_warning(f"  Skipping dedicated-number setup: {exc}")
+
     _seed_identity_state(identity)
     _print_agent_summary(identity)
 
@@ -1525,8 +1519,6 @@ def interactive_setup() -> None:
         _wait_for_sms_opt_in(api_key, base_url, getattr(identity, "phone_number", None), Inkbox)
 
     _configure_realtime_calls(identity)
-
-    _configure_imessage(api_key, base_url, identity.agent_handle, Inkbox)
 
     _setup_signing_key(api_key, base_url, Inkbox)
 

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -506,9 +506,11 @@ def _test_openai_realtime_api_key(api_key: str, model: str = OPENAI_REALTIME_TES
         return False, f"Could not run Realtime validation from this setup process: {exc}"
 
 
-def _configure_realtime_calls(identity: Any) -> None:
+def _configure_realtime_calls(identity: Any, *, imessage_enabled: bool = False) -> None:
+    # Calls can arrive over the dedicated number OR the shared iMessage line,
+    # so offer realtime whenever either exists.
     phone = getattr(identity, "phone_number", None)
-    if phone is None:
+    if phone is None and not imessage_enabled:
         return
 
     print()
@@ -757,7 +759,7 @@ def _configure_avatar(base_url: str, api_key: str, identity: Any, *, is_signup: 
         print_info("  You can set one later in the Inkbox console.")
 
 
-def _configure_imessage(api_key: str, base_url: str, handle: str, Inkbox: Any) -> None:
+def _configure_imessage(api_key: str, base_url: str, handle: str, Inkbox: Any) -> bool:
     """Offer to enable iMessage for the agent and walk through connecting.
 
     Args:
@@ -767,39 +769,42 @@ def _configure_imessage(api_key: str, base_url: str, handle: str, Inkbox: Any) -
         Inkbox (Any): The Inkbox SDK client class.
 
     Returns:
-        None: Prints progress; failures degrade to a warning and return.
+        bool: True when iMessage ended up enabled (newly or already), so the
+        caller can gate iMessage-dependent steps like realtime calling.
     """
     print()
     print(color("  --- iMessage ---", Colors.CYAN))
     print_info("  Inkbox can make this agent reachable over iMessage from your iPhone.")
     print_info("  No number to provision — you connect through the Inkbox iMessage router.")
+    print_info("  Once connected, the agent can also make and take voice calls with you")
+    print_info("  over that same shared iMessage line.")
 
     try:
         client = Inkbox(**inkbox_client_kwargs(api_key, base_url))
         identity = client.get_identity(handle)
     except Exception as exc:
         print_warning(f"  Could not load the identity for iMessage setup: {exc}")
-        return
+        return False
 
     # Old SDKs predate iMessage entirely — detect by surface, not version.
     if not hasattr(client, "imessages") or not hasattr(identity, "imessage_enabled"):
         print_warning("  The installed Inkbox SDK does not support iMessage yet.")
         print_info("  Upgrade it and rerun setup:")
         print_info(f"    {_install_command_text()}")
-        return
+        return False
 
     if identity.imessage_enabled:
         print_success("  iMessage is already enabled for this agent.")
     else:
         if not prompt_yes_no("  Enable iMessage for this agent?", True):
             print_info("  Skipped. Rerun `hermes inkbox setup` anytime to enable iMessage.")
-            return
+            return False
         try:
             identity.update(imessage_enabled=True)
         except Exception as exc:
             print_error(f"  Could not enable iMessage: {exc}")
             print_info("  You can enable it later from the Inkbox console and rerun setup.")
-            return
+            return False
         print_success("  iMessage enabled for this agent.")
         try:
             # Re-fetch so the local object reflects the new flag (the SDK
@@ -807,7 +812,7 @@ def _configure_imessage(api_key: str, base_url: str, handle: str, Inkbox: Any) -
             identity = client.get_identity(handle)
         except Exception as exc:
             print_warning(f"  Could not refresh the identity after enabling: {exc}")
-            return
+            return True
 
     # Surface phones already connected through the router so reruns don't
     # read like a first-time setup, and default the walkthrough off when a
@@ -832,8 +837,9 @@ def _configure_imessage(api_key: str, base_url: str, handle: str, Inkbox: Any) -
     )
     if not prompt_yes_no(question, not connected):
         print_info("  You can connect anytime — rerun `hermes inkbox setup` for the walkthrough.")
-        return
+        return True
     _wait_for_imessage_first_message(client, identity, handle)
+    return True
 
 
 def _wait_for_imessage_first_message(client: Any, identity: Any, handle: str) -> None:
@@ -1350,7 +1356,12 @@ def _offer_dedicated_number(client: Any, identity: Any) -> tuple[Any, bool]:
     dedicated number.  Returns ``(possibly-refreshed identity, provisioned?)``;
     a no-op when the identity already has a number.
     """
-    if getattr(identity, "phone_number", None) is not None:
+    existing = getattr(identity, "phone_number", None)
+    if existing is not None:
+        # Say so instead of silently skipping — otherwise the step looks lost.
+        print()
+        print(color("  --- Dedicated phone number ---", Colors.CYAN))
+        print_success(f"  Already provisioned: {existing.number}")
         return identity, False
 
     print()
@@ -1503,7 +1514,7 @@ def interactive_setup() -> None:
     # the shared Inkbox iMessage router), THEN offer a dedicated phone number
     # for SMS + voice.  Provisioning is decoupled from identity creation so this
     # ordering holds across every entry path (signup, admin, agent-scoped).
-    _configure_imessage(api_key, base_url, identity.agent_handle, Inkbox)
+    imessage_on = _configure_imessage(api_key, base_url, identity.agent_handle, Inkbox)
 
     did_provision_phone = False
     try:
@@ -1521,7 +1532,7 @@ def interactive_setup() -> None:
     if did_provision_phone:
         _wait_for_sms_opt_in(api_key, base_url, getattr(identity, "phone_number", None), Inkbox)
 
-    _configure_realtime_calls(identity)
+    _configure_realtime_calls(identity, imessage_enabled=imessage_on)
 
     _setup_signing_key(api_key, base_url, Inkbox)
 

--- a/skills/inkbox-imessage-responder/SKILL.md
+++ b/skills/inkbox-imessage-responder/SKILL.md
@@ -15,7 +15,7 @@ The Inkbox plugin makes this agent reachable over iMessage. Unlike SMS, the agen
 - **Recipient-first:** the agent cannot message anyone over iMessage until that person has messaged it first. There is no cold outreach on this channel. If an outbound send returns a 409-style error saying the recipient hasn't messaged yet or is no longer connected, tell the user the person needs to (re)connect and send a message first.
 - If someone asks "how do I iMessage you?", answer with the router number and connect command from `inkbox_imessage_triage_number`.
 
-## Calling someone on iMessage
+## Calling someone on iMessage Shared Line
 
 If a person you're connected to over iMessage asks you to call them (or you decide to call), place the call over the **shared iMessage line** — the same line you're already messaging them on — with `inkbox_place_call` and `origination: "shared_imessage_number"`. Because the current conversation is on iMessage, that's already the default line, but set it explicitly to be sure. Do **not** call an iMessage contact from your dedicated phone number; they reach you on iMessage, and shared-line calling only works while they stay connected. If the call is refused because they aren't connected, ask them to reconnect over iMessage first (or, only if you have their number for that purpose, call your dedicated line instead).
 

--- a/skills/inkbox-imessage-responder/SKILL.md
+++ b/skills/inkbox-imessage-responder/SKILL.md
@@ -15,6 +15,10 @@ The Inkbox plugin makes this agent reachable over iMessage. Unlike SMS, the agen
 - **Recipient-first:** the agent cannot message anyone over iMessage until that person has messaged it first. There is no cold outreach on this channel. If an outbound send returns a 409-style error saying the recipient hasn't messaged yet or is no longer connected, tell the user the person needs to (re)connect and send a message first.
 - If someone asks "how do I iMessage you?", answer with the router number and connect command from `inkbox_imessage_triage_number`.
 
+## Calling someone on iMessage
+
+If a person you're connected to over iMessage asks you to call them (or you decide to call), place the call over the **shared iMessage line** — the same line you're already messaging them on — with `inkbox_place_call` and `origination: "shared_imessage_number"`. Because the current conversation is on iMessage, that's already the default line, but set it explicitly to be sure. Do **not** call an iMessage contact from your dedicated phone number; they reach you on iMessage, and shared-line calling only works while they stay connected. If the call is refused because they aren't connected, ask them to reconnect over iMessage first (or, only if you have their number for that purpose, call your dedicated line instead).
+
 ## Required tools
 
 - `inkbox_list_imessage_conversations` — start here for triage; returns conversation IDs, latest-message previews, unread counts, and assignment status

--- a/skills/inkbox-outbound-calling/SKILL.md
+++ b/skills/inkbox-outbound-calling/SKILL.md
@@ -24,9 +24,11 @@ already talking to the person on:
   number or ask them to message you on iMessage first. The agent never sees or
   chooses the underlying shared number — Inkbox resolves it from the connection.
 
-If only one path is available (you have just a number, or just iMessage), you
-can omit `origination` and it resolves automatically. When both are available,
-set it explicitly to match the conversation's channel.
+If you omit `origination`, it resolves automatically: to whichever line is the
+only one available, or — when both are available — to the line matching the
+conversation you're currently on (an iMessage turn calls over the shared
+iMessage line; an SMS/phone turn calls over the dedicated number). Set it
+explicitly only to override that default.
 
 ## Optional tool
 
@@ -39,7 +41,7 @@ set it explicitly to match the conversation's channel.
 3. Call `inkbox_place_call` with:
    - `to_number`
    - `purpose` — required. Include the reason/topic the user gave; if none was given, say the user asked for a general call.
-   - `origination` — set to match the channel when both paths are available; omit to auto-resolve when only one is.
+   - `origination` — usually omit it; it auto-follows the conversation's channel (and the only available line). Set it explicitly only to override.
    - `opening_message` — include when the user told you what to say first.
    - `context` — concise background the voice agent may need during the call.
 4. Do not invent or request `client_websocket_url`; the plugin supplies the active Inkbox call bridge when the channel gateway is running.

--- a/skills/inkbox-outbound-calling/SKILL.md
+++ b/skills/inkbox-outbound-calling/SKILL.md
@@ -6,22 +6,44 @@ user-invocable: false
 
 # Inkbox outbound calling
 
-Use this skill when the user asks you to call someone from the configured Inkbox phone number.
+Use this skill when the user asks you to call someone.
+
+## Two calling paths
+
+A call can go out over one of two lines. Match the line to the channel you're
+already talking to the person on:
+
+- **Your dedicated number** (`origination: "dedicated_number"`) — the agent's
+  own phone number, the same line SMS and voice conversations use. Use this to
+  call anyone reachable by phone, and whenever you're continuing a phone/SMS
+  conversation.
+- **The shared Inkbox iMessage line** (`origination: "shared_imessage_number"`)
+  — call someone over the shared iMessage line you're already messaging them
+  on. This only works if that person is connected to you over iMessage; if they
+  aren't, the call is rejected and you should either fall back to your dedicated
+  number or ask them to message you on iMessage first. The agent never sees or
+  chooses the underlying shared number — Inkbox resolves it from the connection.
+
+If only one path is available (you have just a number, or just iMessage), you
+can omit `origination` and it resolves automatically. When both are available,
+set it explicitly to match the conversation's channel.
 
 ## Optional tool
 
-- `inkbox_place_call` — place an outbound call from the configured Inkbox identity.
+- `inkbox_place_call` — place an outbound call over either line.
 
 ## Workflow
 
 1. Resolve the recipient to an E.164 phone number. If the user names a contact, use Inkbox contact lookup tools first.
-2. Call `inkbox_place_call` with:
-   - `toNumber`
+2. Decide the line: are you continuing an iMessage conversation (use the shared iMessage line) or a phone/SMS conversation, or calling someone new (use your dedicated number)?
+3. Call `inkbox_place_call` with:
+   - `to_number`
    - `purpose` — required. Include the reason/topic the user gave; if none was given, say the user asked for a general call.
-   - `openingMessage` — include when the user told you what to say first.
+   - `origination` — set to match the channel when both paths are available; omit to auto-resolve when only one is.
+   - `opening_message` — include when the user told you what to say first.
    - `context` — concise background the voice agent may need during the call.
-3. Do not invent or request `clientWebsocketUrl`; the plugin supplies the active Inkbox call bridge when the channel gateway is running.
-4. When the callee answers, the call session starts with the supplied purpose/context instead of a generic greeting.
+4. Do not invent or request `client_websocket_url`; the plugin supplies the active Inkbox call bridge when the channel gateway is running.
+5. When the callee answers, the call session starts with the supplied purpose/context instead of a generic greeting.
 
 ## Follow-ups
 

--- a/skills/inkbox-sms-responder/SKILL.md
+++ b/skills/inkbox-sms-responder/SKILL.md
@@ -29,6 +29,10 @@ The Inkbox plugin gives you a working phone number under an agent identity. Use 
 
 4. **Mark as handled** if you have the optional tool allowlisted: `inkbox_mark_text_conversation_read` with `conversationId`.
 
+## Calling someone on SMS
+
+If someone in an SMS/text conversation asks you to call them (or you decide to), place the call from your **dedicated phone line** — the same number this conversation is on — with `inkbox_place_call` and `origination: "dedicated_number"`. That's already the default for a phone/SMS conversation, but set it explicitly to be sure. (The shared iMessage line is only for people connected over iMessage.)
+
 ## Gates and errors
 
 - **Opt-in required.** Recipients must have texted `START` to one of your Inkbox numbers. If they haven't, `inkbox_send_sms` returns the plain-language error "Recipient has not opted in to SMS." Surface this to the user; do not try to bypass.

--- a/tests/test_place_call_origination.py
+++ b/tests/test_place_call_origination.py
@@ -1,0 +1,63 @@
+"""Outbound-call line resolution: explicit choice, capability fallback, and
+channel-aware defaulting when the identity has BOTH a dedicated number and
+iMessage enabled.
+
+Regression guard for the bug where an agent on an iMessage conversation asked
+to "call me" and the call went out over the dedicated number instead of the
+shared iMessage line.
+"""
+
+import types
+
+import tools
+
+
+def _identity(has_number: bool, imessage: bool):
+    return types.SimpleNamespace(
+        phone_number=types.SimpleNamespace(number="+15550000000") if has_number else None,
+        imessage_enabled=imessage,
+    )
+
+
+def _set_channel(monkeypatch, thread_id):
+    # _current_channel_hint reads the host session var, falling back to
+    # os.environ when the gateway isn't present (as in tests).
+    if thread_id is None:
+        monkeypatch.delenv("HERMES_SESSION_THREAD_ID", raising=False)
+    else:
+        monkeypatch.setenv("HERMES_SESSION_THREAD_ID", thread_id)
+
+
+def test_single_line_resolves_unambiguously(monkeypatch):
+    _set_channel(monkeypatch, None)
+    assert tools._resolve_call_origination(_identity(True, False), "") == "dedicated_number"
+    assert tools._resolve_call_origination(_identity(False, True), "") == "shared_imessage_number"
+    assert tools._resolve_call_origination(_identity(False, False), "") is None
+
+
+def test_explicit_choice_wins_over_channel(monkeypatch):
+    _set_channel(monkeypatch, "imessage:conv")
+    assert tools._resolve_call_origination(_identity(True, True), "dedicated_number") == "dedicated_number"
+    _set_channel(monkeypatch, "sms:conv")
+    assert tools._resolve_call_origination(_identity(True, True), "shared_imessage_number") == "shared_imessage_number"
+
+
+def test_both_lines_follow_conversation_channel(monkeypatch):
+    both = _identity(True, True)
+    _set_channel(monkeypatch, "imessage:conv-1")
+    assert tools._resolve_call_origination(both, "") == "shared_imessage_number"
+    _set_channel(monkeypatch, "sms:conv-1")
+    assert tools._resolve_call_origination(both, "") == "dedicated_number"
+    _set_channel(monkeypatch, "phone:conv-1")
+    assert tools._resolve_call_origination(both, "") == "dedicated_number"
+
+
+def test_both_lines_unknown_channel_defaults_dedicated(monkeypatch):
+    _set_channel(monkeypatch, None)
+    assert tools._resolve_call_origination(_identity(True, True), "") == "dedicated_number"
+
+
+def test_channel_only_breaks_ties(monkeypatch):
+    # An iMessage-only identity stays shared even on an SMS-looking thread.
+    _set_channel(monkeypatch, "sms:conv")
+    assert tools._resolve_call_origination(_identity(False, True), "") == "shared_imessage_number"

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -26,7 +26,7 @@ def test_install_command_prefers_uv_when_available(monkeypatch):
         "install",
         "--python",
         "/tmp/hermes/venv/bin/python",
-        "inkbox>=0.4.15",
+        "inkbox>=0.4.15,<1.0.0",
         "aiohttp>=3.9",
         "segno>=1.5",
     ]]
@@ -37,10 +37,10 @@ def test_install_command_falls_back_to_pip_and_ensurepip(monkeypatch):
     monkeypatch.setattr(setup_wizard.shutil, "which", lambda _name: None)
 
     assert setup_wizard._install_commands() == [
-        [["/tmp/hermes/venv/bin/python", "-m", "pip", "install", "inkbox>=0.4.15", "aiohttp>=3.9", "segno>=1.5"]],
+        [["/tmp/hermes/venv/bin/python", "-m", "pip", "install", "inkbox>=0.4.15,<1.0.0", "aiohttp>=3.9", "segno>=1.5"]],
         [
             ["/tmp/hermes/venv/bin/python", "-m", "ensurepip", "--upgrade"],
-            ["/tmp/hermes/venv/bin/python", "-m", "pip", "install", "inkbox>=0.4.15", "aiohttp>=3.9", "segno>=1.5"],
+            ["/tmp/hermes/venv/bin/python", "-m", "pip", "install", "inkbox>=0.4.15,<1.0.0", "aiohttp>=3.9", "segno>=1.5"],
         ],
     ]
 
@@ -59,7 +59,7 @@ def test_missing_sdk_guidance_prints_hermes_python(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "/tmp/hermes/venv/bin/python" in out
     assert "uv pip install --python" in out
-    assert "inkbox>=0.4.15" in out
+    assert "inkbox>=0.4.15,<1.0.0" in out
     assert "aiohttp>=3.9" in out
 
 

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -26,7 +26,7 @@ def test_install_command_prefers_uv_when_available(monkeypatch):
         "install",
         "--python",
         "/tmp/hermes/venv/bin/python",
-        "inkbox>=0.4.10",
+        "inkbox>=0.4.15",
         "aiohttp>=3.9",
         "segno>=1.5",
     ]]
@@ -37,10 +37,10 @@ def test_install_command_falls_back_to_pip_and_ensurepip(monkeypatch):
     monkeypatch.setattr(setup_wizard.shutil, "which", lambda _name: None)
 
     assert setup_wizard._install_commands() == [
-        [["/tmp/hermes/venv/bin/python", "-m", "pip", "install", "inkbox>=0.4.10", "aiohttp>=3.9", "segno>=1.5"]],
+        [["/tmp/hermes/venv/bin/python", "-m", "pip", "install", "inkbox>=0.4.15", "aiohttp>=3.9", "segno>=1.5"]],
         [
             ["/tmp/hermes/venv/bin/python", "-m", "ensurepip", "--upgrade"],
-            ["/tmp/hermes/venv/bin/python", "-m", "pip", "install", "inkbox>=0.4.10", "aiohttp>=3.9", "segno>=1.5"],
+            ["/tmp/hermes/venv/bin/python", "-m", "pip", "install", "inkbox>=0.4.15", "aiohttp>=3.9", "segno>=1.5"],
         ],
     ]
 
@@ -59,7 +59,7 @@ def test_missing_sdk_guidance_prints_hermes_python(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "/tmp/hermes/venv/bin/python" in out
     assert "uv pip install --python" in out
-    assert "inkbox>=0.4.10" in out
+    assert "inkbox>=0.4.15" in out
     assert "aiohttp>=3.9" in out
 
 

--- a/tools.py
+++ b/tools.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import os
 import secrets
 import time
 from pathlib import Path
@@ -146,11 +147,32 @@ def inkbox_whoami(args: dict, **kwargs) -> str:
     del args, kwargs
     try:
         cfg, client, identity = _client_and_identity()
+        # Present the two lines with explicit labels so the agent describes
+        # them correctly: its OWN dedicated phone line vs the SHARED iMessage
+        # line. The dedicated number is the one for SMS + voice; the iMessage
+        # line's number is managed by Inkbox and never surfaced.
+        phone = getattr(identity, "phone_number", None)
+        dedicated_number = getattr(phone, "number", None) if phone else None
+        imessage_enabled = bool(getattr(identity, "imessage_enabled", False))
+        lines = {
+            "dedicated_phone_line": dedicated_number or "(none provisioned)",
+            "dedicated_phone_line_note": (
+                "Your own phone line for SMS and voice calls. Call from it with "
+                "origination=dedicated_number."
+            ),
+            "shared_imessage_line": "enabled" if imessage_enabled else "disabled",
+            "shared_imessage_line_note": (
+                "Voice + iMessage with people connected to you over iMessage. Its "
+                "number is managed by Inkbox and not shown. Call over it with "
+                "origination=shared_imessage_number."
+            ),
+        }
         return _json({
             "ok": True,
             "base_url": cfg.base_url,
             "whoami": object_summary(client.whoami()),
             "identity": object_summary(identity),
+            "lines": lines,
             "call_websocket_url": public_call_ws_url(cfg, identity),
         })
     except Exception as exc:
@@ -725,23 +747,61 @@ def inkbox_mark_imessage_conversation_read(args: dict, **kwargs) -> str:
         return _json({"error": str(exc)})
 
 
+def _current_channel_hint() -> str | None:
+    """Which Inkbox channel is the current agent turn happening on?
+
+    The gateway stamps each inbound turn with a session thread-id; iMessage
+    turns are ``imessage:<cid>`` and SMS/phone turns are ``sms:``/``text:``/
+    ``phone:<cid>``.  We read that (concurrency-safe, per-turn) so an outbound
+    call can follow the conversation's channel without the agent having to say
+    so.  Returns ``"imessage"`` | ``"dedicated"`` | ``None`` (unknown / not in
+    a gateway turn, e.g. CLI or tests).
+    """
+    thread_id = ""
+    try:
+        # Host-provided per-turn context var (falls back to os.environ for
+        # CLI/cron).  Imported lazily + guarded so the plugin still works
+        # standalone (unit tests, non-gateway hosts).
+        from gateway.session_context import get_session_env
+
+        thread_id = get_session_env("HERMES_SESSION_THREAD_ID", "") or ""
+    except Exception:
+        thread_id = os.environ.get("HERMES_SESSION_THREAD_ID", "") or ""
+    t = thread_id.strip().lower()
+    if t.startswith("imessage:"):
+        return "imessage"
+    if t.startswith(("sms:", "text:", "phone:")):
+        return "dedicated"
+    return None
+
+
 def _resolve_call_origination(identity, explicit: str) -> str | None:
     """Pick which line an outbound call originates from.
 
     Calls can go out over two paths: the agent's own ``dedicated_number`` or
     the ``shared_imessage_number`` it's already messaging the recipient on.
-    An explicit choice (from the agent, matching the conversation's channel)
-    always wins.  Otherwise we auto-resolve only when the choice is
-    unambiguous — a dedicated number but no iMessage → dedicated; iMessage
-    enabled but no number → shared.  When BOTH are available and the agent
-    didn't say, default to the dedicated number (the open line that can reach
-    anyone).  Returns ``None`` when neither path exists (nothing to call from).
+    Resolution order:
+
+    1. An explicit choice (from the agent) always wins.
+    2. If only one path exists, use it (dedicated number but no iMessage →
+       dedicated; iMessage enabled but no number → shared).
+    3. If BOTH exist, follow the channel the current conversation is on — an
+       iMessage turn calls over the shared iMessage line, an SMS/phone turn
+       over the dedicated number.  This makes "call me" do the right thing
+       without the agent having to specify the line.
+    4. If both exist but we can't tell the channel, default to the dedicated
+       number (the open line that can reach anyone).
+
+    Returns ``None`` when neither path exists (nothing to call from).
     """
     explicit = (explicit or "").strip().lower()
     if explicit in {"dedicated_number", "shared_imessage_number"}:
         return explicit
     has_number = getattr(identity, "phone_number", None) is not None
     imessage_enabled = bool(getattr(identity, "imessage_enabled", False))
+    if has_number and imessage_enabled:
+        # Both lines available — follow the conversation's channel.
+        return "shared_imessage_number" if _current_channel_hint() == "imessage" else "dedicated_number"
     if has_number:
         return "dedicated_number"
     if imessage_enabled:

--- a/tools.py
+++ b/tools.py
@@ -725,6 +725,30 @@ def inkbox_mark_imessage_conversation_read(args: dict, **kwargs) -> str:
         return _json({"error": str(exc)})
 
 
+def _resolve_call_origination(identity, explicit: str) -> str | None:
+    """Pick which line an outbound call originates from.
+
+    Calls can go out over two paths: the agent's own ``dedicated_number`` or
+    the ``shared_imessage_number`` it's already messaging the recipient on.
+    An explicit choice (from the agent, matching the conversation's channel)
+    always wins.  Otherwise we auto-resolve only when the choice is
+    unambiguous — a dedicated number but no iMessage → dedicated; iMessage
+    enabled but no number → shared.  When BOTH are available and the agent
+    didn't say, default to the dedicated number (the open line that can reach
+    anyone).  Returns ``None`` when neither path exists (nothing to call from).
+    """
+    explicit = (explicit or "").strip().lower()
+    if explicit in {"dedicated_number", "shared_imessage_number"}:
+        return explicit
+    has_number = getattr(identity, "phone_number", None) is not None
+    imessage_enabled = bool(getattr(identity, "imessage_enabled", False))
+    if has_number:
+        return "dedicated_number"
+    if imessage_enabled:
+        return "shared_imessage_number"
+    return None
+
+
 def inkbox_place_call(args: dict, **kwargs) -> str:
     del kwargs
     try:
@@ -735,6 +759,13 @@ def inkbox_place_call(args: dict, **kwargs) -> str:
             return _json({"error": "`to_number` is required"})
         if not purpose:
             return _json({"error": "`purpose` is required so the live call starts with the right context"})
+
+        # Resolve the outbound line (dedicated number vs shared iMessage line).
+        origination = _resolve_call_origination(
+            identity, args.get("origination") or args.get("origination_type") or "",
+        )
+        if origination is None:
+            return _json({"error": "This identity can't place calls: it has no dedicated phone number and iMessage is not enabled. Provision a number or enable iMessage first."})
 
         ws_url = str(args.get("client_websocket_url") or args.get("clientWebsocketUrl") or "").strip()
         if not ws_url:
@@ -751,22 +782,39 @@ def inkbox_place_call(args: dict, **kwargs) -> str:
         decorated_ws_url = _append_query_param(ws_url, "context_token", token)
 
         def _place():
-            if hasattr(identity, "place_call"):
-                try:
-                    return identity.place_call(to_number=to_number, client_websocket_url=decorated_ws_url)
-                except TypeError:
-                    return identity.place_call({"to_number": to_number, "client_websocket_url": decorated_ws_url})
-            if hasattr(identity, "placeCall"):
-                return identity.placeCall({"toNumber": to_number, "clientWebsocketUrl": decorated_ws_url})
-            raise RuntimeError("Inkbox SDK identity has no place_call method")
+            if not hasattr(identity, "place_call"):
+                raise RuntimeError("Inkbox SDK identity has no place_call method (upgrade inkbox to >=0.4.15)")
+            try:
+                return identity.place_call(
+                    to_number=to_number,
+                    origination=origination,
+                    client_websocket_url=decorated_ws_url,
+                )
+            except TypeError:
+                # Older SDK without ``origination`` support → dedicated only.
+                return identity.place_call(
+                    to_number=to_number,
+                    client_websocket_url=decorated_ws_url,
+                )
 
-        call = _place()
+        try:
+            call = _place()
+        except Exception as exc:  # noqa: BLE001 — surface a legible reason to the agent
+            msg = str(exc)
+            if "no_shared_connection" in msg:
+                return _json({
+                    "error": "Can't place a shared iMessage-line call: this person isn't connected to you over iMessage yet. They need to message your iMessage number first. To call from your own phone number instead, set origination to \"dedicated_number\".",
+                    "detail": msg,
+                })
+            return _json({"error": msg})
+
         rate = object_summary(getattr(call, "rate_limit", None) or getattr(call, "rateLimit", None))
         return _json({
             "ok": True,
             "call_id": str(getattr(call, "id", "")),
             "status": object_summary(getattr(call, "status", None)),
             "to_number": to_number,
+            "origination": origination,
             "context_token": token,
             "rate_limit": rate,
         })
@@ -1103,12 +1151,31 @@ MARK_IMESSAGE_CONVERSATION_READ_SCHEMA = {
 
 PLACE_CALL_SCHEMA = {
     "name": "inkbox_place_call",
-    "description": "Place an outbound call from the configured Inkbox identity phone number. Always include purpose.",
+    "description": (
+        "Place an outbound voice call. Calls can go out over two lines: your "
+        "own dedicated phone number, or the shared Inkbox iMessage line you are "
+        "already messaging the recipient on. Match the channel you're talking on "
+        "— call SMS/phone contacts from your dedicated number, and call an "
+        "iMessage contact over the shared iMessage line (set `origination` "
+        "accordingly). Always include purpose."
+    ),
     "parameters": {
         "type": "object",
         "properties": {
             "to_number": {"type": "string", "description": "Recipient phone number in E.164 format."},
             "purpose": {"type": "string", "description": "Why the call is being placed; loaded into the live call before greeting."},
+            "origination": {
+                "type": "string",
+                "enum": ["dedicated_number", "shared_imessage_number"],
+                "description": (
+                    "Which line to call from. Use \"dedicated_number\" to call from your own "
+                    "phone number (the same line SMS/voice conversations use). Use "
+                    "\"shared_imessage_number\" to call someone over the shared iMessage line you "
+                    "are already messaging them on — this only works if they are connected to you "
+                    "over iMessage (otherwise the call is rejected). If omitted, it is resolved "
+                    "automatically when only one path is available."
+                ),
+            },
             "opening_message": {"type": "string", "description": "Optional first thing to say when the call connects."},
             "context": {"type": "string", "description": "Optional concise background for the voice agent."},
             "client_websocket_url": {"type": "string", "description": "Optional explicit call media WebSocket URL."},


### PR DESCRIPTION
Adds a second calling path — over the shared Inkbox iMessage line — alongside the agent's dedicated number. Rebased onto `main`, which already carries the inkbox SDK 0.4.15 adoption (#37), so this PR is now scoped to the **shared-line calling feature** only.

## The two calling lines
An agent can place and receive voice calls over either:
- **Its dedicated number** — the agent's own line (same one SMS uses).
- **The shared Inkbox iMessage line** — voice with someone it's already connected to over iMessage. The underlying number is never surfaced (Inkbox resolves it from the connection); only works for connected people (unknown inbound callers are rejected, and an outbound call with no connection is refused).

The agent picks the line to match the channel it's conversing on.

## Outbound (`tools.py`)
`inkbox_place_call` gains `origination` (`dedicated_number` | `shared_imessage_number`):
- Explicit choice wins.
- Otherwise auto-resolves: to the only enabled line, or — when BOTH are enabled — to the line matching the **conversation's channel** (read deterministically from the host's per-turn `HERMES_SESSION_THREAD_ID`: an iMessage turn calls over the shared iMessage line, an SMS/phone turn over the dedicated number). Unknown channel falls back to the dedicated line. This fixes an agent on iMessage dialing out over the dedicated number.
- `409 no_shared_connection` returns a legible message telling the agent to fall back to its own number or ask the person to message it on iMessage first.

## Inbound (`adapter.py`)
- Inbound-call config moves from the number-scoped `phone_numbers.update` shim to identity-scoped `set_incoming_call_action`. One `auto_accept` row now governs **both** the dedicated number and any shared iMessage line, and a shared-only identity (no dedicated number) can finally be configured at all.
- Call-context lookup switches to the identity-centered `calls.get(call_id)`. The old number-scoped `_calls.get(pn_id, call_id)` was removed in 0.4.15 **and** skipped shared calls (which have no owning number) — this also fixes a latent break left on `main`.

## Wizard (`setup_wizard.py`)
Phone provisioning is decoupled from identity creation, so the wizard walks channels in order — **iMessage first, then a standalone dedicated-number step** — consistently across signup, admin, and agent-scoped entry paths. If number provisioning fails (e.g. plan gating), the wizard prints a paid-tier pointer to https://inkbox.ai/pricing and moves on. The iMessage section notes that connected people can also make/take voice calls over the shared line; the OpenAI-Realtime step is offered when the identity has a dedicated number OR iMessage enabled (calls arrive over either line); and an identity that already owns a number gets an explicit “Already provisioned” line instead of a silent skip. Also bumps `INKBOX_MIN_VERSION` to 0.4.15 (the runtime gate `main` left at 0.4.10).

## Docs
The `inkbox-outbound-calling` skill and the README explain the two lines. The realtime (voice) system prompt now also names the two lines — the dedicated phone line vs the shared iMessage line (whose number is never spoken) — via a new `RealtimeCallMeta.agent_imessage_enabled` field. `inkbox_whoami` now returns an explicit `lines` block (`dedicated_phone_line` vs `shared_imessage_line`), and the SMS/iMessage responder skills state which line calls use in that channel, so the agent describes and picks the right one.

## Version
Plugin `0.2.1` → `0.2.2`.

## Notes
- Rebased onto `main` (was stacked on #33). The capability-map "calls" summary lives in #33's `realtime.py`, which isn't on `main` yet — its one-line update to mention shared calling should ride along when #33 lands (or a quick follow-up).
- Full unit suite green (170 passed); wizard ordering and outbound origin resolution driven end-to-end against a fake SDK.