### PR TITLE
Adopt inkbox SDK 0.4.15 identity-centered phone API

### DIFF
--- a/.github/workflows/live-channels.yml
+++ b/.github/workflows/live-channels.yml
@@ -72,7 +72,7 @@ jobs:
           ln -sfn "$GITHUB_WORKSPACE" "$HERMES_HOME/plugins/inkbox"
           hermes plugins enable inkbox
           "$HERMES_HOME/bin/uv" pip install --python "$HERMES_HOME/hermes-agent/venv/bin/python3" \
-            'inkbox>=0.4.7' 'aiohttp>=3.9' 'segno>=1.5'
+            'inkbox>=0.4.15' 'aiohttp>=3.9' 'segno>=1.5'
 
       - name: Configure AUT identity + model (${{ matrix.mode }})
         env:

--- a/.github/workflows/live-external-events.yml
+++ b/.github/workflows/live-external-events.yml
@@ -51,7 +51,7 @@ jobs:
           ln -sfn "$GITHUB_WORKSPACE" "$HERMES_HOME/plugins/inkbox"
           hermes plugins enable inkbox
           "$HERMES_HOME/bin/uv" pip install --python "$HERMES_HOME/hermes-agent/venv/bin/python3" \
-            'inkbox>=0.4.7' 'aiohttp>=3.9' 'segno>=1.5'
+            'inkbox>=0.4.15' 'aiohttp>=3.9' 'segno>=1.5'
 
       - name: Configure AUT identity + model
         env:

--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -58,7 +58,7 @@ jobs:
           ln -sfn "$GITHUB_WORKSPACE" "$HERMES_HOME/plugins/inkbox"
           hermes plugins enable inkbox
           "$HERMES_HOME/bin/uv" pip install --python "$HERMES_HOME/hermes-agent/venv/bin/python3" \
-            'inkbox>=0.4.7' 'aiohttp>=3.9' 'segno>=1.5' fastapi uvicorn
+            'inkbox>=0.4.15' 'aiohttp>=3.9' 'segno>=1.5' fastapi uvicorn
 
       - name: Configure AUT identity + model + speech path (${{ matrix.scenario }})
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "hermes-agent-plugin"
-version = "0.2.0"
+version = "0.2.1"
 description = "Inkbox platform plugin for Hermes Agent"
 # inkbox>=0.4.7 requires Python 3.11+, so we can't claim 3.10 support.
 requires-python = ">=3.11"
 dependencies = [
   "aiohttp>=3.9",
-  "inkbox>=0.4.10,<0.4.15",
+  "inkbox>=0.4.15",
   "segno>=1.5",
 ]
 

--- a/tests/live/test_cross_channel.py
+++ b/tests/live/test_cross_channel.py
@@ -156,7 +156,7 @@ def test_sms_request_gets_email_response(xc):
 def _inbound_calls_from_aut(remote, remote_pid: str, aut_phone: str):
     """The driver's inbound calls originating from the AUT's number."""
     tail = _digits(aut_phone)[-10:]
-    return [c for c in remote.calls.list(remote_pid, limit=30)
+    return [c for c in remote.calls.list(limit=30)
             if (getattr(c, "direction", "") or "").lower() == "inbound"
             and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == tail]
 

--- a/tests/live/test_external_event_github.py
+++ b/tests/live/test_external_event_github.py
@@ -110,7 +110,7 @@ def _outbound_calls_to(aut, aut_number_id, driver_phone: str) -> list:
     """AUT's outbound calls dialed to the driver's number (newest first)."""
     tail = _digits(driver_phone)[-10:]
     return [
-        c for c in aut.calls.list(aut_number_id, limit=30)
+        c for c in aut.calls.list(limit=30)
         if (getattr(c, "direction", "") or "").lower() == "outbound"
         and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == tail
     ]

--- a/tests/live/test_external_event_intelligence.py
+++ b/tests/live/test_external_event_intelligence.py
@@ -106,7 +106,7 @@ def _outbound_calls_to(aut, aut_number_id, driver_phone: str) -> list:
     """AUT's outbound calls dialed to the driver's number (newest first)."""
     tail = _digits(driver_phone)[-10:]
     return [
-        c for c in aut.calls.list(aut_number_id, limit=30)
+        c for c in aut.calls.list(limit=30)
         if (getattr(c, "direction", "") or "").lower() == "outbound"
         and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == tail
     ]

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -60,7 +60,8 @@ def _aut_phone(aut) -> str:
 
 def _segments(remote, number_id, call_id):
     """Transcript segments for a call, split by who spoke."""
-    segs = remote.transcripts.list(number_id, call_id)
+    # Identity-centered transcript read (SDK 0.4.15+); number_id is vestigial.
+    segs = remote.calls.transcripts(call_id)
     rem = [s for s in segs if (getattr(s, "party", "") or "").lower() == "remote" and (s.text or "").strip()]
     loc = [s for s in segs if (getattr(s, "party", "") or "").lower() == "local" and (s.text or "").strip()]
     return segs, rem, loc
@@ -89,9 +90,8 @@ def _aut_speech_mode(aut, direction, driver_number):
     """(use_inkbox_tts, use_inkbox_stt) of the agent's most recent answered call
     in `direction` with the driver. Tells Inkbox STT/TTS (True/True) from realtime
     (False/False), so each leg can prove it ran the speech path it claims."""
-    num_id = str(aut.phone_numbers.list()[0].id)
     tail = _digits(driver_number)[-10:]
-    answered = [c for c in aut.calls.list(num_id, limit=10)
+    answered = [c for c in aut.calls.list(limit=10)
                 if (getattr(c, "direction", "") or "").lower() == direction
                 and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == tail
                 and c.use_inkbox_tts is not None]
@@ -127,7 +127,7 @@ def test_outbound_call_realtime():
     tail = _digits(aut_phone)[-10:]
 
     def _inbound_from_aut():
-        return [c for c in remote.calls.list(st["number_id"], limit=30)
+        return [c for c in remote.calls.list(limit=30)
                 if (getattr(c, "direction", "") or "").lower() == "inbound"
                 and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == tail]
 


### PR DESCRIPTION
inkbox SDK 0.4.15 (inkbox-ai/inkbox#90) re-centered the phone module on the agent identity and removed the number-scoped call/transcript paths. The live-test driver still used the old surface, so today's `live (real)` job failed on the two cross-channel call tests with `TypeError: CallsResource.list() takes 1 positional argument...` ([failing run](https://github.com/inkbox-ai/hermes-agent-plugin/actions/runs/28603668459)) — the live workflows install the SDK directly with `pip install 'inkbox>=0.4.7'`, bypassing the `<0.4.15` pyproject pin from #34.

- Tests: `calls.list(number_id, ...)` → keyword-only `calls.list(...)` (identity-scoped keys resolve their own identity); `transcripts.list(number_id, call_id)` → `calls.transcripts(call_id)`.
- Workflows: bump the direct installs in live-channels / live-external-events / live-voice to `inkbox>=0.4.15`.
- pyproject: lift the temporary `<0.4.15` pin from #34 to `inkbox>=0.4.15`; version 0.2.0 → 0.2.1.

Runtime code (adapter, realtime) never used the dropped paths — identity delegators (`list_calls`/`list_transcripts`) are signature-stable in 0.4.15. Matches the migration already on the `imessage-shared-calling` branch, so that branch merges cleanly over this.