### PR TITLE
Hosted realtime voice over the single call WebSocket (X-Use-Inkbox-Agent)

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -245,6 +245,13 @@ _DESIRED_IMESSAGE_EVENTS: tuple[str, ...] = (
     "imessage.reaction_received",
 )
 
+# Call lifecycle: identity-owned, fire-and-forget post-call fan-out. ``call.ended``
+# hands the ended-call summary + (when platform-hosted voice ran) the transcript to
+# the agent so it can follow up even when no live supervisor socket was held. This is
+# a SEPARATE identity-owned subscription from the iMessage one; see
+# ``_call_lifecycle_webhook_url`` for why it must live on its own URL.
+_DESIRED_CALL_EVENTS: tuple[str, ...] = ("call.ended",)
+
 
 def _inkbox_state_path():
     """Return the on-disk path used for the Inkbox identity state file.
@@ -632,6 +639,49 @@ def _reconcile_imessage_subscription(
 
     iMessage traffic rides shared Inkbox-managed numbers, so the
     subscription owner is the agent identity, not a phone number.
+    """
+    return _reconcile_subscription(
+        client,
+        owner_kwarg="agent_identity_id",
+        owner_id=agent_identity_id,
+        desired_url=desired_url,
+        previous_webhook_url=previous_webhook_url,
+        desired_events=desired_events,
+    )
+
+
+def _call_lifecycle_webhook_url(base_webhook_url: str) -> str:
+    """Derive the identity's call-lifecycle webhook URL from the base webhook URL.
+
+    iMessage and call-lifecycle subscriptions are BOTH owned by the agent
+    identity, and the server allows only one active subscription per
+    (identity, url). They therefore cannot share a URL — so the call sub gets
+    a dedicated path suffix on the same webhook server (routed to the same
+    handler, dispatched by ``event_type``). Applied identically to the current
+    and previously-registered base so reconcile cleanup lines up.
+
+    Args:
+        base_webhook_url (str): The base webhook URL (public URL + webhook path).
+
+    Returns:
+        str: The call-lifecycle webhook URL (base + ``/call-lifecycle``).
+    """
+    return base_webhook_url.rstrip("/") + "/call-lifecycle"
+
+
+def _reconcile_call_subscription(
+    client,
+    agent_identity_id,
+    desired_url: str,
+    previous_webhook_url: Optional[str],
+    desired_events: tuple[str, ...] = _DESIRED_CALL_EVENTS,
+):
+    """Reconcile the identity-owned call-lifecycle webhook subscription.
+
+    Independent of the iMessage row and of the ``incoming_call_webhook_url`` /
+    ``auto_accept`` config on the same identity: this reconcile only ever
+    touches rows whose URL equals the dedicated call-lifecycle URL, so it never
+    churns or strips those neighbours.
     """
     return _reconcile_subscription(
         client,
@@ -1342,19 +1392,6 @@ class _HostedSupervisorChannel:
             {"event": "update_instructions", "instructions": instructions}
         )
 
-    async def tool_decision(
-        self, tool_call_id: str, decision: str, reason: Optional[str] = None,
-    ) -> None:
-        """Approve or deny an approval-gated tool call by id."""
-        frame: Dict[str, Any] = {
-            "event": "tool.decision",
-            "tool_call_id": tool_call_id,
-            "decision": decision,
-        }
-        if reason:
-            frame["reason"] = reason
-        await self._send(frame)
-
     async def hang_up(self, reason: Optional[str] = None) -> None:
         """Ask the platform to end the call."""
         frame: Dict[str, Any] = {"event": "hang_up"}
@@ -1389,6 +1426,14 @@ class InkboxAdapter(BasePlatformAdapter):
         # Started in _start_imessage_typing, cancelled in _stop_imessage_typing
         # (on send or on failure).
         self._imessage_typing_tasks: Dict[str, "asyncio.Task"] = {}
+        # Post-call reflection dedup. A connected call surfaces call.ended over
+        # BOTH the supervisor WS (when one is held) and the call-lifecycle
+        # webhook. The WS frame is richer (it carries post_call_actions), so the
+        # webhook defers to it for calls we actively supervised; the claim map
+        # then keeps reflection exactly-once (guarding webhook re-deliveries and
+        # any WS/webhook overlap). Both keyed call_id -> timestamp, pruned by TTL.
+        self._supervised_call_ids: Dict[str, float] = {}
+        self._post_call_reflected: Dict[str, float] = {}
         self._base_url = (
             extra.get("base_url") or os.getenv("INKBOX_BASE_URL") or INKBOX_BASE_URL_DEFAULT
         ).strip()
@@ -1397,6 +1442,11 @@ class InkboxAdapter(BasePlatformAdapter):
             extra.get("port") or os.getenv("INKBOX_LISTEN_PORT") or DEFAULT_PORT
         )
         self._webhook_path = str(extra.get("webhook_path") or DEFAULT_WEBHOOK_PATH)
+        # Dedicated path for the identity-owned call-lifecycle subscription; it
+        # cannot share the base webhook URL with the iMessage sub (one active
+        # subscription per (identity, url) at the server). Routed to the same
+        # handler, dispatched by ``event_type``.
+        self._call_webhook_path = _call_lifecycle_webhook_url(self._webhook_path)
         self._ws_path = str(extra.get("ws_path") or DEFAULT_WS_PATH)
         # Default delivery target for messages with no human counterparty on
         # the source thread (e.g. external-event summaries). ``home_channel``
@@ -1579,6 +1629,9 @@ class InkboxAdapter(BasePlatformAdapter):
             self._app = web.Application()
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_post(self._webhook_path, self._handle_webhook)
+            # Call-lifecycle (call.ended) posts land on their own path but reuse
+            # the same verify-then-dispatch handler.
+            self._app.router.add_post(self._call_webhook_path, self._handle_webhook)
             self._app.router.add_get(self._ws_path, self._handle_call_ws)
             self._runner = web.AppRunner(self._app)
             await self._runner.setup()
@@ -1900,6 +1953,34 @@ class InkboxAdapter(BasePlatformAdapter):
             logger.info(
                 "[Inkbox] Patched iMessage for identity %s → %s",
                 self._identity_handle, webhook_url,
+            )
+
+        # Call lifecycle: identity-owned post-call fan-out (call.ended). Only for
+        # platform-hosted voice — that's the case where the brain runs remotely
+        # and the agent would otherwise miss the call end + transcript without a
+        # live supervisor socket (e.g. a call supervised on another worker). In
+        # local mode the in-process bridge already reflects on call end, so
+        # subscribing would double up. Its own URL keeps it an independent row
+        # from the iMessage sub and the incoming-call config on this identity.
+        hosted_realtime = (
+            self._realtime_config.enabled and self._realtime_config.hosted
+        )
+        if can_receive_calls and self._identity_id and hosted_realtime:
+            call_webhook_url = _call_lifecycle_webhook_url(webhook_url)
+            previous_call_webhook_url = (
+                _call_lifecycle_webhook_url(previous_webhook_url)
+                if previous_webhook_url else None
+            )
+            _reconcile_call_subscription(
+                self._inkbox,
+                self._identity_id,
+                desired_url=call_webhook_url,
+                previous_webhook_url=previous_call_webhook_url,
+                desired_events=_DESIRED_CALL_EVENTS,
+            )
+            logger.info(
+                "[Inkbox] Patched call-lifecycle subscription for identity %s → %s",
+                self._identity_handle, call_webhook_url,
             )
 
         # Persist the resolved identity so non-Inkbox sessions (CLI, etc.) can
@@ -2501,6 +2582,8 @@ class InkboxAdapter(BasePlatformAdapter):
                     response = await self._on_imessage_reaction(envelope)
                 elif event_type and event_type.startswith("imessage."):
                     response = await self._on_imessage_lifecycle(envelope)
+                elif event_type == "call.ended":
+                    response = await self._on_call_ended(envelope)
                 else:
                     response = await self._on_incoming_call(envelope)
             elif source is not None and source != "inkbox":
@@ -2535,10 +2618,10 @@ class InkboxAdapter(BasePlatformAdapter):
         """Whether a payload is a known Inkbox event shape (vs a forwarded external one).
 
         Used only as a secondary discriminator *after* the source is verified as
-        Inkbox: mail / text / iMessage arrive as ``{event_type: "<kind>.<...>"}``;
-        the incoming-call webhook is a flat object carrying ``phone_number_id`` +
-        ``remote_phone_number``. Everything else (e.g. an Inkbox-signed CI
-        escalation) is treated as external.
+        Inkbox: mail / text / iMessage / call-lifecycle arrive as
+        ``{event_type: "<kind>.<...>"}``; the incoming-call webhook is a flat
+        object carrying ``phone_number_id`` + ``remote_phone_number``. Everything
+        else (e.g. an Inkbox-signed CI escalation) is treated as external.
 
         Args:
             event_type (str | None): The payload's ``event_type`` field, if any.
@@ -2547,7 +2630,9 @@ class InkboxAdapter(BasePlatformAdapter):
         Returns:
             bool: True for a recognised Inkbox event shape.
         """
-        if event_type and event_type.startswith(("message.", "text.", "imessage.")):
+        if event_type and event_type.startswith(
+            ("message.", "text.", "imessage.", "call.")
+        ):
             return True
         return "phone_number_id" in envelope and "remote_phone_number" in envelope
 
@@ -4634,9 +4719,9 @@ class InkboxAdapter(BasePlatformAdapter):
         """Supervise a platform-hosted voice call over its own call WS.
 
         In hosted mode the platform runs the whole voice brain; this same call
-        WS carries observe frames (transcript, tool calls, consult requests,
-        call end) up and intervene frames (consult answers, injects, tool
-        decisions) back down. Builds a :class:`RealtimeCallMeta` from the
+        WS carries observe frames (transcript, consult requests, call end) up
+        and intervene frames (consult answers, injects, instruction updates,
+        hang up) back down. Builds a :class:`RealtimeCallMeta` from the
         already-resolved call context, then pumps observe frames until the
         platform closes the call.
 
@@ -4651,16 +4736,26 @@ class InkboxAdapter(BasePlatformAdapter):
         # Wrap the socket so observe-event handlers can push intervene frames.
         channel = _HostedSupervisorChannel(ws)
         call_meta = self._hosted_call_meta_from(meta)
-        # Observe frames arrive as JSON text on the same WS; drain until close.
-        async for msg in ws:
-            if msg.type != WSMsgType.TEXT:
-                continue
-            try:
-                event = json.loads(msg.data)
-            except json.JSONDecodeError:
-                continue
-            with suppress(Exception):
-                await self._hosted_dispatch_event(channel, event, call_meta)
+        # Mark this call supervised so the (redundant, transcript-only) webhook
+        # call.ended defers to the richer WS frame for it.
+        self._mark_supervised_call(call_meta.call_id)
+        try:
+            # Observe frames arrive as JSON text on the same WS; drain until close.
+            async for msg in ws:
+                if msg.type != WSMsgType.TEXT:
+                    continue
+                try:
+                    event = json.loads(msg.data)
+                except json.JSONDecodeError:
+                    continue
+                with suppress(Exception):
+                    await self._hosted_dispatch_event(channel, event, call_meta)
+        finally:
+            # Stop deferring once the socket is gone. If it closed before a
+            # call.ended frame (abnormal end), a webhook re-delivery can now
+            # reflect the call instead of being silently dropped; the claim map
+            # still prevents a double reflection when the WS did handle it.
+            self._clear_supervised_call(call_meta.call_id)
 
     def _hosted_call_meta_from(self, meta: Dict[str, Any]) -> RealtimeCallMeta:
         """Build supervisor call metadata from the WS-resolved call context.
@@ -4700,11 +4795,6 @@ class InkboxAdapter(BasePlatformAdapter):
                 "[Inkbox] hosted realtime transcript call_id=%s party=%s: %s",
                 call_id, _field(event, "party"), _field(event, "text"),
             )
-        elif kind == "model.tool_call":
-            logger.info(
-                "[Inkbox] hosted realtime tool_call call_id=%s tool=%s approval=%s",
-                call_id, _field(event, "tool_name"), _field(event, "requires_approval"),
-            )
         elif kind == "consult.requested":
             await self._hosted_handle_consult(channel, event, call_meta)
         elif kind == "call.ended":
@@ -4743,6 +4833,14 @@ class InkboxAdapter(BasePlatformAdapter):
         self, event: Any, call_meta: RealtimeCallMeta,
     ) -> None:
         """Enqueue post-call reconciliation from the call.ended frame."""
+        # Claim the reflection so a duplicate frame (or a webhook that didn't
+        # defer) can't reflect the same call twice.
+        if not self._claim_post_call_reflection(call_meta.call_id):
+            logger.info(
+                "[Inkbox] hosted realtime call.ended already reflected call_id=%s (skip)",
+                call_meta.call_id,
+            )
+            return
         transcript = self._hosted_transcript(_field(event, "transcript"))
         actions = self._hosted_actions(_field(event, "post_call_actions"))
         if actions:
@@ -4755,6 +4853,159 @@ class InkboxAdapter(BasePlatformAdapter):
         )
 
     @staticmethod
+    def _prune_ttl_map(store: Dict[str, float], now: float) -> None:
+        """Drop entries older than the dedup TTL so a map can't grow unbounded."""
+        for key, ts in list(store.items()):
+            if now - ts >= WEBHOOK_DEDUP_TTL_SECONDS:
+                store.pop(key, None)
+
+    def _mark_supervised_call(self, call_id: str) -> None:
+        """Record that a live supervisor WS is handling ``call_id``.
+
+        Args:
+            call_id (str): The supervised call's id.
+
+        Returns:
+            None
+        """
+        if not hasattr(self, "_supervised_call_ids"):
+            self._supervised_call_ids = {}
+        now = time.time()
+        self._prune_ttl_map(self._supervised_call_ids, now)
+        key = str(call_id or "").strip()
+        if key:
+            self._supervised_call_ids[key] = now
+
+    def _clear_supervised_call(self, call_id: str) -> None:
+        """Drop the supervised mark for ``call_id`` (supervisor socket closed)."""
+        if not hasattr(self, "_supervised_call_ids"):
+            return
+        self._supervised_call_ids.pop(str(call_id or "").strip(), None)
+
+    def _is_supervised_call(self, call_id: str) -> bool:
+        """Whether ``call_id`` is (recently) handled by a live supervisor WS.
+
+        Args:
+            call_id (str): The ended call's id.
+
+        Returns:
+            bool: True if the WS path owns this call's post-call reflection.
+        """
+        if not hasattr(self, "_supervised_call_ids"):
+            return False
+        self._prune_ttl_map(self._supervised_call_ids, time.time())
+        return str(call_id or "").strip() in self._supervised_call_ids
+
+    def _claim_post_call_reflection(self, call_id: str) -> bool:
+        """Claim the one post-call reflection for ``call_id``; True if we won.
+
+        Guards against reflecting the same call twice — a webhook re-delivery,
+        or a WS frame and a webhook frame that both slip through. Old claims are
+        pruned by TTL so the map cannot grow unbounded.
+
+        Args:
+            call_id (str): The ended call's id.
+
+        Returns:
+            bool: True if this caller should perform the reflection.
+        """
+        if not hasattr(self, "_post_call_reflected"):
+            self._post_call_reflected = {}
+        now = time.time()
+        self._prune_ttl_map(self._post_call_reflected, now)
+        key = str(call_id or "").strip()
+        if not key:
+            # No id to dedupe on — reflect rather than silently swallow.
+            return True
+        if key in self._post_call_reflected:
+            return False
+        self._post_call_reflected[key] = now
+        return True
+
+    async def _on_call_ended(self, envelope: Dict[str, Any]) -> "web.Response":
+        """Handle a ``call.ended`` lifecycle webhook: reflect + hand over transcript.
+
+        Fired by the server once a connected call terminates, independent of any
+        supervisor socket. Builds call metadata from the payload, extracts the
+        inline transcript (present only for platform-hosted voice calls), and
+        threads both into the existing post-call reflection path so the agent can
+        follow up. Deduped against the WS ``call.ended`` path by call_id.
+
+        Args:
+            envelope (Dict[str, Any]): The parsed, signature-verified webhook body.
+
+        Returns:
+            web.Response: Always 200 — the fan-out is fire-and-forget.
+        """
+        data = envelope.get("data") or {}
+        call = data.get("call") or {}
+        call_id = str(call.get("id") or "").strip()
+        if not call_id:
+            return web.Response(status=200, text="ok")
+        # Defer to the richer WS frame for calls we actively supervised — it
+        # already reflects those (and carries post_call_actions this webhook
+        # doesn't). The webhook is the handover for calls with NO supervisor WS.
+        if self._is_supervised_call(call_id):
+            return web.Response(status=200, text="ok")
+        # Otherwise reflect once; the claim guards webhook re-deliveries.
+        if not self._claim_post_call_reflection(call_id):
+            return web.Response(status=200, text="ok")
+
+        contacts = _webhook_list(data, "contacts", "contact_list")
+        contact = contacts[0] if contacts else {}
+        contact_id = str(_field(contact, "id") or "").strip()
+        contact_name = str(_field(contact, "name") or "").strip()
+        remote = str(_field(call, "remote_phone_number") or "").strip() or None
+        direction = str(_field(call, "direction") or "inbound").strip().lower() or "inbound"
+
+        call_meta = RealtimeCallMeta(
+            call_id=call_id,
+            contact_id=contact_id or (remote or "unknown"),
+            contact_name=contact_name or (remote or "unknown"),
+            remote_phone_number=remote,
+            direction=direction,
+            agent_identity_handle=self._identity_handle,
+            contact_known=bool(contact_id),
+        )
+        # Inline transcript is present only for hosted-voice calls; absent
+        # otherwise (data.transcript_url stays authoritative for the full copy).
+        transcript = self._webhook_call_transcript(data.get("transcript"))
+        await self._realtime_call_ended(call_meta, transcript)
+        logger.info(
+            "[Inkbox] call-lifecycle call.ended reflected call_id=%s transcript_turns=%d",
+            call_id, len(transcript),
+        )
+        return web.Response(status=200, text="ok")
+
+    @staticmethod
+    def _webhook_call_transcript(raw: Any) -> List[Tuple[str, str]]:
+        """Flatten a ``call.ended`` transcript block into ``(party, text)`` pairs.
+
+        Reads ``raw["entries"]`` (``{party: local|remote, text, ts_ms}``),
+        skipping abridged-marker rows (``{marker: "abridged", ...}``) which carry
+        no speaker/text. Returns an empty list when no inline transcript rode the
+        payload (non-hosted calls, or a signing-secret-only consumer that must
+        rely on the inline abridged copy).
+
+        Args:
+            raw (Any): The ``data.transcript`` object, or None.
+
+        Returns:
+            List[Tuple[str, str]]: ``(party, text)`` pairs in wire order.
+        """
+        entries = _webhook_list(raw, "entries") if isinstance(raw, dict) else []
+        turns: List[Tuple[str, str]] = []
+        for entry in entries:
+            # Abridged markers have no party/text — they only note the cut.
+            if _field(entry, "marker"):
+                continue
+            text = str(_field(entry, "text") or "").strip()
+            if text:
+                party = str(_field(entry, "party") or "remote").strip() or "remote"
+                turns.append((party, text))
+        return turns
+
+    @staticmethod
     def _hosted_transcript(raw: Any) -> List[Tuple[str, str]]:
         """Flatten wire ``[{speaker, text}]`` turns into ``(speaker, text)`` pairs."""
         turns: List[Tuple[str, str]] = []
@@ -4765,6 +5016,27 @@ class InkboxAdapter(BasePlatformAdapter):
         return turns
 
     @staticmethod
+    def _coerce_details(raw: Any) -> str:
+        """Render a post-call action's ``details`` field as display text.
+
+        The server may send ``details`` as a plain string OR as a structured
+        object (e.g. ``{"query": "..."}``). A dict is JSON-encoded so it reads
+        cleanly in the reflection text instead of leaking a Python ``repr``.
+
+        Args:
+            raw (Any): the wire ``details`` value (str, dict, None, or other).
+
+        Returns:
+            str: a stripped, human-readable rendering of ``details``.
+        """
+        if raw is None:
+            return ""
+        # Structured details serialise as compact JSON rather than a repr.
+        if isinstance(raw, (dict, list)):
+            return json.dumps(raw, sort_keys=True)
+        return str(raw).strip()
+
+    @staticmethod
     def _hosted_actions(raw: Any) -> List[Dict[str, str]]:
         """Normalise wire ``[{action, details}]`` post-call actions."""
         actions: List[Dict[str, str]] = []
@@ -4773,7 +5045,7 @@ class InkboxAdapter(BasePlatformAdapter):
             if action:
                 actions.append({
                     "action": action,
-                    "details": str(_field(entry, "details") or "").strip(),
+                    "details": InkboxAdapter._coerce_details(_field(entry, "details")),
                 })
         return actions
 

--- a/adapter.py
+++ b/adapter.py
@@ -140,6 +140,8 @@ try:
         DEFAULT_MODEL as REALTIME_DEFAULT_MODEL,
         DEFAULT_VOICE as REALTIME_DEFAULT_VOICE,
         DEFAULT_CONSULT_TIMEOUT_S as REALTIME_DEFAULT_CONSULT_TIMEOUT_S,
+        MODE_HOSTED as REALTIME_MODE_HOSTED,
+        MODE_LOCAL as REALTIME_MODE_LOCAL,
         RealtimeCallMeta,
         RealtimeConfig,
         RealtimeBridgeConnectError,
@@ -154,6 +156,8 @@ except ImportError:  # pragma: no cover - direct local import/test fallback
         DEFAULT_MODEL as REALTIME_DEFAULT_MODEL,
         DEFAULT_VOICE as REALTIME_DEFAULT_VOICE,
         DEFAULT_CONSULT_TIMEOUT_S as REALTIME_DEFAULT_CONSULT_TIMEOUT_S,
+        MODE_HOSTED as REALTIME_MODE_HOSTED,
+        MODE_LOCAL as REALTIME_MODE_LOCAL,
         RealtimeCallMeta,
         RealtimeConfig,
         RealtimeBridgeConnectError,
@@ -408,8 +412,33 @@ def _resolve_realtime_config(extra: Dict[str, Any]) -> RealtimeConfig:
         else "auto"
     )
     rt_enabled_requested = rt_enabled_text in ("auto", "true", "1", "yes", "on")
+
+    # Voice mode. ``hosted`` hands the voice leg to the platform, so it needs no
+    # local provider credential — opting in is enough. Explicit ``mode`` wins
+    # over the ``hosted`` boolean; both fall back to env, defaulting to local.
+    mode_raw = rt_extra.get("mode") or os.getenv("INKBOX_REALTIME_MODE")
+    hosted_raw = (
+        rt_extra.get("hosted")
+        if "hosted" in rt_extra
+        else os.getenv("INKBOX_REALTIME_HOSTED")
+    )
+    if mode_raw:
+        mode = str(mode_raw).strip().lower()
+    elif _realtime_bool(hosted_raw, False):
+        mode = REALTIME_MODE_HOSTED
+    else:
+        mode = REALTIME_MODE_LOCAL
+    if mode not in (REALTIME_MODE_LOCAL, REALTIME_MODE_HOSTED):
+        logger.warning(
+            "[Inkbox] unknown realtime mode %r; falling back to local.", mode,
+        )
+        mode = REALTIME_MODE_LOCAL
+
+    hosted = mode == REALTIME_MODE_HOSTED
     config = RealtimeConfig(
-        enabled=rt_enabled_requested and rt_has_cred,
+        # Hosted needs no local credential; local still requires one.
+        enabled=rt_enabled_requested and (hosted or rt_has_cred),
+        mode=mode,
         api_key=rt_api_key,
         model=str(rt_extra.get("model") or os.getenv("INKBOX_REALTIME_MODEL") or REALTIME_DEFAULT_MODEL),
         voice=str(rt_extra.get("voice") or os.getenv("INKBOX_REALTIME_VOICE") or REALTIME_DEFAULT_VOICE),
@@ -431,7 +460,7 @@ def _resolve_realtime_config(extra: Dict[str, Any]) -> RealtimeConfig:
             True,
         ),
     )
-    if rt_enabled_text in ("true", "1", "yes", "on") and not rt_has_cred:
+    if not hosted and rt_enabled_text in ("true", "1", "yes", "on") and not rt_has_cred:
         logger.warning(
             "[Inkbox] realtime voice was enabled but no OpenAI credential was found "
             "(checked realtime.api_key, INKBOX_REALTIME_API_KEY, OPENAI_API_KEY); "
@@ -1377,6 +1406,13 @@ class InkboxAdapter(BasePlatformAdapter):
         self._site: Optional[Any] = None
         self._tunnel: Optional[Any] = None  # inkbox.tunnels.client.TunnelListener
         self._tunnel_runtime_thread: Optional["threading.Thread"] = None
+        # Hosted-realtime observe/intervene control channel. Populated only in
+        # hosted mode: the long-lived subscription task, the SDK session it
+        # drives, and per-call metadata (keyed by call_id) resolved from the
+        # observe stream so consult/post-call handling has caller context.
+        self._realtime_control_task: Optional["asyncio.Task"] = None
+        self._realtime_control_session: Optional[Any] = None
+        self._hosted_call_meta: Dict[str, RealtimeCallMeta] = {}
         # contact_id → active call WebSocket. Used by send()/edit_message() to
         # push voice replies to the correct ongoing call.
         self._active_call_ws: Dict[str, Any] = {}
@@ -1531,6 +1567,13 @@ class InkboxAdapter(BasePlatformAdapter):
             self._identity_handle, self._public_url, self._host, self._port,
         )
 
+        # Hosted realtime: enable the platform-run voice leg for this identity
+        # and open the observe/intervene control channel. Best-effort — a
+        # failure here must not sink an otherwise-healthy connection.
+        if self._realtime_config.hosted:
+            with suppress(Exception):
+                await self._start_hosted_realtime()
+
         return True
 
     async def disconnect(self) -> None:
@@ -1562,6 +1605,18 @@ class InkboxAdapter(BasePlatformAdapter):
                 return_exceptions=True,
             )
         self._imessage_typing_tasks.clear()
+
+        # Tear down the hosted-realtime control channel and its subscription task.
+        if self._realtime_control_task is not None:
+            self._realtime_control_task.cancel()
+            with suppress(asyncio.CancelledError, Exception):
+                await self._realtime_control_task
+            self._realtime_control_task = None
+        if self._realtime_control_session is not None:
+            with suppress(Exception):
+                await self._realtime_control_session.close()
+            self._realtime_control_session = None
+        self._hosted_call_meta.clear()
 
         # Close any live call WS so callers don't hang on a half-open socket.
         for ws in list(self._active_call_ws.values()):
@@ -3840,7 +3895,10 @@ class InkboxAdapter(BasePlatformAdapter):
         # before accepting the Inkbox websocket in raw-media mode. If preflight
         # fails and fallback is allowed, we still accept the same phone call
         # with Inkbox STT/TTS and continue into the text-event flow below.
-        if self._realtime_config.enabled:
+        # In hosted mode the platform runs the voice leg, so we never open a
+        # local bridge here — the observe/intervene control channel handles the
+        # call out of band (see _run_realtime_control_channel).
+        if self._realtime_config.enabled and not self._realtime_config.hosted:
             realtime_bridge = None
             try:
                 identity_for_meta = None
@@ -4460,6 +4518,223 @@ class InkboxAdapter(BasePlatformAdapter):
                 "[Inkbox] post-call action enqueue failed for call_id=%s: %s",
                 meta.call_id, exc,
             )
+
+    # ------------------------------------------------------------------
+    # Hosted realtime — observe/intervene control channel
+    # ------------------------------------------------------------------
+
+    async def _start_hosted_realtime(self) -> None:
+        """Enable the platform-hosted voice leg and open the control channel.
+
+        Turns on hosted realtime for this identity (voice / model / extra
+        instructions from local config) so the server runs the voice agent,
+        then launches the long-lived task that consumes observe events and
+        answers consults.
+        """
+        if self._inkbox is None:
+            logger.warning("[Inkbox] hosted realtime requested but SDK client is unavailable")
+            return
+        cfg = self._realtime_config
+        try:
+            await asyncio.to_thread(
+                self._inkbox.phone.hosted_realtime.set_config,
+                enabled=True,
+                voice=cfg.voice or None,
+                model=cfg.model or None,
+                instructions=cfg.additional_instructions or None,
+                agent_identity_id=self._identity_id,
+            )
+            logger.info(
+                "[Inkbox] hosted realtime enabled for identity=%s (voice=%s model=%s)",
+                self._identity_handle, cfg.voice, cfg.model,
+            )
+        except AttributeError:
+            logger.warning(
+                "[Inkbox] installed SDK exposes no hosted-realtime config surface; "
+                "cannot enable hosted voice for identity=%s", self._identity_handle,
+            )
+            return
+        except Exception as exc:
+            # The identity may already be enabled server-side; still open the
+            # control channel so we can observe and intervene.
+            logger.warning("[Inkbox] failed to enable hosted realtime: %s", exc)
+
+        self._realtime_control_task = asyncio.create_task(
+            self._run_realtime_control_channel(),
+            name="inkbox-realtime-control",
+        )
+
+    async def _run_realtime_control_channel(self) -> None:
+        """Observe live hosted calls and drive intervene commands.
+
+        Subscribes to this identity's live and future calls, logs transcript
+        and tool activity so the main agent is informed as a call happens,
+        answers consult requests via the existing main-agent oneshot, and
+        enqueues the post-call reconciliation turn when a call ends.
+        Reconnects with backoff; exits cleanly on teardown cancellation.
+        """
+        backoff = 1.0
+        while True:
+            session = None
+            try:
+                session = await self._inkbox.phone.realtime.connect(
+                    agent_identity_id=self._identity_id,
+                )
+                self._realtime_control_session = session
+                backoff = 1.0
+                logger.info(
+                    "[Inkbox] hosted realtime control channel open for identity=%s",
+                    self._identity_handle,
+                )
+                async for event in session:
+                    with suppress(Exception):
+                        await self._hosted_dispatch_event(session, event)
+            except asyncio.CancelledError:
+                if session is not None:
+                    with suppress(Exception):
+                        await session.close()
+                raise
+            except AttributeError:
+                logger.warning(
+                    "[Inkbox] installed SDK exposes no realtime control channel; "
+                    "hosted observe/intervene disabled",
+                )
+                return
+            except Exception as exc:
+                logger.warning("[Inkbox] hosted realtime control channel error: %s", exc)
+            finally:
+                if self._realtime_control_session is session:
+                    self._realtime_control_session = None
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, 30.0)
+
+    async def _hosted_dispatch_event(self, session: Any, event: Any) -> None:
+        """Route one observe event to logging, consult, or post-call handling."""
+        kind = str(_field(event, "event") or "").strip()
+        call_id = str(_field(event, "call_id") or "").strip()
+        if kind == "call.started":
+            await self._hosted_register_call(event, call_id)
+        elif kind == "transcript":
+            logger.info(
+                "[Inkbox] hosted realtime transcript call_id=%s party=%s: %s",
+                call_id, _field(event, "party"), _field(event, "text"),
+            )
+        elif kind == "model.tool_call":
+            logger.info(
+                "[Inkbox] hosted realtime tool_call call_id=%s tool=%s approval=%s",
+                call_id, _field(event, "tool_name"), _field(event, "requires_approval"),
+            )
+        elif kind == "consult.requested":
+            await self._hosted_handle_consult(session, event, call_id)
+        elif kind == "call.ended":
+            await self._hosted_handle_call_ended(event, call_id)
+        # call.answered / barge_in and other observe events need no action.
+
+    async def _hosted_register_call(self, event: Any, call_id: str) -> None:
+        """Resolve caller context on call.started and cache it by call_id."""
+        phone = str(_field(event, "phone_number") or "").strip() or None
+        direction = str(_field(event, "direction") or "inbound").strip().lower() or "inbound"
+        contact_id = phone or call_id or "unknown"
+        contact_name = phone or "unknown"
+        contact_known = False
+        if phone:
+            with suppress(Exception):
+                details = await self._resolve_contact_full(kind="phone", value=phone)
+                if details:
+                    contact_id = str(details.get("id") or contact_id)
+                    contact_name = str(details.get("name") or contact_name)
+                    contact_known = True
+        self._hosted_call_meta[call_id] = RealtimeCallMeta(
+            call_id=call_id or "unknown",
+            contact_id=contact_id,
+            contact_name=contact_name,
+            remote_phone_number=phone,
+            direction=direction,
+            agent_identity_handle=self._identity_handle,
+            contact_known=contact_known,
+        )
+        logger.info(
+            "[Inkbox] hosted realtime call.started call_id=%s direction=%s",
+            call_id, direction,
+        )
+
+    def _hosted_meta_for(self, event: Any, call_id: str) -> RealtimeCallMeta:
+        """Return cached call metadata, or a minimal record from the event."""
+        meta = self._hosted_call_meta.get(call_id)
+        if meta is not None:
+            return meta
+        phone = str(_field(event, "phone_number") or "").strip() or None
+        direction = str(_field(event, "direction") or "inbound").strip().lower() or "inbound"
+        return RealtimeCallMeta(
+            call_id=call_id or "unknown",
+            contact_id=phone or call_id or "unknown",
+            contact_name=phone or "unknown",
+            remote_phone_number=phone,
+            direction=direction,
+            agent_identity_handle=self._identity_handle,
+        )
+
+    async def _hosted_handle_consult(self, session: Any, event: Any, call_id: str) -> None:
+        """Run the main-agent consult and push the answer back to the call."""
+        consult_id = str(_field(event, "consult_id") or "").strip()
+        query = str(_field(event, "query") or "").strip()
+        if not consult_id or not query:
+            logger.warning(
+                "[Inkbox] hosted consult missing consult_id/query for call_id=%s", call_id,
+            )
+            return
+        meta = self._hosted_meta_for(event, call_id)
+        transcript = self._hosted_transcript(_field(event, "transcript_tail"))
+        try:
+            answer = await self._realtime_agent_consult(meta, query, transcript)
+        except Exception as exc:
+            logger.warning("[Inkbox] hosted consult failed for call_id=%s: %s", call_id, exc)
+            answer = (
+                "I couldn't get an answer right now — tell the caller you'll "
+                "follow up after the call."
+            )
+        with suppress(Exception):
+            await session.answer_consult(consult_id, answer)
+        logger.info(
+            "[Inkbox] hosted consult answered call_id=%s consult_id=%s", call_id, consult_id,
+        )
+
+    async def _hosted_handle_call_ended(self, event: Any, call_id: str) -> None:
+        """Enqueue post-call reconciliation from the call.ended event."""
+        meta = self._hosted_call_meta.pop(call_id, None) or self._hosted_meta_for(event, call_id)
+        transcript = self._hosted_transcript(_field(event, "transcript"))
+        actions = self._hosted_actions(_field(event, "post_call_actions"))
+        if actions:
+            await self._realtime_post_call_actions(meta, actions, transcript)
+        else:
+            await self._realtime_call_ended(meta, transcript)
+        logger.info(
+            "[Inkbox] hosted realtime call.ended call_id=%s actions=%d",
+            call_id, len(actions),
+        )
+
+    @staticmethod
+    def _hosted_transcript(raw: Any) -> List[Tuple[str, str]]:
+        """Flatten wire ``[{speaker, text}]`` turns into ``(speaker, text)`` pairs."""
+        turns: List[Tuple[str, str]] = []
+        for turn in raw or []:
+            text = str(_field(turn, "text") or "").strip()
+            if text:
+                turns.append((str(_field(turn, "speaker") or "caller").strip() or "caller", text))
+        return turns
+
+    @staticmethod
+    def _hosted_actions(raw: Any) -> List[Dict[str, str]]:
+        """Normalise wire ``[{action, details}]`` post-call actions."""
+        actions: List[Dict[str, str]] = []
+        for entry in raw or []:
+            action = str(_field(entry, "action") or "").strip()
+            if action:
+                actions.append({
+                    "action": action,
+                    "details": str(_field(entry, "details") or "").strip(),
+                })
+        return actions
 
     # ------------------------------------------------------------------
 

--- a/adapter.py
+++ b/adapter.py
@@ -1295,6 +1295,70 @@ def check_inkbox_requirements() -> bool:
     return INKBOX_AVAILABLE and AIOHTTP_AVAILABLE
 
 
+class _HostedSupervisorChannel:
+    """Intervene half of a hosted call's supervisor WS.
+
+    In platform-hosted agent mode the brain runs server-side and the plugin
+    keeps the one call WS open as a supervisor channel. This wraps that socket
+    so observe-event handlers can push intervene frames back down it as JSON,
+    matching the wire contract's ``event`` discriminator.
+
+    Args:
+        ws (web.WebSocketResponse): the live per-call supervisor socket.
+    """
+
+    def __init__(self, ws: Any) -> None:
+        self._ws = ws
+
+    async def _send(self, frame: Dict[str, Any]) -> None:
+        # One JSON frame per intervene command; the platform reads them off
+        # the same connection it emits observe frames on.
+        await self._ws.send_str(json.dumps(frame))
+
+    async def answer_consult(
+        self, consult_id: str, answer: str, instructions: Optional[str] = None,
+    ) -> None:
+        """Resolve a pending consult; optional ``instructions`` steer the brain."""
+        frame: Dict[str, Any] = {
+            "event": "consult.answer",
+            "consult_id": consult_id,
+            "answer": answer,
+        }
+        if instructions:
+            frame["instructions"] = instructions
+        await self._send(frame)
+
+    async def inject(self, text: str, mode: str = "say") -> None:
+        """Push text into the call — ``say`` speaks now, ``context`` is hidden."""
+        await self._send({"event": "inject", "mode": mode, "text": text})
+
+    async def update_instructions(self, instructions: str) -> None:
+        """Replace the running brain's system instructions mid-call."""
+        await self._send(
+            {"event": "update_instructions", "instructions": instructions}
+        )
+
+    async def tool_decision(
+        self, tool_call_id: str, decision: str, reason: Optional[str] = None,
+    ) -> None:
+        """Approve or deny an approval-gated tool call by id."""
+        frame: Dict[str, Any] = {
+            "event": "tool.decision",
+            "tool_call_id": tool_call_id,
+            "decision": decision,
+        }
+        if reason:
+            frame["reason"] = reason
+        await self._send(frame)
+
+    async def hang_up(self, reason: Optional[str] = None) -> None:
+        """Ask the platform to end the call."""
+        frame: Dict[str, Any] = {"event": "hang_up"}
+        if reason:
+            frame["reason"] = reason
+        await self._send(frame)
+
+
 class InkboxAdapter(BasePlatformAdapter):
     """Hermes platform adapter for Inkbox (email + SMS + voice)."""
 
@@ -1406,13 +1470,6 @@ class InkboxAdapter(BasePlatformAdapter):
         self._site: Optional[Any] = None
         self._tunnel: Optional[Any] = None  # inkbox.tunnels.client.TunnelListener
         self._tunnel_runtime_thread: Optional["threading.Thread"] = None
-        # Hosted-realtime observe/intervene control channel. Populated only in
-        # hosted mode: the long-lived subscription task, the SDK session it
-        # drives, and per-call metadata (keyed by call_id) resolved from the
-        # observe stream so consult/post-call handling has caller context.
-        self._realtime_control_task: Optional["asyncio.Task"] = None
-        self._realtime_control_session: Optional[Any] = None
-        self._hosted_call_meta: Dict[str, RealtimeCallMeta] = {}
         # contact_id → active call WebSocket. Used by send()/edit_message() to
         # push voice replies to the correct ongoing call.
         self._active_call_ws: Dict[str, Any] = {}
@@ -1567,13 +1624,6 @@ class InkboxAdapter(BasePlatformAdapter):
             self._identity_handle, self._public_url, self._host, self._port,
         )
 
-        # Hosted realtime: enable the platform-run voice leg for this identity
-        # and open the observe/intervene control channel. Best-effort — a
-        # failure here must not sink an otherwise-healthy connection.
-        if self._realtime_config.hosted:
-            with suppress(Exception):
-                await self._start_hosted_realtime()
-
         return True
 
     async def disconnect(self) -> None:
@@ -1605,18 +1655,6 @@ class InkboxAdapter(BasePlatformAdapter):
                 return_exceptions=True,
             )
         self._imessage_typing_tasks.clear()
-
-        # Tear down the hosted-realtime control channel and its subscription task.
-        if self._realtime_control_task is not None:
-            self._realtime_control_task.cancel()
-            with suppress(asyncio.CancelledError, Exception):
-                await self._realtime_control_task
-            self._realtime_control_task = None
-        if self._realtime_control_session is not None:
-            with suppress(Exception):
-                await self._realtime_control_session.close()
-            self._realtime_control_session = None
-        self._hosted_call_meta.clear()
 
         # Close any live call WS so callers don't hang on a half-open socket.
         for ws in list(self._active_call_ws.values()):
@@ -3765,8 +3803,18 @@ class InkboxAdapter(BasePlatformAdapter):
         # commits Inkbox to raw-media mode before we know Realtime is reachable.
         ws = web.WebSocketResponse()
 
-        async def _prepare_call_ws(*, use_realtime: bool) -> None:
-            if use_realtime:
+        async def _prepare_call_ws(
+            *, use_realtime: bool, use_agent: bool = False,
+        ) -> None:
+            if use_agent:
+                # Platform-hosted agent mode: the platform runs the whole voice
+                # brain (LLM + STT + TTS + VAD). Opting in is just this one
+                # response header, set alongside the STT/TTS flags — which the
+                # platform also owns here, so both stay "true".
+                ws.headers["x-use-inkbox-agent"] = "true"
+                ws.headers["x-use-inkbox-text-to-speech"] = "true"
+                ws.headers["x-use-inkbox-speech-to-text"] = "true"
+            elif use_realtime:
                 ws.headers["x-use-inkbox-text-to-speech"] = "false"
                 ws.headers["x-use-inkbox-speech-to-text"] = "false"
             else:
@@ -3891,14 +3939,46 @@ class InkboxAdapter(BasePlatformAdapter):
                     "[Inkbox] Failed to load context_token %s: %s", ctx_token, exc,
                 )
 
+        # Platform-hosted agent voice — the platform runs the whole brain, so
+        # we open no local voice bridge and never enter the text-event flow.
+        # We accept this same call WS with the ``x-use-inkbox-agent`` header
+        # and keep it open as a supervisor channel: observe frames come up,
+        # intervene frames go back down (see _run_hosted_supervisor).
+        if self._realtime_config.hosted:
+            await _prepare_call_ws(use_agent=True)
+            logger.info(
+                "[Inkbox] Hosted agent call WS open: call_id=%s contact_id=%s "
+                "remote=%s direction=%s thread=%s",
+                call_id, contact_id, remote_phone_number, direction,
+                call_thread_id,
+            )
+            try:
+                await self._run_hosted_supervisor(ws, meta)
+            except Exception as exc:
+                logger.warning(
+                    "[Inkbox] hosted supervisor crashed for call_id=%s: %s",
+                    call_id, exc,
+                )
+            finally:
+                # Unbind the voice sink and mark the call recently-closed so the
+                # gateway's outbound routing falls back to SMS/email.
+                self._active_call_ws.pop(contact_id, None)
+                if self._last_inbound_modality.get(str(contact_id)) == "voice":
+                    self._last_inbound_modality.pop(str(contact_id), None)
+                self._voice_recently_closed[str(contact_id)] = time.time()
+                with suppress(Exception):
+                    if not ws.closed:
+                        await ws.close()
+                logger.info(
+                    "[Inkbox] Hosted agent call WS closed: call_id=%s", call_id,
+                )
+            return ws
+
         # Realtime voice bridge — when configured, pre-open OpenAI Realtime
         # before accepting the Inkbox websocket in raw-media mode. If preflight
         # fails and fallback is allowed, we still accept the same phone call
         # with Inkbox STT/TTS and continue into the text-event flow below.
-        # In hosted mode the platform runs the voice leg, so we never open a
-        # local bridge here — the observe/intervene control channel handles the
-        # call out of band (see _run_realtime_control_channel).
-        if self._realtime_config.enabled and not self._realtime_config.hosted:
+        if self._realtime_config.enabled:
             realtime_bridge = None
             try:
                 identity_for_meta = None
@@ -4520,101 +4600,75 @@ class InkboxAdapter(BasePlatformAdapter):
             )
 
     # ------------------------------------------------------------------
-    # Hosted realtime — observe/intervene control channel
+    # Hosted realtime — single-WS observe/intervene supervisor
     # ------------------------------------------------------------------
 
-    async def _start_hosted_realtime(self) -> None:
-        """Enable the platform-hosted voice leg and open the control channel.
+    async def _run_hosted_supervisor(self, ws: Any, meta: Dict[str, Any]) -> None:
+        """Supervise a platform-hosted voice call over its own call WS.
 
-        Turns on hosted realtime for this identity (voice / model / extra
-        instructions from local config) so the server runs the voice agent,
-        then launches the long-lived task that consumes observe events and
-        answers consults.
+        In hosted mode the platform runs the whole voice brain; this same call
+        WS carries observe frames (transcript, tool calls, consult requests,
+        call end) up and intervene frames (consult answers, injects, tool
+        decisions) back down. Builds a :class:`RealtimeCallMeta` from the
+        already-resolved call context, then pumps observe frames until the
+        platform closes the call.
+
+        Args:
+            ws (web.WebSocketResponse): the live per-call supervisor socket.
+            meta (Dict[str, Any]): call context resolved by the WS handler
+                (contact id/name, remote number, direction, contact record).
+
+        Returns:
+            None
         """
-        if self._inkbox is None:
-            logger.warning("[Inkbox] hosted realtime requested but SDK client is unavailable")
-            return
-        cfg = self._realtime_config
-        try:
-            await asyncio.to_thread(
-                self._inkbox.phone.hosted_realtime.set_config,
-                enabled=True,
-                voice=cfg.voice or None,
-                model=cfg.model or None,
-                instructions=cfg.additional_instructions or None,
-                agent_identity_id=self._identity_id,
-            )
-            logger.info(
-                "[Inkbox] hosted realtime enabled for identity=%s (voice=%s model=%s)",
-                self._identity_handle, cfg.voice, cfg.model,
-            )
-        except AttributeError:
-            logger.warning(
-                "[Inkbox] installed SDK exposes no hosted-realtime config surface; "
-                "cannot enable hosted voice for identity=%s", self._identity_handle,
-            )
-            return
-        except Exception as exc:
-            # The identity may already be enabled server-side; still open the
-            # control channel so we can observe and intervene.
-            logger.warning("[Inkbox] failed to enable hosted realtime: %s", exc)
+        # Wrap the socket so observe-event handlers can push intervene frames.
+        channel = _HostedSupervisorChannel(ws)
+        call_meta = self._hosted_call_meta_from(meta)
+        # Observe frames arrive as JSON text on the same WS; drain until close.
+        async for msg in ws:
+            if msg.type != WSMsgType.TEXT:
+                continue
+            try:
+                event = json.loads(msg.data)
+            except json.JSONDecodeError:
+                continue
+            with suppress(Exception):
+                await self._hosted_dispatch_event(channel, event, call_meta)
 
-        self._realtime_control_task = asyncio.create_task(
-            self._run_realtime_control_channel(),
-            name="inkbox-realtime-control",
+    def _hosted_call_meta_from(self, meta: Dict[str, Any]) -> RealtimeCallMeta:
+        """Build supervisor call metadata from the WS-resolved call context.
+
+        Args:
+            meta (Dict[str, Any]): the call context dict assembled in the WS
+                handler (call_id, contact_id/name, remote number, direction,
+                full contact record).
+
+        Returns:
+            RealtimeCallMeta: metadata threaded into consult / post-call handling.
+        """
+        contact = meta.get("contact") or {}
+        return RealtimeCallMeta(
+            call_id=str(meta.get("call_id") or "unknown"),
+            contact_id=str(meta.get("contact_id") or "unknown"),
+            contact_name=str(meta.get("contact_name") or "unknown"),
+            remote_phone_number=(meta.get("remote_phone_number") or "").strip() or None,
+            direction=(meta.get("direction") or "inbound").strip().lower() or "inbound",
+            agent_identity_handle=self._identity_handle,
+            contact_known=bool(meta.get("contact")),
+            contact_emails=list(contact.get("emails") or []),
+            contact_phones=list(contact.get("phones") or []),
+            contact_company=contact.get("company") or None,
+            contact_notes=contact.get("notes") or None,
         )
 
-    async def _run_realtime_control_channel(self) -> None:
-        """Observe live hosted calls and drive intervene commands.
-
-        Subscribes to this identity's live and future calls, logs transcript
-        and tool activity so the main agent is informed as a call happens,
-        answers consult requests via the existing main-agent oneshot, and
-        enqueues the post-call reconciliation turn when a call ends.
-        Reconnects with backoff; exits cleanly on teardown cancellation.
-        """
-        backoff = 1.0
-        while True:
-            session = None
-            try:
-                session = await self._inkbox.phone.realtime.connect(
-                    agent_identity_id=self._identity_id,
-                )
-                self._realtime_control_session = session
-                backoff = 1.0
-                logger.info(
-                    "[Inkbox] hosted realtime control channel open for identity=%s",
-                    self._identity_handle,
-                )
-                async for event in session:
-                    with suppress(Exception):
-                        await self._hosted_dispatch_event(session, event)
-            except asyncio.CancelledError:
-                if session is not None:
-                    with suppress(Exception):
-                        await session.close()
-                raise
-            except AttributeError:
-                logger.warning(
-                    "[Inkbox] installed SDK exposes no realtime control channel; "
-                    "hosted observe/intervene disabled",
-                )
-                return
-            except Exception as exc:
-                logger.warning("[Inkbox] hosted realtime control channel error: %s", exc)
-            finally:
-                if self._realtime_control_session is session:
-                    self._realtime_control_session = None
-            await asyncio.sleep(backoff)
-            backoff = min(backoff * 2, 30.0)
-
-    async def _hosted_dispatch_event(self, session: Any, event: Any) -> None:
-        """Route one observe event to logging, consult, or post-call handling."""
+    async def _hosted_dispatch_event(
+        self, channel: "_HostedSupervisorChannel", event: Any,
+        call_meta: RealtimeCallMeta,
+    ) -> None:
+        """Route one observe frame to logging, consult, or post-call handling."""
         kind = str(_field(event, "event") or "").strip()
-        call_id = str(_field(event, "call_id") or "").strip()
-        if kind == "call.started":
-            await self._hosted_register_call(event, call_id)
-        elif kind == "transcript":
+        call_id = call_meta.call_id
+        if kind == "transcript":
             logger.info(
                 "[Inkbox] hosted realtime transcript call_id=%s party=%s: %s",
                 call_id, _field(event, "party"), _field(event, "text"),
@@ -4625,57 +4679,17 @@ class InkboxAdapter(BasePlatformAdapter):
                 call_id, _field(event, "tool_name"), _field(event, "requires_approval"),
             )
         elif kind == "consult.requested":
-            await self._hosted_handle_consult(session, event, call_id)
+            await self._hosted_handle_consult(channel, event, call_meta)
         elif kind == "call.ended":
-            await self._hosted_handle_call_ended(event, call_id)
-        # call.answered / barge_in and other observe events need no action.
+            await self._hosted_handle_call_ended(event, call_meta)
+        # call.started / call.answered / barge_in need no supervisor action.
 
-    async def _hosted_register_call(self, event: Any, call_id: str) -> None:
-        """Resolve caller context on call.started and cache it by call_id."""
-        phone = str(_field(event, "phone_number") or "").strip() or None
-        direction = str(_field(event, "direction") or "inbound").strip().lower() or "inbound"
-        contact_id = phone or call_id or "unknown"
-        contact_name = phone or "unknown"
-        contact_known = False
-        if phone:
-            with suppress(Exception):
-                details = await self._resolve_contact_full(kind="phone", value=phone)
-                if details:
-                    contact_id = str(details.get("id") or contact_id)
-                    contact_name = str(details.get("name") or contact_name)
-                    contact_known = True
-        self._hosted_call_meta[call_id] = RealtimeCallMeta(
-            call_id=call_id or "unknown",
-            contact_id=contact_id,
-            contact_name=contact_name,
-            remote_phone_number=phone,
-            direction=direction,
-            agent_identity_handle=self._identity_handle,
-            contact_known=contact_known,
-        )
-        logger.info(
-            "[Inkbox] hosted realtime call.started call_id=%s direction=%s",
-            call_id, direction,
-        )
-
-    def _hosted_meta_for(self, event: Any, call_id: str) -> RealtimeCallMeta:
-        """Return cached call metadata, or a minimal record from the event."""
-        meta = self._hosted_call_meta.get(call_id)
-        if meta is not None:
-            return meta
-        phone = str(_field(event, "phone_number") or "").strip() or None
-        direction = str(_field(event, "direction") or "inbound").strip().lower() or "inbound"
-        return RealtimeCallMeta(
-            call_id=call_id or "unknown",
-            contact_id=phone or call_id or "unknown",
-            contact_name=phone or "unknown",
-            remote_phone_number=phone,
-            direction=direction,
-            agent_identity_handle=self._identity_handle,
-        )
-
-    async def _hosted_handle_consult(self, session: Any, event: Any, call_id: str) -> None:
-        """Run the main-agent consult and push the answer back to the call."""
+    async def _hosted_handle_consult(
+        self, channel: "_HostedSupervisorChannel", event: Any,
+        call_meta: RealtimeCallMeta,
+    ) -> None:
+        """Run the main-agent consult and push the answer back over the WS."""
+        call_id = call_meta.call_id
         consult_id = str(_field(event, "consult_id") or "").strip()
         query = str(_field(event, "query") or "").strip()
         if not consult_id or not query:
@@ -4683,10 +4697,9 @@ class InkboxAdapter(BasePlatformAdapter):
                 "[Inkbox] hosted consult missing consult_id/query for call_id=%s", call_id,
             )
             return
-        meta = self._hosted_meta_for(event, call_id)
         transcript = self._hosted_transcript(_field(event, "transcript_tail"))
         try:
-            answer = await self._realtime_agent_consult(meta, query, transcript)
+            answer = await self._realtime_agent_consult(call_meta, query, transcript)
         except Exception as exc:
             logger.warning("[Inkbox] hosted consult failed for call_id=%s: %s", call_id, exc)
             answer = (
@@ -4694,23 +4707,24 @@ class InkboxAdapter(BasePlatformAdapter):
                 "follow up after the call."
             )
         with suppress(Exception):
-            await session.answer_consult(consult_id, answer)
+            await channel.answer_consult(consult_id, answer)
         logger.info(
             "[Inkbox] hosted consult answered call_id=%s consult_id=%s", call_id, consult_id,
         )
 
-    async def _hosted_handle_call_ended(self, event: Any, call_id: str) -> None:
-        """Enqueue post-call reconciliation from the call.ended event."""
-        meta = self._hosted_call_meta.pop(call_id, None) or self._hosted_meta_for(event, call_id)
+    async def _hosted_handle_call_ended(
+        self, event: Any, call_meta: RealtimeCallMeta,
+    ) -> None:
+        """Enqueue post-call reconciliation from the call.ended frame."""
         transcript = self._hosted_transcript(_field(event, "transcript"))
         actions = self._hosted_actions(_field(event, "post_call_actions"))
         if actions:
-            await self._realtime_post_call_actions(meta, actions, transcript)
+            await self._realtime_post_call_actions(call_meta, actions, transcript)
         else:
-            await self._realtime_call_ended(meta, transcript)
+            await self._realtime_call_ended(call_meta, transcript)
         logger.info(
             "[Inkbox] hosted realtime call.ended call_id=%s actions=%d",
-            call_id, len(actions),
+            call_meta.call_id, len(actions),
         )
 
     @staticmethod

--- a/adapter.py
+++ b/adapter.py
@@ -3804,7 +3804,7 @@ class InkboxAdapter(BasePlatformAdapter):
         ws = web.WebSocketResponse()
 
         async def _prepare_call_ws(
-            *, use_realtime: bool, use_agent: bool = False,
+            *, use_realtime: bool = False, use_agent: bool = False,
         ) -> None:
             if use_agent:
                 # Platform-hosted agent mode: the platform runs the whole voice

--- a/adapter.py
+++ b/adapter.py
@@ -442,7 +442,11 @@ def _resolve_realtime_config(extra: Dict[str, Any]) -> RealtimeConfig:
         api_key=rt_api_key,
         model=str(rt_extra.get("model") or os.getenv("INKBOX_REALTIME_MODEL") or REALTIME_DEFAULT_MODEL),
         voice=str(rt_extra.get("voice") or os.getenv("INKBOX_REALTIME_VOICE") or REALTIME_DEFAULT_VOICE),
-        additional_instructions=str(rt_extra.get("additional_instructions") or ""),
+        additional_instructions=str(
+            rt_extra.get("additional_instructions")
+            or os.getenv("INKBOX_REALTIME_INSTRUCTIONS")
+            or ""
+        ),
         consult_timeout_s=float(
             rt_extra.get("consult_timeout_s")
             or os.getenv("INKBOX_REALTIME_CONSULT_TIMEOUT_S")
@@ -1858,6 +1862,29 @@ class InkboxAdapter(BasePlatformAdapter):
             logger.info(
                 "[Inkbox] Patched incoming-call action for identity %s → %s + %s",
                 self._identity_handle, webhook_url, ws_url,
+            )
+
+        # Platform-hosted realtime voice: in hosted mode the Inkbox server runs
+        # the whole voice agent, so persist the identity's hosted-voice config
+        # (which also flips the server-side enable flag the hosted path gates on).
+        # ``additional_instructions`` is appended to the base system prompt
+        # server-side, so callers hear the user's persona/tone rules.
+        if (
+            self._realtime_config.enabled
+            and self._realtime_config.hosted
+            and hasattr(identity, "set_hosted_realtime_config")
+        ):
+            identity.set_hosted_realtime_config(
+                enabled=True,
+                voice=self._realtime_config.voice or None,
+                model=self._realtime_config.model or None,
+                instructions=(self._realtime_config.additional_instructions or None),
+            )
+            logger.info(
+                "[Inkbox] Enabled Inkbox-hosted realtime voice for identity %s "
+                "(extra instructions: %s)",
+                self._identity_handle,
+                "set" if self._realtime_config.additional_instructions else "none",
             )
 
         # iMessage: identity-owned subscription, only while the identity is

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -58,6 +58,14 @@ optional_env:
     description: "Realtime voice name. Defaults to cedar."
     prompt: "Realtime voice"
     secret: false
+  - name: INKBOX_REALTIME_HOSTED
+    description: "Let the Inkbox platform host the realtime voice agent for inbound calls (no local OpenAI key needed). Set true to enable."
+    prompt: "Host realtime voice on Inkbox"
+    secret: false
+  - name: INKBOX_REALTIME_INSTRUCTIONS
+    description: "Extra system instructions appended to the voice agent's base prompt (e.g. tone, persona, do/don't rules). Applies to both local and Inkbox-hosted realtime."
+    prompt: "Realtime extra instructions"
+    secret: false
   - name: INKBOX_REALTIME_CONNECT_TIMEOUT_S
     description: "Seconds to wait for OpenAI Realtime preflight before falling back or failing."
     prompt: "Realtime connect timeout"

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: inkbox
 label: Inkbox
 kind: platform
-version: 0.2.3
+version: 0.2.4
 description: Inkbox email, SMS/MMS, iMessage, and voice platform plugin for Hermes Agent.
 author: Inkbox
 requires_env: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hermes-agent-plugin"
-version = "0.2.3"
+version = "0.2.4"
 description = "Inkbox platform plugin for Hermes Agent"
 # inkbox>=0.4.7 requires Python 3.11+, so we can't claim 3.10 support.
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,10 @@ description = "Inkbox platform plugin for Hermes Agent"
 requires-python = ">=3.11"
 dependencies = [
   "aiohttp>=3.9",
-  "inkbox>=0.4.15,<1.0.0",
+  # >=0.4.18: first SDK whose webhook-subscription coherence accepts the
+  # identity-owned `call.ended` event this plugin subscribes to (R8). Older
+  # SDKs reject it client-side, aborting identity registration.
+  "inkbox>=0.4.18,<1.0.0",
   "segno>=1.5",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,10 @@ description = "Inkbox platform plugin for Hermes Agent"
 requires-python = ">=3.11"
 dependencies = [
   "aiohttp>=3.9",
-  # >=0.4.18: first SDK whose webhook-subscription coherence accepts the
+  # >=0.4.19: first SDK whose webhook-subscription coherence accepts the
   # identity-owned `call.ended` event this plugin subscribes to (R8). Older
   # SDKs reject it client-side, aborting identity registration.
-  "inkbox>=0.4.18,<1.0.0",
+  "inkbox>=0.4.19,<1.0.0",
   "segno>=1.5",
 ]
 

--- a/realtime.py
+++ b/realtime.py
@@ -59,6 +59,13 @@ logger = logging.getLogger(__name__)
 REALTIME_URL = "wss://api.openai.com/v1/realtime"
 DEFAULT_MODEL = "gpt-realtime-2"
 DEFAULT_VOICE = "cedar"
+
+# Realtime voice mode. ``local`` runs the voice bridge in this process, bringing
+# its own provider credential. ``hosted`` hands the voice leg to the platform:
+# the server runs the voice agent and this plugin only opens the observe +
+# intervene control channel (see adapter._run_realtime_control_channel).
+MODE_LOCAL = "local"
+MODE_HOSTED = "hosted"
 AUDIO_FORMAT_TELEPHONY = {"type": "audio/pcmu"}
 INPUT_TRANSCRIPTION_MODEL = "gpt-4o-mini-transcribe"
 
@@ -437,10 +444,17 @@ class RealtimeConfig:
     fallback_to_inkbox_stt_tts: bool = True
     # ``api.openai.com`` by default; override for Azure / proxies.
     base_url: str = REALTIME_URL
+    # ``local`` (in-process voice bridge) or ``hosted`` (platform runs the voice
+    # agent; this plugin only opens the control channel). See MODE_* constants.
+    mode: str = MODE_LOCAL
 
     @property
     def has_credential(self) -> bool:
         return bool(self.api_key)
+
+    @property
+    def hosted(self) -> bool:
+        return self.mode == MODE_HOSTED
 
 
 @dataclass

--- a/realtime.py
+++ b/realtime.py
@@ -62,8 +62,10 @@ DEFAULT_VOICE = "cedar"
 
 # Realtime voice mode. ``local`` runs the voice bridge in this process, bringing
 # its own provider credential. ``hosted`` hands the voice leg to the platform:
-# the server runs the voice agent and this plugin only opens the observe +
-# intervene control channel (see adapter._run_realtime_control_channel).
+# the server runs the whole voice brain and this plugin keeps the one call WS
+# open as a supervisor channel, opting in via the ``x-use-inkbox-agent`` header
+# and exchanging observe/intervene frames over it (see
+# adapter._run_hosted_supervisor).
 MODE_LOCAL = "local"
 MODE_HOSTED = "hosted"
 AUDIO_FORMAT_TELEPHONY = {"type": "audio/pcmu"}
@@ -445,7 +447,7 @@ class RealtimeConfig:
     # ``api.openai.com`` by default; override for Azure / proxies.
     base_url: str = REALTIME_URL
     # ``local`` (in-process voice bridge) or ``hosted`` (platform runs the voice
-    # agent; this plugin only opens the control channel). See MODE_* constants.
+    # brain; this plugin supervises over the one call WS). See MODE_* constants.
     mode: str = MODE_LOCAL
 
     @property

--- a/tests/test_realtime_hosted.py
+++ b/tests/test_realtime_hosted.py
@@ -192,14 +192,10 @@ def test_channel_inject_and_update_instructions():
     }
 
 
-def test_channel_tool_decision_and_hang_up():
+def test_channel_hang_up():
     ws = _FakeWS()
-    asyncio.run(_channel(ws).tool_decision("t-1", "approve"))
     asyncio.run(_channel(ws).hang_up(reason="done"))
-    assert json.loads(ws.sent[0]) == {
-        "event": "tool.decision", "tool_call_id": "t-1", "decision": "approve",
-    }
-    assert json.loads(ws.sent[1]) == {"event": "hang_up", "reason": "done"}
+    assert json.loads(ws.sent[0]) == {"event": "hang_up", "reason": "done"}
 
 
 # ── meta from WS-resolved context ────────────────────────────────────────────
@@ -330,6 +326,187 @@ def test_call_ended_without_actions_enqueues_reflection():
 
     assert len(captured) == 1
     assert "[call_ended]" in captured[0].text
+
+
+def test_call_ended_action_dict_details_are_json_not_repr():
+    a = _adapter()
+    captured = []
+
+    async def fake_enqueue(event):
+        captured.append(event)
+
+    a._enqueue = fake_enqueue
+    event = {
+        "event": "call.ended",
+        "post_call_actions": [
+            {"action": "look it up", "details": {"query": "order status"}},
+        ],
+        "transcript": [],
+    }
+
+    asyncio.run(a._hosted_dispatch_event(_channel(_FakeWS()), event, _call_meta()))
+
+    assert len(captured) == 1
+    # Dict details render as JSON, never a Python repr with single quotes.
+    assert '{"query": "order status"}' in captured[0].text
+    assert "{'query'" not in captured[0].text
+
+
+# ── call.ended lifecycle webhook ─────────────────────────────────────────────
+
+
+def _call_ended_envelope(**call_overrides):
+    """Build a ``call.ended`` webhook envelope with an inline transcript."""
+    call = {
+        "id": "call-web-1",
+        "origin": "dedicated_number",
+        "remote_phone_number": "+15550002222",
+        "direction": "inbound",
+        "status": "completed",
+        "use_inkbox_agent": True,
+    }
+    call.update(call_overrides)
+    return {
+        "event_type": "call.ended",
+        "data": {
+            "call": call,
+            "contacts": [{"id": "c-web-1", "name": "Dana"}],
+            "agent_identities": [],
+            "transcript": {
+                "entries": [
+                    {"party": "remote", "text": "hi there", "ts_ms": 0},
+                    {"marker": "abridged", "omitted_turns": 3, "omitted_ms": 9000},
+                    {"party": "local", "text": "all set", "ts_ms": 12000},
+                ],
+                "abridged": True,
+                "url": "https://example.test/api/v1/phone/calls/call-web-1/transcripts",
+            },
+            "transcript_url": "https://example.test/api/v1/phone/calls/call-web-1/transcripts",
+        },
+    }
+
+
+def test_on_call_ended_webhook_reflects_with_inline_transcript():
+    a = _adapter()
+    captured = []
+
+    async def fake_enqueue(event):
+        captured.append(event)
+
+    a._enqueue = fake_enqueue
+
+    resp = asyncio.run(a._on_call_ended(_call_ended_envelope()))
+
+    assert resp.status == 200
+    assert len(captured) == 1
+    body = captured[0].text
+    assert "[call_ended]" in body
+    # Inline transcript turns thread through; the abridged marker is dropped.
+    assert "remote: hi there" in body
+    assert "local: all set" in body
+    assert "abridged" not in body
+
+
+def test_on_call_ended_webhook_dedupes_redeliveries():
+    a = _adapter()
+    captured = []
+
+    async def fake_enqueue(event):
+        captured.append(event)
+
+    a._enqueue = fake_enqueue
+    envelope = _call_ended_envelope()
+
+    # First delivery reflects; a webhook re-delivery for the same call_id is
+    # dropped by the claim but still 200s.
+    asyncio.run(a._on_call_ended(envelope))
+    asyncio.run(a._on_call_ended(envelope))
+
+    assert len(captured) == 1
+
+
+def test_on_call_ended_webhook_defers_to_supervised_ws():
+    a = _adapter()
+    captured = []
+
+    async def fake_enqueue(event):
+        captured.append(event)
+
+    a._enqueue = fake_enqueue
+    envelope = _call_ended_envelope()
+    # A live supervisor WS owns this call — the richer WS frame reflects it, so
+    # the transcript-only webhook defers (no enqueue) but still 200s.
+    a._mark_supervised_call("call-web-1")
+
+    resp = asyncio.run(a._on_call_ended(envelope))
+
+    assert resp.status == 200
+    assert captured == []
+
+
+def test_on_call_ended_webhook_reflects_after_supervisor_closed():
+    a = _adapter()
+    captured = []
+
+    async def fake_enqueue(event):
+        captured.append(event)
+
+    a._enqueue = fake_enqueue
+    envelope = _call_ended_envelope()
+    # Supervisor opened then closed (e.g. abnormal end) without reflecting; the
+    # webhook is now the only handover and must reflect.
+    a._mark_supervised_call("call-web-1")
+    a._clear_supervised_call("call-web-1")
+
+    asyncio.run(a._on_call_ended(envelope))
+
+    assert len(captured) == 1
+
+
+def test_on_call_ended_webhook_without_inline_transcript():
+    a = _adapter()
+    captured = []
+
+    async def fake_enqueue(event):
+        captured.append(event)
+
+    a._enqueue = fake_enqueue
+    envelope = _call_ended_envelope(use_inkbox_agent=False)
+    envelope["data"].pop("transcript", None)  # non-hosted: no inline transcript
+
+    resp = asyncio.run(a._on_call_ended(envelope))
+
+    assert resp.status == 200
+    assert len(captured) == 1
+    assert "[call_ended]" in captured[0].text
+
+
+def test_webhook_call_transcript_skips_markers():
+    turns = InkboxAdapter._webhook_call_transcript({
+        "entries": [
+            {"party": "remote", "text": "one"},
+            {"marker": "abridged", "omitted_turns": 2},
+            {"party": "local", "text": "two"},
+            {"party": "remote", "text": ""},  # empty text dropped
+        ],
+    })
+    assert turns == [("remote", "one"), ("local", "two")]
+
+
+def test_webhook_call_transcript_handles_missing_block():
+    assert InkboxAdapter._webhook_call_transcript(None) == []
+    assert InkboxAdapter._webhook_call_transcript({}) == []
+
+
+def test_call_lifecycle_webhook_url_is_distinct_from_base():
+    # The call-lifecycle sub must live on its own URL so it never collides with
+    # the identity's iMessage sub (one active subscription per identity+url).
+    base = "https://tunnel.example.test/webhook"
+    call_url = adapter_mod._call_lifecycle_webhook_url(base)
+    assert call_url != base
+    assert call_url.startswith(base)
+    # Idempotent shape so current/previous URLs line up during reconcile.
+    assert adapter_mod._call_lifecycle_webhook_url(base + "/") == call_url
 
 
 # ── supervisor pump over the one call WS ─────────────────────────────────────

--- a/tests/test_realtime_hosted.py
+++ b/tests/test_realtime_hosted.py
@@ -1,0 +1,363 @@
+"""Tests for the hosted realtime voice path (config resolution + control channel)."""
+
+import asyncio
+import sys
+import types
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("inkbox_plugin")
+pkg.__path__ = [str(ROOT)]
+sys.modules.setdefault("inkbox_plugin", pkg)
+
+from inkbox_plugin import adapter as adapter_mod
+from inkbox_plugin.adapter import InkboxAdapter
+from inkbox_plugin.realtime import MODE_HOSTED, MODE_LOCAL, RealtimeConfig
+
+
+def _clear_realtime_env(monkeypatch):
+    for name in (
+        "INKBOX_REALTIME_ENABLED",
+        "INKBOX_REALTIME_API_KEY",
+        "OPENAI_API_KEY",
+        "INKBOX_REALTIME_MODE",
+        "INKBOX_REALTIME_HOSTED",
+        "INKBOX_REALTIME_VOICE",
+        "INKBOX_REALTIME_MODEL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+# ── config resolution ────────────────────────────────────────────────────────
+
+
+def test_default_mode_is_local(monkeypatch):
+    _clear_realtime_env(monkeypatch)
+    cfg = adapter_mod._resolve_realtime_config({})
+    assert cfg.mode == MODE_LOCAL
+    assert cfg.hosted is False
+
+
+def test_hosted_enabled_without_local_credential(monkeypatch):
+    _clear_realtime_env(monkeypatch)
+    # Hosted hands the voice leg to the platform, so no local key is required.
+    cfg = adapter_mod._resolve_realtime_config({"realtime": {"mode": "hosted"}})
+    assert cfg.mode == MODE_HOSTED
+    assert cfg.hosted is True
+    assert cfg.enabled is True
+    assert cfg.api_key == ""
+
+
+def test_hosted_via_env_mode(monkeypatch):
+    _clear_realtime_env(monkeypatch)
+    monkeypatch.setenv("INKBOX_REALTIME_MODE", "hosted")
+    cfg = adapter_mod._resolve_realtime_config({})
+    assert cfg.hosted is True
+    assert cfg.enabled is True
+
+
+def test_hosted_via_env_boolean(monkeypatch):
+    _clear_realtime_env(monkeypatch)
+    monkeypatch.setenv("INKBOX_REALTIME_HOSTED", "true")
+    cfg = adapter_mod._resolve_realtime_config({})
+    assert cfg.mode == MODE_HOSTED
+    assert cfg.enabled is True
+
+
+def test_explicit_mode_wins_over_hosted_flag(monkeypatch):
+    _clear_realtime_env(monkeypatch)
+    cfg = adapter_mod._resolve_realtime_config(
+        {"realtime": {"mode": "local", "hosted": True}}
+    )
+    assert cfg.mode == MODE_LOCAL
+
+
+def test_hosted_can_be_disabled(monkeypatch):
+    _clear_realtime_env(monkeypatch)
+    monkeypatch.setenv("INKBOX_REALTIME_MODE", "hosted")
+    monkeypatch.setenv("INKBOX_REALTIME_ENABLED", "false")
+    cfg = adapter_mod._resolve_realtime_config({})
+    assert cfg.hosted is True
+    assert cfg.enabled is False
+
+
+def test_unknown_mode_falls_back_to_local(monkeypatch):
+    _clear_realtime_env(monkeypatch)
+    cfg = adapter_mod._resolve_realtime_config({"realtime": {"mode": "bogus"}})
+    assert cfg.mode == MODE_LOCAL
+
+
+def test_hosted_carries_voice_and_model(monkeypatch):
+    _clear_realtime_env(monkeypatch)
+    cfg = adapter_mod._resolve_realtime_config(
+        {"realtime": {"mode": "hosted", "voice": "river", "model": "voice-x"}}
+    )
+    assert cfg.voice == "river"
+    assert cfg.model == "voice-x"
+
+
+# ── control-channel fakes ────────────────────────────────────────────────────
+
+
+class _FakeControlSession:
+    def __init__(self, events=None):
+        self._events = list(events or [])
+        self.answers = []
+        self.closed = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._events:
+            return self._events.pop(0)
+        raise StopAsyncIteration
+
+    async def answer_consult(self, consult_id, answer, instructions=None):
+        self.answers.append((consult_id, answer, instructions))
+
+    async def close(self):
+        self.closed = True
+
+
+class _FakeHostedRealtime:
+    def __init__(self):
+        self.config_calls = []
+
+    def set_config(self, **kwargs):
+        self.config_calls.append(kwargs)
+
+
+class _FakeRealtime:
+    def __init__(self, sessions):
+        self._sessions = list(sessions)
+        self.connects = []
+
+    async def connect(self, **kwargs):
+        self.connects.append(kwargs)
+        if self._sessions:
+            return self._sessions.pop(0)
+        # No further sessions — surface as "no control channel" to end the loop.
+        raise AttributeError("no more sessions")
+
+
+class _FakePhone:
+    def __init__(self, sessions):
+        self.hosted_realtime = _FakeHostedRealtime()
+        self.realtime = _FakeRealtime(sessions)
+
+
+class _FakeInkbox:
+    def __init__(self, sessions=None):
+        self.phone = _FakePhone(sessions or [])
+
+
+def _event(kind, **fields):
+    return types.SimpleNamespace(event=kind, **fields)
+
+
+def _adapter():
+    a = object.__new__(InkboxAdapter)
+    a._identity_handle = "acme"
+    a._identity_id = "identity-123"
+    a._inkbox = None
+    a._realtime_control_task = None
+    a._realtime_control_session = None
+    a._hosted_call_meta = {}
+    a._contact_cache = {}
+    a._realtime_config = RealtimeConfig(enabled=True, mode=MODE_HOSTED, voice="cedar", model="voice-x")
+    a.config = types.SimpleNamespace(extra={})
+    return a
+
+
+# ── control-channel consult answer ───────────────────────────────────────────
+
+
+def test_consult_requested_answers_via_main_agent():
+    a = _adapter()
+    seen = {}
+
+    async def fake_consult(meta, query, transcript, *_a, **_kw):
+        seen["meta"] = meta
+        seen["query"] = query
+        seen["transcript"] = transcript
+        return "The meeting is at 3pm."
+
+    a._realtime_agent_consult = fake_consult
+    session = _FakeControlSession()
+    event = _event(
+        "consult.requested",
+        call_id="call-1",
+        consult_id="consult-9",
+        query="when is the meeting?",
+        transcript_tail=[{"speaker": "remote", "text": "hi"}],
+    )
+
+    asyncio.run(a._hosted_dispatch_event(session, event))
+
+    assert session.answers == [("consult-9", "The meeting is at 3pm.", None)]
+    assert seen["query"] == "when is the meeting?"
+    assert seen["transcript"] == [("remote", "hi")]
+
+
+def test_consult_failure_pushes_graceful_answer():
+    a = _adapter()
+
+    async def boom(*_a, **_kw):
+        raise RuntimeError("agent unreachable")
+
+    a._realtime_agent_consult = boom
+    session = _FakeControlSession()
+    event = _event(
+        "consult.requested",
+        call_id="call-1",
+        consult_id="consult-9",
+        query="anything?",
+        transcript_tail=[],
+    )
+
+    asyncio.run(a._hosted_dispatch_event(session, event))
+
+    assert len(session.answers) == 1
+    consult_id, answer, _instr = session.answers[0]
+    assert consult_id == "consult-9"
+    assert "follow up" in answer.lower()
+
+
+def test_consult_uses_cached_call_meta():
+    a = _adapter()
+    a._hosted_call_meta["call-1"] = types.SimpleNamespace(
+        call_id="call-1", contact_name="Bob", remote_phone_number="+15550001111",
+        direction="inbound", contact_known=True,
+    )
+    captured = {}
+
+    async def fake_consult(meta, query, transcript, *_a, **_kw):
+        captured["meta"] = meta
+        return "ok"
+
+    a._realtime_agent_consult = fake_consult
+    session = _FakeControlSession()
+    event = _event(
+        "consult.requested", call_id="call-1", consult_id="c-1", query="q",
+        transcript_tail=[],
+    )
+
+    asyncio.run(a._hosted_dispatch_event(session, event))
+
+    assert captured["meta"].contact_name == "Bob"
+
+
+# ── post-call handling ───────────────────────────────────────────────────────
+
+
+def test_call_ended_with_actions_enqueues_post_call_turn():
+    a = _adapter()
+    captured = []
+
+    async def fake_enqueue(event):
+        captured.append(event)
+
+    a._enqueue = fake_enqueue
+    event = _event(
+        "call.ended",
+        call_id="call-1",
+        reason="completed",
+        post_call_actions=[{"action": "email bob the quote", "details": "re: pricing"}],
+        transcript=[{"speaker": "remote", "text": "thanks, bye"}],
+    )
+
+    asyncio.run(a._hosted_dispatch_event(None, event))
+
+    assert len(captured) == 1
+    assert "email bob the quote" in captured[0].text
+    assert "re: pricing" in captured[0].text
+
+
+def test_call_ended_without_actions_enqueues_reflection():
+    a = _adapter()
+    captured = []
+
+    async def fake_enqueue(event):
+        captured.append(event)
+
+    a._enqueue = fake_enqueue
+    event = _event(
+        "call.ended",
+        call_id="call-1",
+        reason="completed",
+        post_call_actions=[],
+        transcript=[{"speaker": "remote", "text": "bye"}],
+    )
+
+    asyncio.run(a._hosted_dispatch_event(None, event))
+
+    assert len(captured) == 1
+    assert "[call_ended]" in captured[0].text
+
+
+def test_call_ended_pops_cached_meta():
+    a = _adapter()
+    a._hosted_call_meta["call-1"] = types.SimpleNamespace(
+        call_id="call-1", contact_id="c", contact_name="Bob",
+        remote_phone_number=None, direction="inbound",
+    )
+
+    async def fake_enqueue(event):
+        pass
+
+    a._enqueue = fake_enqueue
+    event = _event(
+        "call.ended", call_id="call-1", reason="done",
+        post_call_actions=[], transcript=[],
+    )
+
+    asyncio.run(a._hosted_dispatch_event(None, event))
+
+    assert "call-1" not in a._hosted_call_meta
+
+
+# ── start + subscription loop ────────────────────────────────────────────────
+
+
+def test_start_hosted_realtime_enables_config_and_subscribes():
+    a = _adapter()
+
+    async def fake_consult(meta, query, transcript, *_a, **_kw):
+        return "answer"
+
+    a._realtime_agent_consult = fake_consult
+    session = _FakeControlSession([
+        _event(
+            "consult.requested", call_id="call-1", consult_id="c-1",
+            query="q", transcript_tail=[],
+        ),
+    ])
+    a._inkbox = _FakeInkbox([session])
+
+    async def scenario():
+        await a._start_hosted_realtime()
+        # The subscription task connects, drains the one session, then exits the
+        # reconnect loop when the fake client reports no further sessions.
+        await a._realtime_control_task
+
+    asyncio.run(scenario())
+
+    hosted = a._inkbox.phone.hosted_realtime
+    assert hosted.config_calls[0]["enabled"] is True
+    assert hosted.config_calls[0]["agent_identity_id"] == "identity-123"
+    assert a._inkbox.phone.realtime.connects[0]["agent_identity_id"] == "identity-123"
+    assert session.answers == [("c-1", "answer", None)]
+
+
+def test_start_hosted_realtime_without_config_surface_is_safe():
+    a = _adapter()
+
+    class _NoSurface:
+        phone = types.SimpleNamespace()
+
+    a._inkbox = _NoSurface()
+    # Missing hosted_realtime attribute must not raise out of start.
+    asyncio.run(a._start_hosted_realtime())
+    assert a._realtime_control_task is None

--- a/tests/test_realtime_hosted.py
+++ b/tests/test_realtime_hosted.py
@@ -1,9 +1,12 @@
-"""Tests for the hosted realtime voice path (config resolution + control channel)."""
+"""Tests for the hosted realtime voice path (config resolution + supervisor WS)."""
 
 import asyncio
+import json
 import sys
 import types
 from pathlib import Path
+
+from aiohttp import WSMsgType
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -13,7 +16,7 @@ sys.modules.setdefault("inkbox_plugin", pkg)
 
 from inkbox_plugin import adapter as adapter_mod
 from inkbox_plugin.adapter import InkboxAdapter
-from inkbox_plugin.realtime import MODE_HOSTED, MODE_LOCAL, RealtimeConfig
+from inkbox_plugin.realtime import MODE_HOSTED, MODE_LOCAL, RealtimeCallMeta, RealtimeConfig
 
 
 def _clear_realtime_env(monkeypatch):
@@ -97,64 +100,39 @@ def test_hosted_carries_voice_and_model(monkeypatch):
     assert cfg.model == "voice-x"
 
 
-# ── control-channel fakes ────────────────────────────────────────────────────
+# ── supervisor WS fakes ──────────────────────────────────────────────────────
 
 
-class _FakeControlSession:
-    def __init__(self, events=None):
-        self._events = list(events or [])
-        self.answers = []
+class _FakeWS:
+    """Minimal call WS: async-iterates observe frames, captures intervene ones."""
+
+    def __init__(self, messages=None):
+        self._messages = list(messages or [])
+        self.sent = []
         self.closed = False
 
     def __aiter__(self):
         return self
 
     async def __anext__(self):
-        if self._events:
-            return self._events.pop(0)
+        if self._messages:
+            return self._messages.pop(0)
         raise StopAsyncIteration
 
-    async def answer_consult(self, consult_id, answer, instructions=None):
-        self.answers.append((consult_id, answer, instructions))
+    async def send_str(self, data):
+        self.sent.append(data)
 
     async def close(self):
         self.closed = True
 
 
-class _FakeHostedRealtime:
-    def __init__(self):
-        self.config_calls = []
-
-    def set_config(self, **kwargs):
-        self.config_calls.append(kwargs)
+def _text_msg(**frame):
+    """Wrap a wire frame dict as a TEXT WS message."""
+    return types.SimpleNamespace(type=WSMsgType.TEXT, data=json.dumps(frame))
 
 
-class _FakeRealtime:
-    def __init__(self, sessions):
-        self._sessions = list(sessions)
-        self.connects = []
-
-    async def connect(self, **kwargs):
-        self.connects.append(kwargs)
-        if self._sessions:
-            return self._sessions.pop(0)
-        # No further sessions — surface as "no control channel" to end the loop.
-        raise AttributeError("no more sessions")
-
-
-class _FakePhone:
-    def __init__(self, sessions):
-        self.hosted_realtime = _FakeHostedRealtime()
-        self.realtime = _FakeRealtime(sessions)
-
-
-class _FakeInkbox:
-    def __init__(self, sessions=None):
-        self.phone = _FakePhone(sessions or [])
-
-
-def _event(kind, **fields):
-    return types.SimpleNamespace(event=kind, **fields)
+def _channel(ws):
+    return adapter_mod._HostedSupervisorChannel(ws)
 
 
 def _adapter():
@@ -162,16 +140,89 @@ def _adapter():
     a._identity_handle = "acme"
     a._identity_id = "identity-123"
     a._inkbox = None
-    a._realtime_control_task = None
-    a._realtime_control_session = None
-    a._hosted_call_meta = {}
     a._contact_cache = {}
     a._realtime_config = RealtimeConfig(enabled=True, mode=MODE_HOSTED, voice="cedar", model="voice-x")
     a.config = types.SimpleNamespace(extra={})
     return a
 
 
-# ── control-channel consult answer ───────────────────────────────────────────
+def _call_meta(**overrides):
+    fields = dict(
+        call_id="call-1",
+        contact_id="c-1",
+        contact_name="Bob",
+        remote_phone_number="+15550001111",
+        direction="inbound",
+        agent_identity_handle="acme",
+        contact_known=True,
+    )
+    fields.update(overrides)
+    return RealtimeCallMeta(**fields)
+
+
+# ── intervene channel frames ─────────────────────────────────────────────────
+
+
+def test_channel_answer_consult_frame():
+    ws = _FakeWS()
+    asyncio.run(_channel(ws).answer_consult("c-9", "at 3pm"))
+    assert json.loads(ws.sent[0]) == {
+        "event": "consult.answer", "consult_id": "c-9", "answer": "at 3pm",
+    }
+
+
+def test_channel_answer_consult_with_instructions():
+    ws = _FakeWS()
+    asyncio.run(_channel(ws).answer_consult("c-9", "at 3pm", instructions="be brief"))
+    assert json.loads(ws.sent[0]) == {
+        "event": "consult.answer", "consult_id": "c-9", "answer": "at 3pm",
+        "instructions": "be brief",
+    }
+
+
+def test_channel_inject_and_update_instructions():
+    ws = _FakeWS()
+    asyncio.run(_channel(ws).inject("hold on", mode="context"))
+    asyncio.run(_channel(ws).update_instructions("stay on topic"))
+    assert json.loads(ws.sent[0]) == {
+        "event": "inject", "mode": "context", "text": "hold on",
+    }
+    assert json.loads(ws.sent[1]) == {
+        "event": "update_instructions", "instructions": "stay on topic",
+    }
+
+
+def test_channel_tool_decision_and_hang_up():
+    ws = _FakeWS()
+    asyncio.run(_channel(ws).tool_decision("t-1", "approve"))
+    asyncio.run(_channel(ws).hang_up(reason="done"))
+    assert json.loads(ws.sent[0]) == {
+        "event": "tool.decision", "tool_call_id": "t-1", "decision": "approve",
+    }
+    assert json.loads(ws.sent[1]) == {"event": "hang_up", "reason": "done"}
+
+
+# ── meta from WS-resolved context ────────────────────────────────────────────
+
+
+def test_call_meta_from_ws_context():
+    a = _adapter()
+    meta = a._hosted_call_meta_from({
+        "call_id": "call-9",
+        "contact_id": "c-9",
+        "contact_name": "Bob",
+        "remote_phone_number": "+15550001111",
+        "direction": "Outbound",
+        "contact": {"emails": ["bob@x.com"], "company": "Acme"},
+    })
+    assert meta.call_id == "call-9"
+    assert meta.direction == "outbound"
+    assert meta.contact_known is True
+    assert meta.contact_emails == ["bob@x.com"]
+    assert meta.contact_company == "Acme"
+
+
+# ── consult over the supervisor WS ───────────────────────────────────────────
 
 
 def test_consult_requested_answers_via_main_agent():
@@ -185,20 +236,24 @@ def test_consult_requested_answers_via_main_agent():
         return "The meeting is at 3pm."
 
     a._realtime_agent_consult = fake_consult
-    session = _FakeControlSession()
-    event = _event(
-        "consult.requested",
-        call_id="call-1",
-        consult_id="consult-9",
-        query="when is the meeting?",
-        transcript_tail=[{"speaker": "remote", "text": "hi"}],
-    )
+    ws = _FakeWS()
+    event = {
+        "event": "consult.requested",
+        "consult_id": "consult-9",
+        "query": "when is the meeting?",
+        "transcript_tail": [{"speaker": "remote", "text": "hi"}],
+    }
 
-    asyncio.run(a._hosted_dispatch_event(session, event))
+    asyncio.run(a._hosted_dispatch_event(_channel(ws), event, _call_meta()))
 
-    assert session.answers == [("consult-9", "The meeting is at 3pm.", None)]
+    assert json.loads(ws.sent[0]) == {
+        "event": "consult.answer", "consult_id": "consult-9",
+        "answer": "The meeting is at 3pm.",
+    }
     assert seen["query"] == "when is the meeting?"
     assert seen["transcript"] == [("remote", "hi")]
+    # The consult runs against the WS-resolved caller context.
+    assert seen["meta"].contact_name == "Bob"
 
 
 def test_consult_failure_pushes_graceful_answer():
@@ -208,45 +263,27 @@ def test_consult_failure_pushes_graceful_answer():
         raise RuntimeError("agent unreachable")
 
     a._realtime_agent_consult = boom
-    session = _FakeControlSession()
-    event = _event(
-        "consult.requested",
-        call_id="call-1",
-        consult_id="consult-9",
-        query="anything?",
-        transcript_tail=[],
-    )
+    ws = _FakeWS()
+    event = {
+        "event": "consult.requested",
+        "consult_id": "consult-9",
+        "query": "anything?",
+        "transcript_tail": [],
+    }
 
-    asyncio.run(a._hosted_dispatch_event(session, event))
+    asyncio.run(a._hosted_dispatch_event(_channel(ws), event, _call_meta()))
 
-    assert len(session.answers) == 1
-    consult_id, answer, _instr = session.answers[0]
-    assert consult_id == "consult-9"
-    assert "follow up" in answer.lower()
+    frame = json.loads(ws.sent[0])
+    assert frame["consult_id"] == "consult-9"
+    assert "follow up" in frame["answer"].lower()
 
 
-def test_consult_uses_cached_call_meta():
+def test_consult_missing_fields_is_noop():
     a = _adapter()
-    a._hosted_call_meta["call-1"] = types.SimpleNamespace(
-        call_id="call-1", contact_name="Bob", remote_phone_number="+15550001111",
-        direction="inbound", contact_known=True,
-    )
-    captured = {}
-
-    async def fake_consult(meta, query, transcript, *_a, **_kw):
-        captured["meta"] = meta
-        return "ok"
-
-    a._realtime_agent_consult = fake_consult
-    session = _FakeControlSession()
-    event = _event(
-        "consult.requested", call_id="call-1", consult_id="c-1", query="q",
-        transcript_tail=[],
-    )
-
-    asyncio.run(a._hosted_dispatch_event(session, event))
-
-    assert captured["meta"].contact_name == "Bob"
+    ws = _FakeWS()
+    event = {"event": "consult.requested", "consult_id": "", "query": ""}
+    asyncio.run(a._hosted_dispatch_event(_channel(ws), event, _call_meta()))
+    assert ws.sent == []
 
 
 # ── post-call handling ───────────────────────────────────────────────────────
@@ -260,15 +297,14 @@ def test_call_ended_with_actions_enqueues_post_call_turn():
         captured.append(event)
 
     a._enqueue = fake_enqueue
-    event = _event(
-        "call.ended",
-        call_id="call-1",
-        reason="completed",
-        post_call_actions=[{"action": "email bob the quote", "details": "re: pricing"}],
-        transcript=[{"speaker": "remote", "text": "thanks, bye"}],
-    )
+    event = {
+        "event": "call.ended",
+        "reason": "completed",
+        "post_call_actions": [{"action": "email bob the quote", "details": "re: pricing"}],
+        "transcript": [{"speaker": "remote", "text": "thanks, bye"}],
+    }
 
-    asyncio.run(a._hosted_dispatch_event(None, event))
+    asyncio.run(a._hosted_dispatch_event(_channel(_FakeWS()), event, _call_meta()))
 
     assert len(captured) == 1
     assert "email bob the quote" in captured[0].text
@@ -283,81 +319,59 @@ def test_call_ended_without_actions_enqueues_reflection():
         captured.append(event)
 
     a._enqueue = fake_enqueue
-    event = _event(
-        "call.ended",
-        call_id="call-1",
-        reason="completed",
-        post_call_actions=[],
-        transcript=[{"speaker": "remote", "text": "bye"}],
-    )
+    event = {
+        "event": "call.ended",
+        "reason": "completed",
+        "post_call_actions": [],
+        "transcript": [{"speaker": "remote", "text": "bye"}],
+    }
 
-    asyncio.run(a._hosted_dispatch_event(None, event))
+    asyncio.run(a._hosted_dispatch_event(_channel(_FakeWS()), event, _call_meta()))
 
     assert len(captured) == 1
     assert "[call_ended]" in captured[0].text
 
 
-def test_call_ended_pops_cached_meta():
-    a = _adapter()
-    a._hosted_call_meta["call-1"] = types.SimpleNamespace(
-        call_id="call-1", contact_id="c", contact_name="Bob",
-        remote_phone_number=None, direction="inbound",
-    )
-
-    async def fake_enqueue(event):
-        pass
-
-    a._enqueue = fake_enqueue
-    event = _event(
-        "call.ended", call_id="call-1", reason="done",
-        post_call_actions=[], transcript=[],
-    )
-
-    asyncio.run(a._hosted_dispatch_event(None, event))
-
-    assert "call-1" not in a._hosted_call_meta
+# ── supervisor pump over the one call WS ─────────────────────────────────────
 
 
-# ── start + subscription loop ────────────────────────────────────────────────
-
-
-def test_start_hosted_realtime_enables_config_and_subscribes():
+def test_run_hosted_supervisor_drains_frames_and_answers_consult():
     a = _adapter()
 
     async def fake_consult(meta, query, transcript, *_a, **_kw):
         return "answer"
 
     a._realtime_agent_consult = fake_consult
-    session = _FakeControlSession([
-        _event(
-            "consult.requested", call_id="call-1", consult_id="c-1",
-            query="q", transcript_tail=[],
+    ws = _FakeWS([
+        _text_msg(event="call.started", call_id="call-1", direction="inbound"),
+        _text_msg(event="transcript", party="remote", text="hi", is_final=True),
+        _text_msg(
+            event="consult.requested", consult_id="c-1", query="q",
+            transcript_tail=[],
         ),
     ])
-    a._inkbox = _FakeInkbox([session])
 
-    async def scenario():
-        await a._start_hosted_realtime()
-        # The subscription task connects, drains the one session, then exits the
-        # reconnect loop when the fake client reports no further sessions.
-        await a._realtime_control_task
+    meta = {
+        "call_id": "call-1",
+        "contact_id": "c-1",
+        "contact_name": "Bob",
+        "remote_phone_number": "+15550001111",
+        "direction": "inbound",
+    }
+    asyncio.run(a._run_hosted_supervisor(ws, meta))
 
-    asyncio.run(scenario())
-
-    hosted = a._inkbox.phone.hosted_realtime
-    assert hosted.config_calls[0]["enabled"] is True
-    assert hosted.config_calls[0]["agent_identity_id"] == "identity-123"
-    assert a._inkbox.phone.realtime.connects[0]["agent_identity_id"] == "identity-123"
-    assert session.answers == [("c-1", "answer", None)]
+    # The consult answer rode back down the same call WS.
+    assert json.loads(ws.sent[0]) == {
+        "event": "consult.answer", "consult_id": "c-1", "answer": "answer",
+    }
 
 
-def test_start_hosted_realtime_without_config_surface_is_safe():
+def test_run_hosted_supervisor_ignores_non_text_frames():
     a = _adapter()
-
-    class _NoSurface:
-        phone = types.SimpleNamespace()
-
-    a._inkbox = _NoSurface()
-    # Missing hosted_realtime attribute must not raise out of start.
-    asyncio.run(a._start_hosted_realtime())
-    assert a._realtime_control_task is None
+    ws = _FakeWS([
+        types.SimpleNamespace(type=WSMsgType.BINARY, data=b"\x00"),
+        types.SimpleNamespace(type=WSMsgType.TEXT, data="not-json"),
+    ])
+    # Neither a binary frame nor malformed JSON should raise out of the pump.
+    asyncio.run(a._run_hosted_supervisor(ws, {"call_id": "call-1"}))
+    assert ws.sent == []

--- a/uv.lock
+++ b/uv.lock
@@ -484,7 +484,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent-plugin"
-version = "0.2.3"
+version = "0.2.4"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -501,7 +501,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9" },
-    { name = "inkbox", specifier = ">=0.4.15,<1.0.0" },
+    { name = "inkbox", specifier = ">=0.4.18,<1.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
     { name = "ruff", marker = "extra == 'test'", specifier = ">=0.11.0" },
     { name = "segno", specifier = ">=1.5" },

--- a/uv.lock
+++ b/uv.lock
@@ -484,7 +484,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent-plugin"
-version = "0.2.2"
+version = "0.2.3"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -501,7 +501,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9" },
-    { name = "inkbox", specifier = ">=0.4.18,<1.0.0" },
+    { name = "inkbox", specifier = ">=0.4.19,<1.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
     { name = "ruff", marker = "extra == 'test'", specifier = ">=0.11.0" },
     { name = "segno", specifier = ">=1.5" },

--- a/uv.lock
+++ b/uv.lock
@@ -484,7 +484,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent-plugin"
-version = "0.2.0"
+version = "0.2.2"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -501,7 +501,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9" },
-    { name = "inkbox", specifier = ">=0.4.10,<0.4.15" },
+    { name = "inkbox", specifier = ">=0.4.15,<1.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
     { name = "ruff", marker = "extra == 'test'", specifier = ">=0.11.0" },
     { name = "segno", specifier = ">=1.5" },
@@ -574,7 +574,7 @@ wheels = [
 
 [[package]]
 name = "inkbox"
-version = "0.4.13"
+version = "0.4.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "argon2-cffi" },
@@ -584,9 +584,9 @@ dependencies = [
     { name = "h2" },
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/22/0891e422160349159f7346a76c65107a93fed6bec60e70c9d41d4689a62d/inkbox-0.4.13.tar.gz", hash = "sha256:f7f91757713c60b8d92085264720a7ef013bd4093c969345eaa6b0bb3f42e35c", size = 294977, upload-time = "2026-06-28T04:37:47.655Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/d7/7b24767d58f2e6ad56fda93655f6d2470468aa5ed30b26da8e5da2578e95/inkbox-0.4.16.tar.gz", hash = "sha256:fc8877d09aa7ab1536e90a57354487c97c8eff6886e6e99c51c09b4f5f48eb78", size = 316994, upload-time = "2026-07-04T07:03:29.622Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/73/fc566f55d0fb3d5563b53a61e42e9b7e992203081f3543c5cabb58485f66/inkbox-0.4.13-py3-none-any.whl", hash = "sha256:31cf621b84c3e2fbe5c5523fc06b00ac2a8e04ad03be634262e9044df5165281", size = 208866, upload-time = "2026-06-28T04:37:46.393Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/d8/05142a38af28f24d45d4140fecb3736deaf3b68afd7dc5b67fdb1c72d7b3/inkbox-0.4.16-py3-none-any.whl", hash = "sha256:28b37eeb5ebb67ed321f0705c465ee3ab48423bda4b2bc202616bb71724e8230", size = 223458, upload-time = "2026-07-04T07:03:28.436Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adopts platform-hosted realtime voice over the **one** call WebSocket. The plugin always opens a single call WS and opts into hosting with the `X-Use-Inkbox-Agent: true` upgrade-response header; the old separate control-socket path is removed.

## Changes
- Hosted mode is negotiated with the `X-Use-Inkbox-Agent` header — no second socket, no `X-Service-Token`, no subscribe handshake.
- In hosted mode the plugin runs a supervisor over that same WS: it drains observe frames (`transcript`, `consult.requested`, `call.ended`, …) and can send intervene frames (`inject`, `consult.answer`, `update_instructions`, `hang_up`). There is no tool-approval flow — hosted write tools apply immediately.
- Framing uses the `inkbox` SDK `phone.realtime` codec (inkbox#93); requires `inkbox>=0.4.19`.
- Consumes the new `call.ended` lifecycle webhook as a post-call trigger, so the agent learns a call ended even when it wasn't holding the call WS.
- Fixes a hosted-path crash: `_prepare_call_ws` now defaults `use_realtime`, so hosted calls no longer raise before the WS is prepared.

## Config (self-contained hosted setup)
- `INKBOX_REALTIME_HOSTED` — opt inbound calls into platform-hosted voice (no local OpenAI key needed).
- `INKBOX_REALTIME_INSTRUCTIONS` — extra system instructions appended to the voice agent's base prompt (persona/tone/rules). Applies to local and hosted.
- In hosted mode the server builds the prompt, so at registration the plugin persists the identity's hosted-voice config via the SDK (`set_hosted_realtime_config`: enabled/voice/model/instructions). That call also flips the server-side enable flag the hosted path gates on — so turning on hosted mode in the plugin is now end-to-end self-contained.

Plugin version 0.2.2 → **0.2.4**. 218 unit tests pass; ruff clean.

