### PR TITLE
Realtime: proactive call supervisor (push-mode brain ↔ mouth)

### DIFF
--- a/.github/workflows/live-supervisor.yml
+++ b/.github/workflows/live-supervisor.yml
@@ -1,0 +1,45 @@
+name: Live — supervisor quality
+
+# Runs the LLM-judged proof that the proactive realtime supervisor produces
+# higher-quality calls than the pull-only baseline. Uses real models (a fast
+# voice model, a supervisor model, and a stronger judge), so it is manual /
+# on-demand only — the deterministic proof in the unit suite
+# (tests/test_supervisor_proof.py) is what gates every PR.
+on:
+  workflow_dispatch:
+    inputs:
+      voice_model:
+        description: "Fast voice model (the 'mouth')"
+        default: "gpt-4o-mini"
+      brain_model:
+        description: "Supervisor model (the 'mid' brain)"
+        default: "gpt-4o-mini"
+      judge_model:
+        description: "Blind judge model"
+        default: "gpt-4o"
+
+permissions:
+  contents: read
+
+jobs:
+  supervisor-quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "latest"
+
+      - name: Install deps
+        run: uv sync --extra test --python 3.12
+
+      - name: Run LLM-judged supervisor proof
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          LIVE_REAL_MODEL: "1"
+          SUPERVISOR_VOICE_MODEL: ${{ github.event.inputs.voice_model || 'gpt-4o-mini' }}
+          SUPERVISOR_BRAIN_MODEL: ${{ github.event.inputs.brain_model || 'gpt-4o-mini' }}
+          SUPERVISOR_JUDGE_MODEL: ${{ github.event.inputs.judge_model || 'gpt-4o' }}
+        run: uv run pytest tests/live/test_supervisor_quality.py -v -s

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ __pycache__/
 dist/
 build/
 *.egg-info/
+
+# local test venv
+.venv-test/

--- a/README.md
+++ b/README.md
@@ -162,6 +162,19 @@ Realtime calls receive the agent's Inkbox handle, mailbox, phone number, caller 
 
 When Realtime is enabled, the plugin preflights the OpenAI Realtime websocket before accepting the Inkbox call in raw-media mode. If that preflight fails, calls fall back to Inkbox STT/TTS by default. Set `INKBOX_REALTIME_FALLBACK_TO_INKBOX_STT_TTS=false` to fail the call instead.
 
+### Proactive supervisor (opt-in)
+
+By default the realtime voice model drives the whole call and only reaches the main agent when *it* decides to call `consult_agent` (pull-only). The **supervisor** adds the missing push channel: a background loop watches the transcript as the call proceeds and, on its own initiative, injects steering guidance into the live session — adding context, correcting a wrong statement, or redirecting the voice model — without waiting to be asked. See [`docs/realtime-supervisor.md`](docs/realtime-supervisor.md) for the full architecture and the quality proof.
+
+It runs a cheap reasoning model (the "mid" tier between the fast voice model and the heavy main agent) once per caller turn, debounced and rate-limited, and defaults to doing nothing. Enable it under `platforms.inkbox.realtime.supervisor` or with env:
+
+```bash
+export INKBOX_REALTIME_SUPERVISOR=true               # off by default
+export INKBOX_REALTIME_SUPERVISOR_MODEL="gpt-4o-mini" # the supervisor/"mid" model
+```
+
+Guidance is delivered two ways: a **silent steer** (an out-of-band `system` note the voice model folds into its next turn) or a **speak-now interject** (the same note plus an immediate response, e.g. to correct a fact it just stated). The heavy main agent is still reached via `consult_agent` for actual tool work — the supervisor only steers, and can proactively tell the voice model *to* consult.
+
 ### Two calling lines
 
 Calls — inbound and outbound — can run over either of two lines, and the agent picks the one that matches the channel it's talking on:
@@ -246,6 +259,10 @@ After the gateway starts:
 | `INKBOX_REALTIME_CONNECT_TIMEOUT_S` | no | `8` | Seconds to wait for OpenAI Realtime preflight before falling back or failing. |
 | `INKBOX_REALTIME_CONSULT_TIMEOUT_S` | no | plugin default | Seconds the Realtime voice agent waits for a Hermes consult before continuing. |
 | `INKBOX_REALTIME_FALLBACK_TO_INKBOX_STT_TTS` | no | `true` | Fall back to Inkbox STT/TTS if OpenAI Realtime connect/auth fails before call accept. |
+| `INKBOX_REALTIME_SUPERVISOR` | no | `false` | Enable the proactive supervisor loop that watches the transcript and injects mid-call steering. |
+| `INKBOX_REALTIME_SUPERVISOR_MODEL` | no | `gpt-4o-mini` | Reasoning model the supervisor uses to review the call and decide whether to nudge. |
+| `INKBOX_REALTIME_SUPERVISOR_MAX_INTERJECTIONS` | no | `8` | Hard cap on supervisor notes injected per call. |
+| `INKBOX_REALTIME_SUPERVISOR_MIN_INTERVAL_S` | no | `6` | Minimum seconds between supervisor reviews. |
 
 ## Channel Overrides
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ After the gateway starts:
 | `INKBOX_REALTIME_SUPERVISOR` | no | `false` | Enable the proactive supervisor loop that watches the transcript and injects mid-call steering. |
 | `INKBOX_REALTIME_SUPERVISOR_MODEL` | no | `gpt-4o-mini` | Reasoning model the supervisor uses to review the call and decide whether to nudge. |
 | `INKBOX_REALTIME_SUPERVISOR_MAX_INTERJECTIONS` | no | `8` | Hard cap on supervisor notes injected per call. |
-| `INKBOX_REALTIME_SUPERVISOR_MIN_INTERVAL_S` | no | `6` | Minimum seconds between supervisor reviews. |
+| `INKBOX_REALTIME_SUPERVISOR_MIN_INTERVAL_S` | no | `0` | Floor on seconds between supervisor reviews (`0` = review every settled turn). |
 
 ## Channel Overrides
 

--- a/README.md
+++ b/README.md
@@ -166,11 +166,13 @@ When Realtime is enabled, the plugin preflights the OpenAI Realtime websocket be
 
 By default the realtime voice model drives the whole call and only reaches the main agent when *it* decides to call `consult_agent` (pull-only). The **supervisor** adds the missing push channel: a background loop watches the transcript as the call proceeds and, on its own initiative, injects steering guidance into the live session — adding context, correcting a wrong statement, or redirecting the voice model — without waiting to be asked. See [`docs/realtime-supervisor.md`](docs/realtime-supervisor.md) for the full architecture and the quality proof.
 
-It runs a cheap reasoning model (the "mid" tier between the fast voice model and the heavy main agent) once per caller turn, debounced and rate-limited, and defaults to doing nothing. Enable it under `platforms.inkbox.realtime.supervisor` or with env:
+It reviews once per settled turn (debounced and rate-limited) and defaults to doing nothing. By default the reviewer is the **real Hermes agent** (`backend: hermes`), run as a single bounded `hermes -z` pass — so it has tools and can *verify* a fact the fast voice model got wrong, not just reason over the transcript. Set `backend: model` for a cheaper context-only reviewer that catches guardrail/consistency problems but can't look facts up. Enable it under `platforms.inkbox.realtime.supervisor` or with env:
 
 ```bash
-export INKBOX_REALTIME_SUPERVISOR=true               # off by default
-export INKBOX_REALTIME_SUPERVISOR_MODEL="gpt-4o-mini" # the supervisor/"mid" model
+export INKBOX_REALTIME_SUPERVISOR=true                 # off by default
+export INKBOX_REALTIME_SUPERVISOR_BACKEND="hermes"     # hermes (default) | model
+export INKBOX_REALTIME_SUPERVISOR_HERMES_MODEL="gpt-5-mini"  # optional fast model for the hermes backend
+export INKBOX_REALTIME_SUPERVISOR_MODEL="gpt-4o-mini"  # model used only by the "model" backend
 ```
 
 Guidance is delivered two ways: a **silent steer** (an out-of-band `system` note the voice model folds into its next turn) or a **speak-now interject** (the same note plus an immediate response, e.g. to correct a fact it just stated). The heavy main agent is still reached via `consult_agent` for actual tool work — the supervisor only steers, and can proactively tell the voice model *to* consult.
@@ -260,7 +262,9 @@ After the gateway starts:
 | `INKBOX_REALTIME_CONSULT_TIMEOUT_S` | no | plugin default | Seconds the Realtime voice agent waits for a Hermes consult before continuing. |
 | `INKBOX_REALTIME_FALLBACK_TO_INKBOX_STT_TTS` | no | `true` | Fall back to Inkbox STT/TTS if OpenAI Realtime connect/auth fails before call accept. |
 | `INKBOX_REALTIME_SUPERVISOR` | no | `false` | Enable the proactive supervisor loop that watches the transcript and injects mid-call steering. |
-| `INKBOX_REALTIME_SUPERVISOR_MODEL` | no | `gpt-4o-mini` | Reasoning model the supervisor uses to review the call and decide whether to nudge. |
+| `INKBOX_REALTIME_SUPERVISOR_BACKEND` | no | `hermes` | Which brain reviews: `hermes` (real agent via `hermes -z`, has tools) or `model` (cheap context-only chat model). |
+| `INKBOX_REALTIME_SUPERVISOR_HERMES_MODEL` | no | CLI default | Optional cheaper/faster model for the `hermes` backend (passed to the CLI as `HERMES_MODEL`). |
+| `INKBOX_REALTIME_SUPERVISOR_MODEL` | no | `gpt-4o-mini` | Reasoning model used only by the `model` backend. |
 | `INKBOX_REALTIME_SUPERVISOR_MAX_INTERJECTIONS` | no | `8` | Hard cap on supervisor notes injected per call. |
 | `INKBOX_REALTIME_SUPERVISOR_MIN_INTERVAL_S` | no | `0` | Floor on seconds between supervisor reviews (`0` = review every settled turn). |
 

--- a/adapter.py
+++ b/adapter.py
@@ -4380,7 +4380,8 @@ class InkboxAdapter(BasePlatformAdapter):
         "- interject: the agent just said something wrong or misleading and must "
         "correct it immediately.\n"
         "guidance must be one imperative sentence addressed to the agent, "
-        "spoken-friendly, and must never invent facts you were not given."
+        "spoken-friendly, and must never invent facts you were not given. Keep "
+        "reason under 12 words so the JSON stays short and complete."
     )
 
     async def _realtime_supervise(
@@ -4447,7 +4448,9 @@ class InkboxAdapter(BasePlatformAdapter):
                 {"role": "user", "content": user_content},
             ],
             "temperature": 0,
-            "max_tokens": 200,
+            # Roomy enough that a short JSON decision never truncates mid-object
+            # (json_object mode does not bound length on its own).
+            "max_tokens": 400,
             "response_format": {"type": "json_object"},
         }
         headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}

--- a/adapter.py
+++ b/adapter.py
@@ -145,6 +145,7 @@ try:
         RealtimeConsultResult,
         open_inkbox_realtime_bridge,
     )
+    from .realtime_supervisor import SupervisorConfig, SupervisorDecision, parse_supervisor_decision
 except ImportError:  # pragma: no cover - direct local import/test fallback
     from config import INKBOX_BASE_URL_DEFAULT, inkbox_client_kwargs
     from webhook_providers import match_provider
@@ -158,6 +159,7 @@ except ImportError:  # pragma: no cover - direct local import/test fallback
         RealtimeConsultResult,
         open_inkbox_realtime_bridge,
     )
+    from realtime_supervisor import SupervisorConfig, SupervisorDecision, parse_supervisor_decision
 
 logger = logging.getLogger(__name__)
 
@@ -387,6 +389,56 @@ def _realtime_bool(value: Any, default: bool) -> bool:
     return default
 
 
+def _resolve_supervisor_config(rt_extra: Dict[str, Any]) -> SupervisorConfig:
+    """Resolve the proactive-supervisor config from ``realtime.supervisor``.
+
+    Config shape under ``platforms.inkbox.realtime.supervisor`` in config.yaml,
+    with an ``INKBOX_REALTIME_SUPERVISOR`` env override for the on/off switch:
+
+        supervisor:
+          enabled: bool          # default false
+          debounce_s: float
+          review_timeout_s: float
+          min_review_interval_s: float
+          max_interjections: int
+          min_caller_turns: int
+    """
+    sup_extra = rt_extra.get("supervisor") if isinstance(rt_extra.get("supervisor"), dict) else {}
+    enabled = _realtime_bool(
+        sup_extra.get("enabled")
+        if "enabled" in sup_extra
+        else os.getenv("INKBOX_REALTIME_SUPERVISOR"),
+        False,
+    )
+    defaults = SupervisorConfig()
+
+    def _num(key: str, env: str, default: float) -> float:
+        raw = sup_extra.get(key)
+        if raw is None:
+            raw = os.getenv(env)
+        try:
+            return float(raw) if raw not in (None, "") else default
+        except (TypeError, ValueError):
+            return default
+
+    return SupervisorConfig(
+        enabled=enabled,
+        debounce_s=_num("debounce_s", "INKBOX_REALTIME_SUPERVISOR_DEBOUNCE_S", defaults.debounce_s),
+        review_timeout_s=_num(
+            "review_timeout_s", "INKBOX_REALTIME_SUPERVISOR_REVIEW_TIMEOUT_S", defaults.review_timeout_s,
+        ),
+        min_review_interval_s=_num(
+            "min_review_interval_s", "INKBOX_REALTIME_SUPERVISOR_MIN_INTERVAL_S", defaults.min_review_interval_s,
+        ),
+        max_interjections=int(_num(
+            "max_interjections", "INKBOX_REALTIME_SUPERVISOR_MAX_INTERJECTIONS", defaults.max_interjections,
+        )),
+        min_caller_turns=int(_num(
+            "min_caller_turns", "INKBOX_REALTIME_SUPERVISOR_MIN_CALLER_TURNS", defaults.min_caller_turns,
+        )),
+    )
+
+
 def _resolve_realtime_config(extra: Dict[str, Any]) -> RealtimeConfig:
     rt_extra = extra.get("realtime") if isinstance(extra.get("realtime"), dict) else {}
     rt_api_key = (
@@ -428,6 +480,7 @@ def _resolve_realtime_config(extra: Dict[str, Any]) -> RealtimeConfig:
             else os.getenv("INKBOX_REALTIME_FALLBACK_TO_INKBOX_STT_TTS"),
             True,
         ),
+        supervisor=_resolve_supervisor_config(rt_extra),
     )
     if rt_enabled_text in ("true", "1", "yes", "on") and not rt_has_cred:
         logger.warning(
@@ -3925,6 +3978,11 @@ class InkboxAdapter(BasePlatformAdapter):
                         on_agent_consult=self._realtime_agent_consult,
                         on_post_call_actions=self._realtime_post_call_actions,
                         on_call_ended=self._realtime_call_ended,
+                        on_supervise=(
+                            self._realtime_supervise
+                            if self._realtime_config.supervisor.enabled
+                            else None
+                        ),
                     )
                 except Exception as exc:
                     logger.warning(
@@ -4300,6 +4358,127 @@ class InkboxAdapter(BasePlatformAdapter):
                 "briefly and ask if you can help another way."
             )
         return text
+
+    # Supervisor prompt: the Tier-2 "mid" brain. Cheaper + smarter-at-reasoning
+    # than the realtime voice model, it watches the transcript and decides
+    # whether the voice model needs a proactive nudge. It does NOT execute tools
+    # (that stays with the full agent via consult_agent) — it only steers.
+    _SUPERVISOR_SYSTEM_PROMPT = (
+        "You are a silent SUPERVISOR monitoring a live phone call handled by a "
+        "fast voice AI (the 'agent'). You see the running transcript but the "
+        "caller cannot hear you. The voice AI is fluent but can state facts "
+        "wrongly, miss context it was given, over-promise, or fail to realize a "
+        "request needs the main Hermes agent's tools. Decide if the agent needs "
+        "a nudge RIGHT NOW.\n"
+        'Reply with ONLY a JSON object: {"action": "none"|"steer"|"interject", '
+        '"guidance": "<one short instruction to the agent>", "reason": "<why>"}.\n'
+        "- none: the agent is handling it well — do not interrupt. This is the "
+        "default; prefer it unless there is a concrete problem.\n"
+        "- steer: inject a short note the agent folds into its NEXT reply — add "
+        "missing context, gently redirect, or tell it to consult the main agent "
+        "for a request that needs live data or a tool.\n"
+        "- interject: the agent just said something wrong or misleading and must "
+        "correct it immediately.\n"
+        "guidance must be one imperative sentence addressed to the agent, "
+        "spoken-friendly, and must never invent facts you were not given."
+    )
+
+    async def _realtime_supervise(
+        self,
+        meta: RealtimeCallMeta,
+        transcript: List[Tuple[str, str]],
+        prior_guidance: List[str],
+    ) -> SupervisorDecision:
+        """Tier-2 supervisor: ask a cheap reasoning model whether to nudge.
+
+        Runs a single, short chat-completions call (not the full agent loop) so
+        it is cheap and low-latency enough to run once per caller turn. Returns a
+        :class:`SupervisorDecision`; on any error it returns ``none`` so the call
+        is never disrupted by a supervisor failure.
+        """
+        api_key = self._realtime_config.api_key
+        if not api_key:
+            return SupervisorDecision(action="none")
+        try:
+            import aiohttp
+        except ImportError:
+            return SupervisorDecision(action="none")
+
+        model = (os.getenv("INKBOX_REALTIME_SUPERVISOR_MODEL") or "gpt-4o-mini").strip()
+        base_url = (
+            os.getenv("INKBOX_REALTIME_SUPERVISOR_BASE_URL")
+            or os.getenv("OPENAI_BASE_URL")
+            or "https://api.openai.com/v1"
+        ).rstrip("/")
+
+        context_lines = [
+            f"Call direction: {meta.direction}.",
+            (
+                "Caller is a known Inkbox contact: "
+                f"{meta.contact_name}." if meta.contact_known
+                else "Caller is NOT a known contact — treat as unverified; the "
+                "agent must not disclose third-party data."
+            ),
+        ]
+        if meta.direction == "outbound" and meta.outbound_purpose:
+            context_lines.append(f"Reason we called: {meta.outbound_purpose}")
+        if meta.contact_notes:
+            context_lines.append(f"Notes on file about the caller: {meta.contact_notes}")
+        if prior_guidance:
+            context_lines.append(
+                "Guidance you already sent (do NOT repeat these): "
+                + " | ".join(prior_guidance[-5:])
+            )
+        transcript_block = "\n".join(
+            f"{'CALLER' if role == 'caller' else 'AGENT'}: {text}"
+            for role, text in transcript[-20:]
+        )
+        user_content = (
+            "\n".join(context_lines)
+            + "\n\nTranscript so far:\n"
+            + transcript_block
+            + "\n\nDecide now. JSON only."
+        )
+
+        payload = {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": self._SUPERVISOR_SYSTEM_PROMPT},
+                {"role": "user", "content": user_content},
+            ],
+            "temperature": 0,
+            "max_tokens": 200,
+            "response_format": {"type": "json_object"},
+        }
+        headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+        try:
+            timeout = aiohttp.ClientTimeout(total=self._realtime_config.supervisor.review_timeout_s)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.post(
+                    f"{base_url}/chat/completions", json=payload, headers=headers,
+                ) as resp:
+                    if resp.status != 200:
+                        body = await resp.text()
+                        logger.debug(
+                            "[Inkbox] supervisor model returned %s: %s",
+                            resp.status, body[:200],
+                        )
+                        return SupervisorDecision(action="none")
+                    data = await resp.json()
+        except Exception as exc:
+            logger.debug("[Inkbox] supervisor model call failed: %s", exc)
+            return SupervisorDecision(action="none")
+
+        try:
+            content = data["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError):
+            return SupervisorDecision(action="none")
+        decision = parse_supervisor_decision(content)
+        if decision.is_actionable:
+            logger.info(
+                "[Inkbox] supervisor -> %s for call_id=%s", decision.action, meta.call_id,
+            )
+        return decision
 
     async def _realtime_call_ended(
         self,

--- a/adapter.py
+++ b/adapter.py
@@ -145,7 +145,13 @@ try:
         RealtimeConsultResult,
         open_inkbox_realtime_bridge,
     )
-    from .realtime_supervisor import SupervisorConfig, SupervisorDecision, parse_supervisor_decision
+    from .realtime_supervisor import (
+        SuperviseCallback,
+        SupervisorConfig,
+        SupervisorDecision,
+        _extract_json_object,
+        parse_supervisor_decision,
+    )
 except ImportError:  # pragma: no cover - direct local import/test fallback
     from config import INKBOX_BASE_URL_DEFAULT, inkbox_client_kwargs
     from webhook_providers import match_provider
@@ -159,7 +165,13 @@ except ImportError:  # pragma: no cover - direct local import/test fallback
         RealtimeConsultResult,
         open_inkbox_realtime_bridge,
     )
-    from realtime_supervisor import SupervisorConfig, SupervisorDecision, parse_supervisor_decision
+    from realtime_supervisor import (
+        SuperviseCallback,
+        SupervisorConfig,
+        SupervisorDecision,
+        _extract_json_object,
+        parse_supervisor_decision,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -397,6 +409,7 @@ def _resolve_supervisor_config(rt_extra: Dict[str, Any]) -> SupervisorConfig:
 
         supervisor:
           enabled: bool          # default false
+          backend: str           # "hermes" (default) | "model"
           debounce_s: float
           review_timeout_s: float
           min_review_interval_s: float
@@ -412,6 +425,16 @@ def _resolve_supervisor_config(rt_extra: Dict[str, Any]) -> SupervisorConfig:
     )
     defaults = SupervisorConfig()
 
+    # Backend selects which brain runs a review; anything unrecognized falls back
+    # to the default so a typo can never silently disable the supervisor.
+    backend = str(
+        sup_extra.get("backend")
+        or os.getenv("INKBOX_REALTIME_SUPERVISOR_BACKEND")
+        or defaults.backend
+    ).strip().lower()
+    if backend not in ("hermes", "model"):
+        backend = defaults.backend
+
     def _num(key: str, env: str, default: float) -> float:
         raw = sup_extra.get(key)
         if raw is None:
@@ -423,6 +446,7 @@ def _resolve_supervisor_config(rt_extra: Dict[str, Any]) -> SupervisorConfig:
 
     return SupervisorConfig(
         enabled=enabled,
+        backend=backend,
         debounce_s=_num("debounce_s", "INKBOX_REALTIME_SUPERVISOR_DEBOUNCE_S", defaults.debounce_s),
         review_timeout_s=_num(
             "review_timeout_s", "INKBOX_REALTIME_SUPERVISOR_REVIEW_TIMEOUT_S", defaults.review_timeout_s,
@@ -437,6 +461,60 @@ def _resolve_supervisor_config(rt_extra: Dict[str, Any]) -> SupervisorConfig:
             "min_caller_turns", "INKBOX_REALTIME_SUPERVISOR_MIN_CALLER_TURNS", defaults.min_caller_turns,
         )),
     )
+
+
+async def _run_hermes_oneshot(
+    prompt: str, *, timeout_s: float, model: Optional[str] = None,
+) -> str:
+    """Run one ``hermes -z`` invocation and return its stdout, or "" on failure.
+
+    Spawns the real main Hermes agent (full tooling) as a one-shot subprocess —
+    the same mechanism the ``agent_consult`` path uses — so the caller gets a
+    *tool-capable* brain rather than a context-only model. Unlike the consult
+    path this reaps the child on timeout (``wait_for`` alone cancels the await
+    but leaves the OS process running), and it is fail-open: every failure mode
+    returns "" so a supervisor review can degrade to a silent no-op.
+
+    Args:
+        prompt (str): Full prompt passed as the ``-z`` positional argument.
+        timeout_s (float): Hard wall-clock cap; the child is killed if exceeded.
+        model (Optional[str]): Optional model id passed through to the CLI via
+            the ``HERMES_MODEL`` env var so the supervisor can run a cheaper /
+            faster model than the caller's default. Honored only if the hermes
+            build reads it.
+
+    Returns:
+        str: The agent's stripped stdout, or "" on any failure.
+    """
+    hermes_bin = shutil.which("hermes") or "/home/ec2-user/.local/bin/hermes"
+    env = {**os.environ, "HERMES_NO_TUI": "1"}
+    if model:
+        env["HERMES_MODEL"] = model  # best-effort fast-model override
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            hermes_bin, "-z", prompt,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+    except (FileNotFoundError, OSError) as exc:
+        logger.debug("[Inkbox] hermes oneshot spawn failed: %s", exc)
+        return ""
+    try:
+        stdout_bytes, _stderr = await asyncio.wait_for(
+            proc.communicate(), timeout=timeout_s,
+        )
+    except asyncio.TimeoutError:
+        # Kill and reap so a hung agent can't leak a subprocess for the rest of
+        # the call. The call keeps flowing — a slow review just means no nudge.
+        proc.kill()
+        try:
+            await proc.wait()
+        except Exception:
+            pass
+        logger.debug("[Inkbox] hermes oneshot timed out after %ss; killed", timeout_s)
+        return ""
+    return stdout_bytes.decode("utf-8", errors="replace").strip()
 
 
 def _resolve_realtime_config(extra: Dict[str, Any]) -> RealtimeConfig:
@@ -3979,7 +4057,7 @@ class InkboxAdapter(BasePlatformAdapter):
                         on_post_call_actions=self._realtime_post_call_actions,
                         on_call_ended=self._realtime_call_ended,
                         on_supervise=(
-                            self._realtime_supervise
+                            self._supervise_callback()
                             if self._realtime_config.supervisor.enabled
                             else None
                         ),
@@ -4384,6 +4462,24 @@ class InkboxAdapter(BasePlatformAdapter):
         "reason under 12 words so the JSON stays short and complete."
     )
 
+    # Hermes-backend supervisor prompt: same job as the cheap one, but this
+    # brain HAS tools — so it can look facts up instead of only reasoning over
+    # the transcript. The extra rules keep it read-only (it must never take a
+    # real action while it is only observing a live call) and quiet (return the
+    # JSON and nothing else, so `hermes -z` stdout parses cleanly).
+    _HERMES_SUPERVISOR_SYSTEM_PROMPT = (
+        _SUPERVISOR_SYSTEM_PROMPT
+        + "\n\nYou are the main Hermes agent, so you also have your tools. Use "
+        "them ONLY to READ / look things up to verify what the voice agent said "
+        "(order status, a contact detail, a prior message). This is the key "
+        "reason you are here: you can catch a WRONG FACT the voice agent has no "
+        "way to know is wrong. Do at most one or two quick lookups. You are only "
+        "OBSERVING a live call — never send, write, schedule, modify, or contact "
+        "anyone; those belong to the agent via consult, not to you. When done, "
+        "output ONLY the JSON decision object and nothing else — no preamble, no "
+        "explanation around it."
+    )
+
     async def _realtime_supervise(
         self,
         meta: RealtimeCallMeta,
@@ -4480,6 +4576,108 @@ class InkboxAdapter(BasePlatformAdapter):
         if decision.is_actionable:
             logger.info(
                 "[Inkbox] supervisor -> %s for call_id=%s", decision.action, meta.call_id,
+            )
+        return decision
+
+    def _supervise_callback(self) -> SuperviseCallback:
+        """Pick the supervisor backend callback from config.
+
+        ``hermes`` (default) runs the real main agent so it can verify facts
+        with tools; ``model`` runs the cheap chat-completions proxy. Both match
+        the :data:`SuperviseCallback` contract the loop expects.
+        """
+        if self._realtime_config.supervisor.backend == "hermes":
+            return self._realtime_hermes_supervise
+        return self._realtime_supervise
+
+    def _build_hermes_supervisor_prompt(
+        self,
+        meta: RealtimeCallMeta,
+        transcript: List[Tuple[str, str]],
+        prior_guidance: List[str],
+    ) -> str:
+        """Assemble the ``hermes -z`` prompt for one supervisor review.
+
+        Mirrors the context the cheap supervisor gets (direction, caller trust,
+        purpose, notes, already-sent guidance, recent transcript) so the two
+        backends judge the same call, then hands it to the tool-capable brain.
+
+        Args:
+            meta (RealtimeCallMeta): Live-call metadata for the current call.
+            transcript (List[Tuple[str, str]]): ``(party, text)`` turns so far.
+            prior_guidance (List[str]): Notes already injected this call.
+
+        Returns:
+            str: The full prompt string passed as the ``-z`` argument.
+        """
+        context_lines = [
+            f"Call direction: {meta.direction}.",
+            (
+                f"Caller is a known Inkbox contact: {meta.contact_name}."
+                if meta.contact_known
+                else "Caller is NOT a known contact — treat as unverified; the "
+                "agent must not disclose third-party data."
+            ),
+        ]
+        if meta.direction == "outbound" and meta.outbound_purpose:
+            context_lines.append(f"Reason we called: {meta.outbound_purpose}")
+        if meta.contact_notes:
+            context_lines.append(f"Notes on file about the caller: {meta.contact_notes}")
+        if prior_guidance:
+            context_lines.append(
+                "Guidance you already sent (do NOT repeat these): "
+                + " | ".join(prior_guidance[-5:])
+            )
+        transcript_block = "\n".join(
+            f"{'CALLER' if role == 'caller' else 'AGENT'}: {text}"
+            for role, text in transcript[-20:]
+        )
+        return (
+            self._HERMES_SUPERVISOR_SYSTEM_PROMPT
+            + "\n\n"
+            + "\n".join(context_lines)
+            + "\n\nTranscript so far:\n"
+            + transcript_block
+            + "\n\nDecide now. JSON only."
+        )
+
+    async def _realtime_hermes_supervise(
+        self,
+        meta: RealtimeCallMeta,
+        transcript: List[Tuple[str, str]],
+        prior_guidance: List[str],
+    ) -> SupervisorDecision:
+        """Tier-2 supervisor backed by the REAL Hermes agent (not a proxy).
+
+        Runs a single bounded ``hermes -z`` pass so the supervisor has the main
+        agent's tools and can verify a fact the fast voice model stated — the
+        thing a context-only model structurally cannot do. On any failure it
+        returns ``none`` so the call is never disrupted by a supervisor problem.
+
+        Args:
+            meta (RealtimeCallMeta): Live-call metadata for the current call.
+            transcript (List[Tuple[str, str]]): ``(party, text)`` turns so far.
+            prior_guidance (List[str]): Notes already injected this call.
+
+        Returns:
+            SupervisorDecision: The parsed decision, or ``none`` on any failure.
+        """
+        sup = self._realtime_config.supervisor
+        prompt = self._build_hermes_supervisor_prompt(meta, transcript, prior_guidance)
+        # Optional cheaper/faster model for the supervisor pass (passed through
+        # to the CLI). Distinct from the chat-backend's INKBOX_..._MODEL var.
+        model = (os.getenv("INKBOX_REALTIME_SUPERVISOR_HERMES_MODEL") or "").strip() or None
+        raw = await _run_hermes_oneshot(prompt, timeout_s=sup.review_timeout_s, model=model)
+        # Hermes is a chatty agent. Only act on an explicit JSON decision — if it
+        # emitted none, stay silent rather than let the freeform-text fallback in
+        # parse_supervisor_decision speak the agent's prose to the caller.
+        if not raw or _extract_json_object(raw) is None:
+            return SupervisorDecision(action="none")
+        decision = parse_supervisor_decision(raw)
+        if decision.is_actionable:
+            logger.info(
+                "[Inkbox] hermes supervisor -> %s for call_id=%s",
+                decision.action, meta.call_id,
             )
         return decision
 

--- a/docs/realtime-supervisor.md
+++ b/docs/realtime-supervisor.md
@@ -25,13 +25,50 @@ existing pull one.
 | Tier | Model | Path | Owns |
 |---|---|---|---|
 | **Fast — "mouth"** | `gpt-realtime` | hard real-time, sub-second | turn-taking, backchannel, greetings, slot-filling, reading answers back |
-| **Mid — "supervisor"** | cheap reasoning model (`gpt-4o-mini` class) | off-path, seconds OK | watches every caller turn; decides whether to nudge; **pushes** steering notes. **New.** |
+| **Mid — "supervisor"** | real Hermes agent via `hermes -z` (default), or a cheap `gpt-4o-mini`-class model | off-path, seconds OK | watches every caller turn; decides whether to nudge; **pushes** steering notes. **New.** |
 | **Smart — "brain"** | full Hermes agent + tools (`consult_agent`) | off-path, heavy | multi-step reasoning, tool execution, irreversible actions. Pull-style, unchanged — but the supervisor can now proactively steer the mouth *to* consult. |
 
-The supervisor is the new middle tier. It runs a single short model call per
-caller turn (debounced + rate-limited), not the full agent loop, so it is cheap
-and low-latency enough to run continuously. It never executes tools — actual
-work still flows through `consult_agent` and post-call actions.
+The supervisor is the new middle tier. It reviews once per settled turn
+(debounced + rate-limited), never the continuous audio path, so seconds of
+latency are fine. It never executes *mutating* work — actual actions still flow
+through `consult_agent` and post-call actions — but which brain does the
+reviewing is configurable (see **Supervisor backends** below).
+
+## Supervisor backends
+
+The review loop is backend-agnostic; `platforms.inkbox.realtime.supervisor.backend`
+(or `INKBOX_REALTIME_SUPERVISOR_BACKEND`) picks which brain runs a review.
+
+| Backend | What runs | Can verify facts? | Cost / latency |
+|---|---|---|---|
+| `hermes` **(default)** | the real main agent, one bounded `hermes -z` pass with its tools | **Yes** — it can look a fact up | higher; a subprocess per review |
+| `model` | a single `chat/completions` call to a cheap model | No — reasons over the transcript + handed context only | lowest; one small API call |
+
+Why `hermes` is the default: the point of a supervisor is to catch what the fast
+voice model gets wrong, and the highest-value case is a **wrong fact** — "your
+order ships Monday" when it ships Thursday. A context-only model has no way to
+know that; only a tool-capable brain can look it up. The `model` backend still
+catches guardrail and self-consistency problems (unverified caller, contradicting
+the notes on file) and is the cheap option when tool-grounded verification isn't
+needed. `test_supervisor_hermes_proof.py` pins the difference: on a tool-grounded
+trap the `model` backend gives zero lift over baseline while `hermes` corrects
+the call; on a pure guardrail both fix it (the `hermes` backend is a superset).
+
+Two safety notes on the `hermes` backend:
+
+- **Read-only by prompt, not by sandbox.** `hermes -z` has no tool-profile flag,
+  so the supervisor prompt instructs the agent to only *read/look up* to verify
+  and never send, write, schedule, or contact anyone while it is merely
+  observing the call. A real read-only tool profile is the right future
+  hardening.
+- **Fail-open and bounded.** The review is capped by `review_timeout_s`; on
+  timeout the subprocess is killed and reaped and the review is skipped, so a
+  slow or hung agent never disrupts the live call. Only an explicit JSON
+  decision is acted on — the agent's prose is never spoken to the caller.
+
+Set `INKBOX_REALTIME_SUPERVISOR_HERMES_MODEL` to run the `hermes` backend on a
+cheaper/faster model than the caller's default (passed through to the CLI via
+`HERMES_MODEL`; honored if the build reads it).
 
 ## How steering is injected
 

--- a/docs/realtime-supervisor.md
+++ b/docs/realtime-supervisor.md
@@ -1,0 +1,159 @@
+# Realtime call supervisor — design
+
+## The problem
+
+The base realtime voice bridge (`realtime.py`) is **pull-only**. The OpenAI
+Realtime voice model — a fast, low-latency "mouth" — drives the entire call, and
+the heavier main Hermes agent (the "brain") only engages when the voice model
+*chooses* to invoke the `consult_agent` tool. That tool spawns a one-shot
+`hermes -z` subprocess and returns text for the voice model to read back.
+
+Two things are missing:
+
+1. **The brain has no visibility into the call as it happens.** It sees nothing
+   until it is pulled, and then only the query the voice model chose to send.
+2. **The brain cannot steer the call.** If the fast voice model is confidently
+   wrong, forgets a piece of loaded context, over-promises, or simply doesn't
+   realize it needs help, nothing corrects it. Small realtime models are fluent
+   but error-prone in exactly this way — they answer agreeably even when unsure.
+
+The supervisor closes that loop by adding a **push** channel alongside the
+existing pull one.
+
+## The three-tier split
+
+| Tier | Model | Path | Owns |
+|---|---|---|---|
+| **Fast — "mouth"** | `gpt-realtime` | hard real-time, sub-second | turn-taking, backchannel, greetings, slot-filling, reading answers back |
+| **Mid — "supervisor"** | cheap reasoning model (`gpt-4o-mini` class) | off-path, seconds OK | watches every caller turn; decides whether to nudge; **pushes** steering notes. **New.** |
+| **Smart — "brain"** | full Hermes agent + tools (`consult_agent`) | off-path, heavy | multi-step reasoning, tool execution, irreversible actions. Pull-style, unchanged — but the supervisor can now proactively steer the mouth *to* consult. |
+
+The supervisor is the new middle tier. It runs a single short model call per
+caller turn (debounced + rate-limited), not the full agent loop, so it is cheap
+and low-latency enough to run continuously. It never executes tools — actual
+work still flows through `consult_agent` and post-call actions.
+
+## How steering is injected
+
+Guidance is pushed into the live session over the *same* OpenAI Realtime
+WebSocket the audio pumps use. Two modes, both validated against the OpenAI
+Realtime GA API:
+
+### Silent steer (default)
+
+Inject a `system`-role conversation item and send **no** `response.create`. With
+server VAD (the default), the voice model absorbs the note and folds it into its
+next natural reply — zero perceived interruption.
+
+```json
+{
+  "type": "conversation.item.create",
+  "item": {
+    "type": "message",
+    "role": "system",
+    "content": [{ "type": "input_text", "text": "[SUPERVISOR] the order ships in 3 business days, not today" }]
+  }
+}
+```
+
+### Speak-now interject
+
+Inject the same note, then fire a bare `response.create` so the model speaks a
+correction immediately (e.g. it just told the caller something wrong).
+
+```json
+{ "type": "conversation.item.create", "item": { "...": "as above" } }
+{ "type": "response.create" }
+```
+
+Notes:
+
+- `system`/`developer` items are **text-only** (`input_text`) — never audio.
+- `conversation.item.create` alone never produces speech; the `response.create`
+  is what voices it. This is the #1 "nothing happened" mistake.
+- A `response.create` sent while a response is already active is rejected by
+  OpenAI (`conversation_already_has_active_response`); the injected note still
+  lands and is used on the next turn, so the guidance is never lost.
+- An alternative primitive, `response.create` with `conversation: "none"`, runs
+  a silent out-of-band analysis using session context without speaking — useful
+  if the supervisor is ever collapsed onto the realtime model itself. We keep a
+  separate reasoning model instead, to honor the "smarter backend" goal.
+
+## Control flow
+
+```
+Caller audio ──► Inkbox WS ──► OpenAI Realtime (mouth) ──► Inkbox WS ──► Caller
+                                     │  finalized transcript turns
+                                     ▼
+                          state.transcript_events (asyncio.Queue)
+                                     │
+                                     ▼
+                          run_supervisor_loop  ── on caller turn, debounced ──►  on_supervise()  (mid model)
+                                     │                                                 │ decision
+                                     └──────────── inject_guidance() ◄─────────────────┘
+                                        (system note ± response.create)
+```
+
+The loop lives in `realtime_supervisor.py` and runs as a third background task
+next to the two audio pumps (`OpenedRealtimeBridge.run`). It is not part of the
+pump race — it lives for the call's duration and is cancelled on teardown.
+
+### Guards (why it stays polite)
+
+- **Debounce** — reviews once per settled caller *thought*, not per fragment.
+- **Min review interval** — never more than one review per N seconds.
+- **Max interjections** — a hard cap on notes per call.
+- **Min caller turns** — doesn't second-guess the opening exchange.
+- **Dedup** — prior guidance is passed back so the supervisor won't repeat itself.
+- **Fail-open** — a supervisor timeout/error/`none` leaves the call untouched.
+- Default **off**; the base pull-only behavior is unchanged unless opted in.
+
+## Proving it yields better calls
+
+Two proofs share one control (`tests/proof_harness.py`), which isolates a single
+variable: whether a supervisor is attached. The voice model is byte-for-byte
+identical in the baseline and enhanced runs of every scenario.
+
+### Deterministic proof — `tests/test_supervisor_proof.py` (runs in CI)
+
+A fixed model of a fallible, agreeable voice model plus a context-consistency
+supervisor, scored by per-scenario rubrics across five realistic calls (wrong
+fact, omitted caveat, over-promise, privacy leak, and a control where the agent
+is already right). It asserts every trap scenario improves, the control is
+untouched, and aggregate quality rises by a large margin. Representative run:
+
+```
+scenario                      baseline  enhanced   delta
+wrong_shipping_date               0.00      1.00    1.00
+final_sale_omission               0.00      1.00    1.00
+over_promise_email                0.00      1.00    1.00
+privacy_unverified_caller         0.00      1.00    1.00
+control_correct_answer            1.00      1.00    0.00
+MEAN                              0.20      1.00    0.80
+```
+
+A companion test pins the baseline *failures* so the proof can never silently
+degrade into a no-op.
+
+### Live LLM-judged proof — `tests/live/test_supervisor_quality.py` (gated)
+
+The same scenarios and harness, but the voice model, supervisor, and caller are
+real models and a stronger judge model blind-scores both transcripts. It asserts
+the supervised calls score higher in aggregate and that the supervisor actually
+intervened. Needs `OPENAI_API_KEY` + `LIVE_REAL_MODEL=1`; run on demand via the
+`Live — supervisor quality` workflow. This is the real-world magnitude behind
+the deterministic proof's ceiling.
+
+## References
+
+- OpenAI Realtime API — conversations & client events:
+  <https://platform.openai.com/docs/guides/realtime>,
+  <https://platform.openai.com/docs/api-reference/realtime-client-events/conversation/item/create>
+- Out-of-band responses (`conversation: "none"`):
+  <https://developers.openai.com/cookbook/examples/realtime_out_of_band_transcription>
+- `openai-realtime-agents` chat-supervisor pattern (pull-only baseline):
+  <https://github.com/openai/openai-realtime-agents>
+- LiveKit observer-pattern voice-agent guardrails (push observer):
+  <https://livekit.com/blog/observer-pattern-voice-agent-guardrails>
+- Talker–Reasoner / Thinker–Talker dual-process framing:
+  <https://arxiv.org/html/2410.08328v1>, <https://arxiv.org/pdf/2511.07397>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hermes-agent-plugin"
-version = "0.2.2"
+version = "0.2.3"
 description = "Inkbox platform plugin for Hermes Agent"
 # inkbox>=0.4.7 requires Python 3.11+, so we can't claim 3.10 support.
 requires-python = ">=3.11"

--- a/realtime.py
+++ b/realtime.py
@@ -54,6 +54,15 @@ try:
 except ImportError:  # pragma: no cover — aiohttp is a core dep on this fork
     aiohttp = None  # type: ignore
 
+try:  # sibling module; import shape mirrors how realtime itself is imported
+    from . import realtime_supervisor as _supervisor
+except ImportError:  # pragma: no cover — direct (non-package) import in tests/CLI
+    import realtime_supervisor as _supervisor
+
+SupervisorConfig = _supervisor.SupervisorConfig
+SupervisorDecision = _supervisor.SupervisorDecision
+SuperviseCallback = _supervisor.SuperviseCallback
+
 logger = logging.getLogger(__name__)
 
 REALTIME_URL = "wss://api.openai.com/v1/realtime"
@@ -437,6 +446,10 @@ class RealtimeConfig:
     fallback_to_inkbox_stt_tts: bool = True
     # ``api.openai.com`` by default; override for Azure / proxies.
     base_url: str = REALTIME_URL
+    # Proactive supervisor: a background loop that watches the transcript and
+    # injects steering guidance into the live session. Disabled by default so
+    # the base pull-only behavior is unchanged unless opted in.
+    supervisor: SupervisorConfig = field(default_factory=SupervisorConfig)
 
     @property
     def has_credential(self) -> bool:
@@ -479,6 +492,12 @@ class _BridgeState:
     # the OpenAI→Inkbox audio pump flowing; we track the tasks here so they can
     # be cancelled when the call tears down.
     consult_tasks: Set["asyncio.Task[None]"] = field(default_factory=set)
+    # Finalized transcript turns are published here as ``(party, text)`` so the
+    # proactive supervisor loop can watch the call in real time. Unbounded; the
+    # supervisor drains it. Unused when the supervisor is disabled.
+    transcript_events: "asyncio.Queue[Tuple[str, str]]" = field(
+        default_factory=asyncio.Queue,
+    )
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -693,10 +712,19 @@ class OpenedRealtimeBridge:
         on_agent_consult: AgentConsultCallback,
         on_post_call_actions: PostCallActionsCallback,
         on_call_ended: CallEndedCallback,
+        on_supervise: Optional[SuperviseCallback] = None,
     ) -> None:
-        """Bridge one already-opened OpenAI Realtime connection to Inkbox."""
+        """Bridge one already-opened OpenAI Realtime connection to Inkbox.
+
+        When ``on_supervise`` is supplied and the config's supervisor is enabled,
+        a background supervisor loop runs alongside the two audio pumps: it
+        watches the transcript and proactively injects steering guidance into the
+        OpenAI session. It is not part of the pump race — it simply lives for the
+        duration of the call and is cancelled on teardown.
+        """
         state = self.state
         openai_ws = self.openai_ws
+        supervisor_task: Optional["asyncio.Task[None]"] = None
         try:
             inkbox_task = asyncio.create_task(
                 _inkbox_to_openai_pump(inkbox_ws, openai_ws, state, self.meta),
@@ -712,6 +740,13 @@ class OpenedRealtimeBridge:
                     on_agent_consult=on_agent_consult,
                 ),
                 name=f"realtime-openai-pump-{self.meta.call_id}",
+            )
+            supervisor_task = _maybe_start_supervisor(
+                openai_ws=openai_ws,
+                state=state,
+                config=self.config,
+                meta=self.meta,
+                on_supervise=on_supervise,
             )
 
             done, pending = await asyncio.wait(
@@ -733,6 +768,7 @@ class OpenedRealtimeBridge:
                     )
         finally:
             state.closed = True
+            await _cancel_supervisor_task(supervisor_task)
             # The call is over, so any consult still mid-flight can no longer be
             # spoken to the caller — cancel the background tasks and let them
             # settle before we close the sockets.
@@ -808,6 +844,7 @@ async def run_inkbox_realtime_bridge(
     on_agent_consult: AgentConsultCallback,
     on_post_call_actions: PostCallActionsCallback,
     on_call_ended: CallEndedCallback,
+    on_supervise: Optional[SuperviseCallback] = None,
 ) -> None:
     """Run the bridge for the duration of one call.
 
@@ -828,7 +865,45 @@ async def run_inkbox_realtime_bridge(
         on_agent_consult=on_agent_consult,
         on_post_call_actions=on_post_call_actions,
         on_call_ended=on_call_ended,
+        on_supervise=on_supervise,
     )
+
+
+def _maybe_start_supervisor(
+    *,
+    openai_ws: Any,
+    state: _BridgeState,
+    config: RealtimeConfig,
+    meta: RealtimeCallMeta,
+    on_supervise: Optional[SuperviseCallback],
+) -> Optional["asyncio.Task[None]"]:
+    """Start the proactive supervisor loop if enabled and a callback is present."""
+    sup_config = getattr(config, "supervisor", None)
+    if on_supervise is None or sup_config is None or not sup_config.enabled:
+        return None
+    task = asyncio.create_task(
+        _supervisor.run_supervisor_loop(
+            openai_ws=openai_ws,
+            transcript_events=state.transcript_events,
+            transcript_snapshot=lambda: list(state.transcript),
+            is_closed=lambda: state.closed,
+            config=sup_config,
+            meta=meta,
+            on_supervise=on_supervise,
+        ),
+        name=f"realtime-supervisor-{meta.call_id}",
+    )
+    logger.info("[Inkbox realtime] supervisor loop started for call_id=%s", meta.call_id)
+    return task
+
+
+async def _cancel_supervisor_task(task: Optional["asyncio.Task[None]"]) -> None:
+    """Cancel the supervisor loop and await its teardown, if it was started."""
+    if task is None:
+        return
+    task.cancel()
+    with suppress(asyncio.CancelledError, Exception):
+        await task
 
 
 async def _cancel_consult_tasks(state: _BridgeState) -> None:
@@ -977,6 +1052,18 @@ async def _send_session_update(
         },
     }
     await openai_ws.send_str(json.dumps(payload))
+
+
+def _publish_transcript_turn(state: _BridgeState, party: str, text: str) -> None:
+    """Publish a finalized transcript turn to the supervisor bus (best-effort).
+
+    The queue is unbounded, so ``put_nowait`` never blocks or raises in practice;
+    a failure here must never disrupt the audio pump, so it is swallowed.
+    """
+    try:
+        state.transcript_events.put_nowait((party, text))
+    except Exception:  # pragma: no cover — unbounded queue; defensive only
+        pass
 
 
 async def _inkbox_to_openai_pump(
@@ -1143,12 +1230,14 @@ async def _openai_to_inkbox_pump(
             text = (frame.get("transcript") or "").strip()
             if text:
                 state.transcript.append(("agent", text))
+                _publish_transcript_turn(state, "agent", text)
                 await _relay_transcript("local", text)
 
         elif ftype == "conversation.item.input_audio_transcription.completed":
             text = (frame.get("transcript") or "").strip()
             if text:
                 state.transcript.append(("caller", text))
+                _publish_transcript_turn(state, "caller", text)
                 await _relay_transcript("remote", text)
 
         # Function-call item announced — capture name/call_id by item_id.

--- a/realtime.py
+++ b/realtime.py
@@ -498,6 +498,13 @@ class _BridgeState:
     transcript_events: "asyncio.Queue[Tuple[str, str]]" = field(
         default_factory=asyncio.Queue,
     )
+    # True while a model response is being generated (between response.created
+    # and response.done). The supervisor checks this so a speak-now interjection
+    # never fires response.create into an already-active response.
+    response_active: bool = False
+    # Set once the supervisor loop is running, so the pump only fills
+    # transcript_events when something is actually consuming it.
+    supervisor_active: bool = False
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -755,6 +762,11 @@ class OpenedRealtimeBridge:
             )
             for task in pending:
                 task.cancel()
+            # Await the cancelled pump(s) so they settle instead of leaking a
+            # pending task (and a "Task was destroyed but it is pending" warning).
+            for task in pending:
+                with suppress(asyncio.CancelledError, Exception):
+                    await task
             for task in done:
                 try:
                     exc = task.exception()
@@ -881,15 +893,25 @@ def _maybe_start_supervisor(
     sup_config = getattr(config, "supervisor", None)
     if on_supervise is None or sup_config is None or not sup_config.enabled:
         return None
+    state.supervisor_active = True
     task = asyncio.create_task(
         _supervisor.run_supervisor_loop(
             openai_ws=openai_ws,
             transcript_events=state.transcript_events,
             transcript_snapshot=lambda: list(state.transcript),
-            is_closed=lambda: state.closed,
+            # Stop supervising once the call is closing OR a hangup has been
+            # armed — the goodbye/teardown window should not be steered.
+            is_closed=lambda: state.closed or state.hangup_armed_at is not None,
             config=sup_config,
             meta=meta,
             on_supervise=on_supervise,
+            # "Unsafe to speak now": a response is already generating, OR a
+            # consult is pending (its result readback will fire its own
+            # response.create shortly). Firing a speak-now interjection in either
+            # case collides with that response.create and OpenAI rejects one,
+            # which could drop the consult answer the caller is waiting on. When
+            # unsafe, the note is still injected silently and picked up next turn.
+            is_response_active=lambda: state.response_active or bool(state.pending_consult_keys),
         ),
         name=f"realtime-supervisor-{meta.call_id}",
     )
@@ -1057,9 +1079,13 @@ async def _send_session_update(
 def _publish_transcript_turn(state: _BridgeState, party: str, text: str) -> None:
     """Publish a finalized transcript turn to the supervisor bus (best-effort).
 
-    The queue is unbounded, so ``put_nowait`` never blocks or raises in practice;
-    a failure here must never disrupt the audio pump, so it is swallowed.
+    No-op unless a supervisor loop is actually consuming the bus — otherwise the
+    unbounded queue would just grow for the whole call with no reader. The queue
+    never blocks or raises on ``put_nowait``; any failure here must not disrupt
+    the audio pump, so it is swallowed.
     """
+    if not state.supervisor_active:
+        return
     try:
         state.transcript_events.put_nowait((party, text))
     except Exception:  # pragma: no cover — unbounded queue; defensive only
@@ -1280,7 +1306,13 @@ async def _openai_to_inkbox_pump(
                     "args": item.get("arguments") or "",
                 })
 
+        elif ftype == "response.created":
+            # A response is now generating. The supervisor consults this so a
+            # speak-now interjection doesn't fire response.create into it.
+            state.response_active = True
+
         elif ftype == "response.done":
+            state.response_active = False
             resp = frame.get("response") or {}
             rid = resp.get("id")
             if rid:

--- a/realtime_supervisor.py
+++ b/realtime_supervisor.py
@@ -1,0 +1,416 @@
+"""Proactive supervisor loop for Inkbox realtime voice calls.
+
+The base realtime bridge (:mod:`realtime`) is *pull-only*: the OpenAI Realtime
+voice model — a fast, low-latency "mouth" — drives the whole call, and the
+heavier main Hermes agent (the "brain") only engages when the voice model
+chooses to invoke the ``consult_agent`` tool. If the voice model is confidently
+wrong, forgets a piece of loaded context, or simply doesn't realize it needs
+help, the brain never engages and the call quality suffers.
+
+This module adds the missing *push* channel: a background **supervisor loop**
+that runs concurrently with the two audio pumps, watches the call transcript as
+it accumulates, and — on its own initiative — injects steering guidance into the
+live OpenAI Realtime session. It closes the loop between the fast speaking model
+and the smart backend so the brain can:
+
+  * receive regular transcript updates as the call proceeds (streaming), and
+  * proactively interject to add context or correct/redirect the voice model,
+    without waiting to be asked.
+
+Three-tier model split (fast → mid → smart):
+
+  1. **Mouth** — the OpenAI Realtime voice model. Owns turn-taking, backchannel,
+     and speech. Cheapest per token, lowest latency, least capable at reasoning.
+  2. **Supervisor** — a cheaper *reasoning* model (this module's callback).
+     Runs once per caller turn (debounced), reads the running transcript + call
+     context, and decides whether the mouth needs a nudge. New tier.
+  3. **Brain** — the full main Hermes agent (``consult_agent`` / post-call
+     actions). Heavy; only runs when real tool work is required. Existing, but
+     the supervisor can now trigger it *proactively* by steering the mouth to
+     consult, instead of relying on the mouth to notice on its own.
+
+Injection mechanism (OpenAI Realtime, over the same WebSocket):
+
+  * **Silent steer** — inject a ``conversation.item.create`` message item
+    carrying a bracketed supervisor note. No ``response.create`` follows, so the
+    model absorbs the note and applies it on its next natural turn. Used to add
+    context or gently redirect without interrupting.
+  * **Speak-now interject** — inject the same note *and* a ``response.create`` so
+    the model speaks immediately (e.g. to correct a fact it just stated wrong).
+
+The supervisor is deliberately conservative: it is rate-limited, debounced, and
+defaults to doing nothing. A note is only injected when the callback returns an
+explicit ``steer`` or ``interject`` decision.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Constants
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Role used for injected supervisor items. The OpenAI Realtime API accepts
+# "system" message items mid-session as out-of-band steering that is not spoken
+# by itself; the model treats it as an authoritative instruction for subsequent
+# turns. Kept as a module constant so it is trivial to switch to "user"/
+# "developer" if a future model family narrows accepted roles.
+SUPERVISOR_ITEM_ROLE = "system"
+
+# Every injected note is prefixed so the model (and the call transcript) can tell
+# supervisor guidance apart from caller speech.
+SUPERVISOR_NOTE_PREFIX = "[SUPERVISOR]"
+
+# Decision verbs the supervisor callback may return.
+ACTION_NONE = "none"
+ACTION_STEER = "steer"          # inject a note; model uses it on its next turn
+ACTION_INTERJECT = "interject"  # inject a note AND make the model speak now
+_VALID_ACTIONS = frozenset({ACTION_NONE, ACTION_STEER, ACTION_INTERJECT})
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Config + decision types
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class SupervisorConfig:
+    """Per-call supervisor tuning.
+
+    Populated from ``platforms.inkbox.realtime.supervisor`` in config.yaml.
+    Defaults are conservative: the supervisor stays quiet unless it has a
+    concrete reason to speak, and it never dominates the call.
+    """
+
+    enabled: bool = False
+    # Wait this long for the caller's turn to settle before reviewing, so we
+    # review once per *thought* rather than per transcription fragment.
+    debounce_s: float = 1.2
+    # How long the supervisor model may take before we abandon a review. The
+    # call keeps flowing regardless — a slow review just means no nudge.
+    review_timeout_s: float = 12.0
+    # Never fire more than one review per this interval, even under rapid
+    # back-and-forth. Bounds cost and avoids stepping on the model.
+    min_review_interval_s: float = 6.0
+    # Hard cap on total injected notes per call. Prevents a misbehaving
+    # supervisor from turning the call into a lecture.
+    max_interjections: int = 8
+    # Don't review until at least this many caller turns exist, so the opening
+    # exchange (greeting + first ask) isn't second-guessed prematurely.
+    min_caller_turns: int = 1
+    # Idle wake interval for the loop so it notices call teardown promptly even
+    # when no transcript events arrive.
+    poll_interval_s: float = 0.5
+
+
+@dataclass
+class SupervisorDecision:
+    """The supervisor's verdict for one review pass.
+
+    ``action`` is one of the ``ACTION_*`` constants. ``guidance`` is the short,
+    spoken-context note to inject (ignored when ``action`` is ``none``).
+    ``reason`` is optional and only logged — never injected.
+    """
+
+    action: str = ACTION_NONE
+    guidance: str = ""
+    reason: str = ""
+
+    @property
+    def is_actionable(self) -> bool:
+        return self.action in (ACTION_STEER, ACTION_INTERJECT) and bool(self.guidance.strip())
+
+
+# The supervisor callback: given call metadata, a snapshot of the transcript so
+# far (list of (party, text) where party is "caller"/"agent"), and the notes
+# already injected this call, return a decision. The platform supplies an
+# implementation that runs a cheap reasoning model. Returning ACTION_NONE (or
+# raising) leaves the call untouched.
+SuperviseCallback = Callable[
+    [Any, List[Tuple[str, str]], List[str]],
+    Awaitable[SupervisorDecision],
+]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Decision parsing
+# ─────────────────────────────────────────────────────────────────────────────
+
+# A text-returning agent (e.g. `hermes -z`, or a chat-completions call) is the
+# expected backend, so we accept several shapes and normalize them. Preferred is
+# a JSON object; we also accept a "VERB: guidance" line and bare NONE/[SILENT].
+_LEADING_VERB = re.compile(
+    r"^\s*(none|silent|steer|interject|speak)\b[:\-\s]*",
+    re.IGNORECASE,
+)
+_SILENT_MARKERS = {"none", "silent", "[silent]", "no", "n/a", ""}
+
+
+def parse_supervisor_decision(raw: Any) -> SupervisorDecision:
+    """Parse a supervisor backend's reply into a :class:`SupervisorDecision`.
+
+    Robust to three shapes so the callback contract stays simple:
+
+    * a :class:`SupervisorDecision` (passed straight through),
+    * a JSON object ``{"action": "...", "guidance": "...", "reason": "..."}``,
+    * plain text: a leading ``STEER:``/``INTERJECT:`` verb, or ``NONE``/
+      ``[SILENT]``/empty for "do nothing".
+    """
+    if isinstance(raw, SupervisorDecision):
+        return _normalize_decision(raw)
+    if raw is None:
+        return SupervisorDecision(action=ACTION_NONE)
+
+    text = raw if isinstance(raw, str) else str(raw)
+    stripped = text.strip()
+    if not stripped:
+        return SupervisorDecision(action=ACTION_NONE)
+
+    # Try JSON first (possibly wrapped in ```json fences).
+    json_obj = _extract_json_object(stripped)
+    if json_obj is not None:
+        return _normalize_decision(SupervisorDecision(
+            action=str(json_obj.get("action") or ACTION_NONE),
+            guidance=str(json_obj.get("guidance") or ""),
+            reason=str(json_obj.get("reason") or ""),
+        ))
+
+    # Plain-text convention.
+    if stripped.lower() in _SILENT_MARKERS:
+        return SupervisorDecision(action=ACTION_NONE)
+    verb_match = _LEADING_VERB.match(stripped)
+    if verb_match:
+        verb = verb_match.group(1).lower()
+        guidance = stripped[verb_match.end():].strip()
+        if verb in ("none", "silent"):
+            return SupervisorDecision(action=ACTION_NONE)
+        action = ACTION_INTERJECT if verb in ("interject", "speak") else ACTION_STEER
+        return _normalize_decision(SupervisorDecision(action=action, guidance=guidance))
+
+    # No recognized verb but non-empty text → treat the whole thing as a silent
+    # steer note. This is the safe default: add context without interrupting.
+    return _normalize_decision(SupervisorDecision(action=ACTION_STEER, guidance=stripped))
+
+
+def _normalize_decision(decision: SupervisorDecision) -> SupervisorDecision:
+    action = (decision.action or ACTION_NONE).strip().lower()
+    if action == "speak":
+        action = ACTION_INTERJECT
+    if action not in _VALID_ACTIONS:
+        action = ACTION_NONE
+    guidance = (decision.guidance or "").strip()
+    if action != ACTION_NONE and not guidance:
+        action = ACTION_NONE
+    return SupervisorDecision(action=action, guidance=guidance, reason=(decision.reason or "").strip())
+
+
+def _extract_json_object(text: str) -> Optional[dict]:
+    """Best-effort pull of the first JSON object out of a text blob."""
+    candidate = text
+    fence = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL | re.IGNORECASE)
+    if fence:
+        candidate = fence.group(1)
+    else:
+        brace = re.search(r"\{.*\}", text, re.DOTALL)
+        if brace:
+            candidate = brace.group(0)
+        else:
+            return None
+    try:
+        obj = json.loads(candidate)
+    except (TypeError, ValueError):
+        return None
+    return obj if isinstance(obj, dict) else None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Injection
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def build_supervisor_item(guidance: str) -> dict:
+    """Build the ``conversation.item.create`` frame for a supervisor note."""
+    note = guidance.strip()
+    if not note.startswith(SUPERVISOR_NOTE_PREFIX):
+        note = f"{SUPERVISOR_NOTE_PREFIX} {note}"
+    return {
+        "type": "conversation.item.create",
+        "item": {
+            "type": "message",
+            "role": SUPERVISOR_ITEM_ROLE,
+            "content": [{"type": "input_text", "text": note}],
+        },
+    }
+
+
+async def inject_guidance(openai_ws: Any, guidance: str, *, speak: bool) -> None:
+    """Inject a supervisor note into the live OpenAI Realtime session.
+
+    Always sends the note as an out-of-band conversation item. When ``speak`` is
+    true, follows with a bare ``response.create`` so the model voices a
+    correction/addition immediately; otherwise the model silently absorbs the
+    note and applies it on its next natural turn.
+
+    A ``response.create`` sent while the model already has an active response
+    will be rejected by OpenAI with an error event (logged by the pump) — the
+    note itself still lands, so the guidance is not lost.
+    """
+    try:
+        await openai_ws.send_str(json.dumps(build_supervisor_item(guidance)))
+        if speak:
+            await openai_ws.send_str(json.dumps({"type": "response.create"}))
+    except Exception as exc:  # best-effort; the call continues regardless
+        logger.debug("[Inkbox supervisor] guidance injection failed: %s", exc)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Supervisor loop
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _SupervisorRuntime:
+    """Mutable per-call supervisor bookkeeping, kept off the shared bridge state."""
+
+    interjections: int = 0
+    last_review_at: float = 0.0
+    reviewed_turns: int = 0
+    guidance: List[str] = field(default_factory=list)
+
+
+async def run_supervisor_loop(
+    *,
+    openai_ws: Any,
+    transcript_events: "asyncio.Queue[Tuple[str, str]]",
+    transcript_snapshot: Callable[[], List[Tuple[str, str]]],
+    is_closed: Callable[[], bool],
+    config: SupervisorConfig,
+    meta: Any,
+    on_supervise: SuperviseCallback,
+    clock: Callable[[], float] = None,  # type: ignore[assignment]
+    runtime: Optional[_SupervisorRuntime] = None,
+) -> None:
+    """Watch the transcript and inject proactive guidance until the call ends.
+
+    Consumes finalized ``(party, text)`` turns from ``transcript_events``. After
+    each new turn — caller or agent — and a short debounce so we review a settled
+    thought, it snapshots the full transcript and asks ``on_supervise`` for a
+    decision, subject to rate-limit / budget guards. Reviewing after *agent*
+    turns too (not only caller turns) is what lets the supervisor catch a wrong
+    statement the moment the mouth makes it and interject a correction, rather
+    than waiting for the next caller turn. Actionable decisions are injected into
+    ``openai_ws`` via :func:`inject_guidance`.
+
+    Designed to run as a background task next to the two audio pumps; it exits
+    when ``is_closed()`` becomes true (and is cancelled on teardown regardless).
+    """
+    if clock is None:
+        clock = asyncio.get_event_loop().time
+    rt = runtime if runtime is not None else _SupervisorRuntime()
+
+    while not is_closed():
+        got = await _next_turn(transcript_events, config, is_closed)
+        if got is None:
+            continue  # timed out waiting; re-check is_closed and loop
+
+        # Debounce: let any trailing fragments of the same thought arrive.
+        await _drain_for(transcript_events, config.debounce_s, is_closed)
+        if is_closed():
+            return
+
+        transcript = transcript_snapshot()
+        caller_turns = sum(1 for role, _ in transcript if role == "caller")
+        if caller_turns < config.min_caller_turns:
+            continue
+        if len(transcript) <= rt.reviewed_turns:
+            continue  # nothing new since the last review
+        now = clock()
+        if now - rt.last_review_at < config.min_review_interval_s:
+            continue
+        if rt.interjections >= config.max_interjections:
+            continue
+
+        rt.reviewed_turns = len(transcript)
+        rt.last_review_at = now
+
+        try:
+            raw = await asyncio.wait_for(
+                on_supervise(meta, transcript, list(rt.guidance)),
+                timeout=config.review_timeout_s,
+            )
+        except asyncio.TimeoutError:
+            logger.debug("[Inkbox supervisor] review timed out; skipping nudge")
+            continue
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.debug("[Inkbox supervisor] review raised: %s", exc)
+            continue
+
+        decision = parse_supervisor_decision(raw)
+        if not decision.is_actionable:
+            continue
+        if is_closed():
+            return
+
+        rt.guidance.append(decision.guidance)
+        rt.interjections += 1
+        logger.info(
+            "[Inkbox supervisor] %s note #%d for call_id=%s",
+            decision.action,
+            rt.interjections,
+            getattr(meta, "call_id", "?"),
+        )
+        await inject_guidance(
+            openai_ws, decision.guidance, speak=(decision.action == ACTION_INTERJECT),
+        )
+
+
+async def _next_turn(
+    transcript_events: "asyncio.Queue[Tuple[str, str]]",
+    config: SupervisorConfig,
+    is_closed: Callable[[], bool],
+) -> Optional[str]:
+    """Block until any finalized turn arrives; return its party, or None on timeout.
+
+    Both caller and agent turns wake a review: a caller turn is a chance to steer
+    the agent's next reply, an agent turn is a chance to catch and correct what it
+    just said. The ``min_review_interval_s`` guard keeps that from getting noisy.
+    """
+    try:
+        party, _text = await asyncio.wait_for(
+            transcript_events.get(), timeout=config.poll_interval_s,
+        )
+    except asyncio.TimeoutError:
+        return None
+    return party
+
+
+async def _drain_for(
+    transcript_events: "asyncio.Queue[Tuple[str, str]]",
+    window_s: float,
+    is_closed: Callable[[], bool],
+) -> None:
+    """Sleep ``window_s`` then discard any events queued during it.
+
+    The authoritative transcript is read from ``transcript_snapshot`` at review
+    time, so queued events during the debounce window only need to be cleared,
+    not inspected. Draining prevents them from immediately re-triggering a
+    second review on the next loop iteration.
+    """
+    if window_s > 0:
+        await asyncio.sleep(window_s)
+    while not transcript_events.empty():
+        try:
+            transcript_events.get_nowait()
+        except asyncio.QueueEmpty:
+            break

--- a/realtime_supervisor.py
+++ b/realtime_supervisor.py
@@ -92,6 +92,13 @@ class SupervisorConfig:
     """
 
     enabled: bool = False
+    # Which brain runs a review. "hermes" (default) is the real main agent via
+    # ``hermes -z`` — it has tools, so it can VERIFY facts against live data and
+    # catch tool-grounded errors a context-only model cannot. "model" is a cheap
+    # chat-completions proxy: fast and cheap, but no tools/live data, so it only
+    # catches guardrail/consistency problems. The loop is backend-agnostic; the
+    # adapter maps this field to the matching callback.
+    backend: str = "hermes"
     # Wait this long for the caller's turn to settle before reviewing, so we
     # review once per *thought* rather than per transcription fragment.
     debounce_s: float = 1.2

--- a/realtime_supervisor.py
+++ b/realtime_supervisor.py
@@ -98,9 +98,11 @@ class SupervisorConfig:
     # How long the supervisor model may take before we abandon a review. The
     # call keeps flowing regardless — a slow review just means no nudge.
     review_timeout_s: float = 12.0
-    # Never fire more than one review per this interval, even under rapid
-    # back-and-forth. Bounds cost and avoids stepping on the model.
-    min_review_interval_s: float = 6.0
+    # Floor on the gap between reviews, as a backstop against pathological
+    # rapid-fire. 0 = review every settled turn (the debounce already coalesces
+    # fragments within a turn), which is what "regular updates as the call
+    # proceeds" wants; raise it to trade responsiveness for fewer model calls.
+    min_review_interval_s: float = 0.0
     # Hard cap on total injected notes per call. Prevents a misbehaving
     # supervisor from turning the call into a lecture.
     max_interjections: int = 8
@@ -183,6 +185,12 @@ def parse_supervisor_decision(raw: Any) -> SupervisorDecision:
             guidance=str(json_obj.get("guidance") or ""),
             reason=str(json_obj.get("reason") or ""),
         ))
+
+    # Looks like JSON but didn't parse (e.g. a max_tokens-truncated object). Do
+    # NOT fall through to the freeform-steer path — injecting a half-JSON blob as
+    # a spoken note would be worse than staying silent.
+    if stripped.startswith("{") or stripped.startswith("```"):
+        return SupervisorDecision(action=ACTION_NONE)
 
     # Plain-text convention.
     if stripped.lower() in _SILENT_MARKERS:
@@ -282,7 +290,9 @@ class _SupervisorRuntime:
     """Mutable per-call supervisor bookkeeping, kept off the shared bridge state."""
 
     interjections: int = 0
-    last_review_at: float = 0.0
+    # -inf so the very first review is never throttled by min_review_interval_s,
+    # regardless of the clock's absolute value.
+    last_review_at: float = float("-inf")
     reviewed_turns: int = 0
     guidance: List[str] = field(default_factory=list)
 
@@ -296,6 +306,7 @@ async def run_supervisor_loop(
     config: SupervisorConfig,
     meta: Any,
     on_supervise: SuperviseCallback,
+    is_response_active: Optional[Callable[[], bool]] = None,
     clock: Callable[[], float] = None,  # type: ignore[assignment]
     runtime: Optional[_SupervisorRuntime] = None,
 ) -> None:
@@ -364,15 +375,23 @@ async def run_supervisor_loop(
 
         rt.guidance.append(decision.guidance)
         rt.interjections += 1
+        # Speak-now only when the model is NOT already mid-response. Firing
+        # response.create while a response is active collides with the bridge's
+        # own server-VAD auto-response and OpenAI rejects one
+        # (conversation_already_has_active_response). When busy, we still inject
+        # the note silently — it lands in context and the in-flight/next response
+        # picks it up — so the guidance is never lost, we just don't double-fire.
+        speak = decision.action == ACTION_INTERJECT and not (
+            is_response_active is not None and is_response_active()
+        )
         logger.info(
-            "[Inkbox supervisor] %s note #%d for call_id=%s",
+            "[Inkbox supervisor] %s note #%d (speak=%s) for call_id=%s",
             decision.action,
             rt.interjections,
+            speak,
             getattr(meta, "call_id", "?"),
         )
-        await inject_guidance(
-            openai_ws, decision.guidance, speak=(decision.action == ACTION_INTERJECT),
-        )
+        await inject_guidance(openai_ws, decision.guidance, speak=speak)
 
 
 async def _next_turn(

--- a/tests/live/test_supervisor_quality.py
+++ b/tests/live/test_supervisor_quality.py
@@ -147,6 +147,9 @@ def _make_supervisor(brief):
 
 
 def _judge(brief, rubric, transcript):
+    # The judge sees only caller/agent turns (supervisor notes are stripped) and
+    # is called per-arm with no "this is the supervised one" label, so it can't
+    # tell which arm it is grading.
     convo = format_transcript([t for t in transcript if t.party in ("caller", "agent")])
     prompt = (
         "You are grading a phone call for quality. The agent was briefed:\n"
@@ -155,18 +158,23 @@ def _judge(brief, rubric, transcript):
         'Score the AGENT from 0 to 10 and reply ONLY as JSON: {"score": <0-10>, '
         '"reason": "<one sentence>"}.'
     )
-    raw = _chat(
-        JUDGE_MODEL,
-        [{"role": "user", "content": prompt}],
-        temperature=0.0,
-        json_mode=True,
-        max_tokens=200,
-    )
-    try:
-        obj = json.loads(raw)
-        return float(obj.get("score", 0)), str(obj.get("reason", ""))
-    except (ValueError, TypeError):
-        return 0.0, "unparseable judge reply"
+    # Retry once; a parse failure must fail loudly rather than silently scoring
+    # 0.0, which could manufacture or destroy the measured delta.
+    last_raw = ""
+    for _ in range(2):
+        last_raw = _chat(
+            JUDGE_MODEL,
+            [{"role": "user", "content": prompt}],
+            temperature=0.0,
+            json_mode=True,
+            max_tokens=200,
+        )
+        try:
+            obj = json.loads(last_raw)
+            return float(obj["score"]), str(obj.get("reason", ""))
+        except (ValueError, TypeError, KeyError):
+            continue
+    pytest.fail(f"judge returned unparseable score twice: {last_raw!r}")
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -269,11 +277,23 @@ def test_supervisor_beats_baseline_by_llm_judge(capsys):
         print(f"BASELINE {r['base']:.1f} ({r['base_reason']}):\n{format_transcript(r['base_t'])}")
         print(f"ENHANCED {r['enh']:.1f} ({r['enh_reason']}):\n{format_transcript(r['enh_t'])}")
 
-    # The proof: with real models, the supervised calls score higher on average.
-    assert enh_mean > base_mean, (
-        f"supervisor did not improve judged quality: baseline={base_mean:.2f} "
-        f"enhanced={enh_mean:.2f}"
-    )
-    # And the supervisor actually did something on at least one scenario (guards
-    # against a vacuous pass where nothing was ever injected).
+    # The supervisor must actually have intervened somewhere (guards against a
+    # vacuous pass where nothing was ever injected).
     assert any(r["interjected"] for r in rows), "supervisor never intervened"
+    # The proof: with real models, the supervised calls score higher on average.
+    # A small margin (on the 0-10 scale) keeps a coin-flip 0.01 edge from
+    # counting as a win; single-shot judging has real variance, so a genuine
+    # architectural effect should clear this comfortably.
+    margin = float(os.environ.get("SUPERVISOR_QUALITY_MARGIN", "0.5"))
+    assert enh_mean >= base_mean + margin, (
+        f"supervisor did not improve judged quality by >= {margin}: "
+        f"baseline={base_mean:.2f} enhanced={enh_mean:.2f}"
+    )
+    # Per-arm non-regression on the scenarios where it intervened: the supervisor
+    # should not have made any individual supervised call worse than its baseline.
+    for r in rows:
+        if r["interjected"]:
+            assert r["enh"] >= r["base"] - 1.0, (
+                f"{r['name']}: supervised call scored materially worse "
+                f"(baseline={r['base']:.1f} enhanced={r['enh']:.1f})"
+            )

--- a/tests/live/test_supervisor_quality.py
+++ b/tests/live/test_supervisor_quality.py
@@ -1,0 +1,279 @@
+"""Live, LLM-judged proof that the proactive supervisor yields better calls.
+
+This is the "real models" half of the supervisor proof. For each scenario it
+runs the SAME scripted caller against the SAME fast voice model twice —
+baseline (no supervisor) and enhanced (the real supervisor prompt) — then has a
+stronger judge model blind-score both transcripts on a scenario rubric. It
+asserts the enhanced calls score higher in aggregate, and prints a scoreboard.
+
+It deliberately uses a small, error-prone voice model (the "mouth") and a
+context that the mouth must respect — exactly the regime where a supervisor
+earns its keep. The only variable between the two runs is whether the
+supervisor is attached.
+
+Gated: needs OPENAI_API_KEY and LIVE_REAL_MODEL=1. Skipped otherwise. Models are
+overridable via env:
+
+  SUPERVISOR_VOICE_MODEL   (default gpt-4o-mini)   — the fast "mouth"
+  SUPERVISOR_BRAIN_MODEL   (default gpt-4o-mini)   — the supervisor
+  SUPERVISOR_JUDGE_MODEL   (default gpt-4o)        — the blind judge
+
+Run locally:
+    OPENAI_API_KEY=sk-... LIVE_REAL_MODEL=1 \
+      python -m pytest tests/live/test_supervisor_quality.py -v -s
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import types
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+pkg = types.ModuleType("inkbox_plugin")
+pkg.__path__ = [str(ROOT)]
+sys.modules.setdefault("inkbox_plugin", pkg)
+
+from inkbox_plugin.realtime_supervisor import SupervisorDecision, parse_supervisor_decision
+from tests.proof_harness import Scenario, format_transcript, run_call
+
+API_KEY = os.environ.get("OPENAI_API_KEY")
+BASE_URL = (os.environ.get("OPENAI_BASE_URL") or "https://api.openai.com/v1").rstrip("/")
+REAL = os.environ.get("LIVE_REAL_MODEL") == "1"
+VOICE_MODEL = os.environ.get("SUPERVISOR_VOICE_MODEL", "gpt-4o-mini")
+BRAIN_MODEL = os.environ.get("SUPERVISOR_BRAIN_MODEL", "gpt-4o-mini")
+JUDGE_MODEL = os.environ.get("SUPERVISOR_JUDGE_MODEL", "gpt-4o")
+
+pytestmark = pytest.mark.skipif(
+    not (API_KEY and REAL),
+    reason="supervisor quality suite: needs OPENAI_API_KEY + LIVE_REAL_MODEL=1",
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Minimal OpenAI chat helper (stdlib only)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _chat(model, messages, *, temperature=0.4, json_mode=False, max_tokens=300):
+    payload = {
+        "model": model,
+        "messages": messages,
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+    }
+    if json_mode:
+        payload["response_format"] = {"type": "json_object"}
+    req = urllib.request.Request(
+        f"{BASE_URL}/chat/completions",
+        data=json.dumps(payload).encode(),
+        headers={"Authorization": f"Bearer {API_KEY}", "Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        data = json.loads(resp.read())
+    return data["choices"][0]["message"]["content"].strip()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# LLM-backed voice model, supervisor, and judge
+# ─────────────────────────────────────────────────────────────────────────────
+
+_VOICE_SYSTEM = (
+    "You are a fast phone voice assistant on a live call. Keep every reply to one "
+    "or two short spoken sentences. Answer the caller directly and naturally. You "
+    "were briefed before the call:\n{brief}\n"
+    "If you receive a message tagged [SUPERVISOR], it is private guidance from your "
+    "back-office team that the caller cannot hear — follow it in your next reply."
+)
+
+_SUPERVISOR_SYSTEM = (
+    "You are a silent SUPERVISOR monitoring a live phone call handled by a fast "
+    "voice AI (the 'agent'); the caller cannot hear you. You were briefed:\n{brief}\n"
+    "Watch the transcript. The voice AI can state facts wrongly, omit briefed "
+    "caveats, or over-promise. Decide if it needs a nudge RIGHT NOW.\n"
+    'Reply with ONLY JSON: {{"action":"none"|"steer"|"interject","guidance":"<one '
+    'short instruction to the agent>","reason":"<why>"}}. Prefer "none" unless '
+    "there is a concrete problem. Never invent facts beyond the briefing."
+)
+
+
+def _make_voice_model(brief):
+    def voice_model(transcript, _context, notes):
+        messages = [{"role": "system", "content": _VOICE_SYSTEM.format(brief=brief)}]
+        for t in transcript:
+            if t.party == "caller":
+                messages.append({"role": "user", "content": t.text})
+            elif t.party == "agent":
+                messages.append({"role": "assistant", "content": t.text})
+            # supervisor turns are injected below as private guidance, not history
+        for note in notes:
+            messages.append({"role": "system", "content": f"[SUPERVISOR] {note}"})
+        return _chat(VOICE_MODEL, messages, temperature=0.5, max_tokens=120)
+
+    return voice_model
+
+
+def _make_supervisor(brief):
+    def supervisor(transcript, _context, prior_guidance):
+        convo = "\n".join(
+            f"{'CALLER' if t.party == 'caller' else 'AGENT'}: {t.text}"
+            for t in transcript if t.party in ("caller", "agent")
+        )
+        prior = (" Already sent (don't repeat): " + " | ".join(prior_guidance)) if prior_guidance else ""
+        user = f"Transcript so far:\n{convo}\n{prior}\nDecide now. JSON only."
+        try:
+            raw = _chat(
+                BRAIN_MODEL,
+                [
+                    {"role": "system", "content": _SUPERVISOR_SYSTEM.format(brief=brief)},
+                    {"role": "user", "content": user},
+                ],
+                temperature=0.0,
+                json_mode=True,
+                max_tokens=200,
+            )
+        except Exception:
+            return SupervisorDecision(action="none")
+        return parse_supervisor_decision(raw)
+
+    return supervisor
+
+
+def _judge(brief, rubric, transcript):
+    convo = format_transcript([t for t in transcript if t.party in ("caller", "agent")])
+    prompt = (
+        "You are grading a phone call for quality. The agent was briefed:\n"
+        f"{brief}\n\nA good call, specifically:\n{rubric}\n\n"
+        f"TRANSCRIPT:\n{convo}\n\n"
+        'Score the AGENT from 0 to 10 and reply ONLY as JSON: {"score": <0-10>, '
+        '"reason": "<one sentence>"}.'
+    )
+    raw = _chat(
+        JUDGE_MODEL,
+        [{"role": "user", "content": prompt}],
+        temperature=0.0,
+        json_mode=True,
+        max_tokens=200,
+    )
+    try:
+        obj = json.loads(raw)
+        return float(obj.get("score", 0)), str(obj.get("reason", ""))
+    except (ValueError, TypeError):
+        return 0.0, "unparseable judge reply"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Live scenarios
+# ─────────────────────────────────────────────────────────────────────────────
+
+_LIVE_SCENARIOS = [
+    {
+        "name": "wrong_shipping_date",
+        "brief": (
+            "You are the phone agent for Acme Store. FACT: the caller's order (#8842) "
+            "ships in 3 business days. It does NOT ship today and will NOT arrive tomorrow."
+        ),
+        "caller": [
+            "Hi, calling about order 8842 — that's going out today and I'll have it tomorrow, right?",
+            "Okay. And it's the blue one?",
+        ],
+        "rubric": (
+            "clearly tells the caller the order ships in about 3 business days and does "
+            "NOT confirm same-day shipping or next-day arrival."
+        ),
+    },
+    {
+        "name": "final_sale_omission",
+        "brief": (
+            "You are the phone agent for a boutique. FACT: the item the caller is asking "
+            "about (the clearance jacket) is FINAL SALE — no returns, no refunds, no exchanges."
+        ),
+        "caller": [
+            "If the clearance jacket doesn't fit, I can just mail it back for a refund, yeah?",
+            "Hm, okay.",
+        ],
+        "rubric": (
+            "clearly tells the caller the clearance jacket is final sale and cannot be "
+            "returned/refunded, rather than confirming a return or refund is possible."
+        ),
+    },
+    {
+        "name": "over_promise_email",
+        "brief": (
+            "You are a fast phone agent. You CANNOT send email yourself — only the main "
+            "back-office agent can, after the call. If asked to email something, you must "
+            "say it's queued to be sent after the call, not that you're sending it now."
+        ),
+        "caller": [
+            "Can you shoot me an email with my invoice right now while we're on the phone?",
+            "Great.",
+        ],
+        "rubric": (
+            "tells the caller the invoice/email is queued to be sent after the call and "
+            "does NOT claim to be sending it right now or that it's already sent."
+        ),
+    },
+]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The proof
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_supervisor_beats_baseline_by_llm_judge(capsys):
+    rows = []
+    for sc in _LIVE_SCENARIOS:
+        scenario = Scenario(
+            name=sc["name"],
+            context={"contact_known": True},
+            caller=sc["caller"],
+            grade=lambda _t: 0.0,  # unused; the judge scores here
+            rubric_note=sc["rubric"],
+        )
+        voice_model = _make_voice_model(sc["brief"])
+        supervisor = _make_supervisor(sc["brief"])
+
+        base_t = run_call(scenario, voice_model, supervisor=None)
+        enh_t = run_call(scenario, voice_model, supervisor=supervisor)
+
+        base_score, base_reason = _judge(sc["brief"], sc["rubric"], base_t)
+        enh_score, enh_reason = _judge(sc["brief"], sc["rubric"], enh_t)
+        rows.append({
+            "name": sc["name"],
+            "base": base_score, "enh": enh_score,
+            "base_reason": base_reason, "enh_reason": enh_reason,
+            "base_t": base_t, "enh_t": enh_t,
+            "interjected": any(t.party == "supervisor" for t in enh_t),
+        })
+
+    base_mean = sum(r["base"] for r in rows) / len(rows)
+    enh_mean = sum(r["enh"] for r in rows) / len(rows)
+
+    print("\n=== Supervisor call-quality proof (live, LLM-judged) ===")
+    print(f"voice={VOICE_MODEL}  supervisor={BRAIN_MODEL}  judge={JUDGE_MODEL}")
+    print(f"{'scenario':<24}{'baseline':>10}{'enhanced':>10}{'delta':>8}{'nudged':>8}")
+    for r in rows:
+        print(f"{r['name']:<24}{r['base']:>10.1f}{r['enh']:>10.1f}"
+              f"{r['enh'] - r['base']:>8.1f}{('yes' if r['interjected'] else 'no'):>8}")
+    print(f"{'MEAN':<24}{base_mean:>10.2f}{enh_mean:>10.2f}{enh_mean - base_mean:>8.2f}")
+    for r in rows:
+        print(f"\n--- {r['name']} ---")
+        print(f"BASELINE {r['base']:.1f} ({r['base_reason']}):\n{format_transcript(r['base_t'])}")
+        print(f"ENHANCED {r['enh']:.1f} ({r['enh_reason']}):\n{format_transcript(r['enh_t'])}")
+
+    # The proof: with real models, the supervised calls score higher on average.
+    assert enh_mean > base_mean, (
+        f"supervisor did not improve judged quality: baseline={base_mean:.2f} "
+        f"enhanced={enh_mean:.2f}"
+    )
+    # And the supervisor actually did something on at least one scenario (guards
+    # against a vacuous pass where nothing was ever injected).
+    assert any(r["interjected"] for r in rows), "supervisor never intervened"

--- a/tests/proof_harness.py
+++ b/tests/proof_harness.py
@@ -1,0 +1,194 @@
+"""Reusable call-simulation harness for the supervisor quality proofs.
+
+The same harness backs two proofs of the claim *"a proactive supervisor yields
+better calls"*:
+
+* the deterministic CI proof (``tests/test_supervisor_proof.py``) — scripted
+  caller, a fixed model of a fallible fast voice model, and a rule-based
+  supervisor, scored by per-scenario rubrics. Runs everywhere, no keys, and
+  locks in the mechanism + the scoreboard.
+* the live LLM-judged proof (``tests/live/test_supervisor_quality.py``) — the
+  *same* scenarios and harness, but the voice model / supervisor / caller are
+  real models and the grader is an LLM judge. That is the real-world evidence;
+  this file is what makes the two share one control.
+
+The harness isolates exactly one variable: whether a supervisor is attached.
+The voice model is byte-for-byte identical between the baseline and enhanced
+runs of a scenario — the only difference is that in the enhanced run a
+supervisor may inject a note, and the voice model incorporates notes it is
+given. That is the whole point: hold the "mouth" fixed, add the "brain", measure
+the delta.
+
+Modeling assumption (deterministic policies only): the fast voice model is
+modeled as *agreeable/confabulating* — when a caller asks something it can't
+answer from a shallow reading, it gives the agreeable answer ("yes", "no
+problem") rather than checking the loaded context. This is the well-documented
+failure mode of small realtime models, and it is what the supervisor exists to
+catch. The live suite measures how strongly the effect holds with real models.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+# Import the real decision type + parser so the simulated supervisor speaks the
+# exact same contract as the production supervisor loop.
+try:
+    from inkbox_plugin.realtime_supervisor import (
+        ACTION_INTERJECT,
+        SupervisorDecision,
+    )
+except ImportError:  # pragma: no cover — direct import fallback
+    from realtime_supervisor import (  # type: ignore
+        ACTION_INTERJECT,
+        SupervisorDecision,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Transcript + callable contracts
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class Turn:
+    party: str  # "caller" | "agent" | "supervisor"
+    text: str
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+
+# A voice model: given the transcript so far, the call context, and any pending
+# supervisor notes, return the agent's next spoken line.
+VoiceModel = Callable[[List[Turn], Dict[str, Any], List[str]], str]
+
+# A supervisor: given the transcript, context, and prior guidance already sent,
+# return a decision (may be action="none").
+Supervisor = Callable[[List[Turn], Dict[str, Any], List[str]], SupervisorDecision]
+
+# A caller: given the transcript and context, return the next caller line, or
+# None to hang up. (A plain list of strings is also accepted and wrapped.)
+Caller = Callable[[List[Turn], Dict[str, Any]], Optional[str]]
+
+
+@dataclass
+class Scenario:
+    name: str
+    context: Dict[str, Any]
+    caller: Any  # Caller callable OR list[str] of scripted lines
+    # Rubric: score a finished transcript in [0, 1]. Higher = better call.
+    grade: Callable[[List[Turn]], float]
+    # Human-readable description of what a *good* call does here.
+    rubric_note: str = ""
+
+
+def _as_caller(caller: Any) -> Caller:
+    """Normalize a scripted list of lines into a Caller callable."""
+    if callable(caller):
+        return caller
+    lines = list(caller)
+
+    def _scripted(transcript: List[Turn], _context: Dict[str, Any]) -> Optional[str]:
+        # One scripted line per caller turn already taken.
+        idx = sum(1 for t in transcript if t.party == "caller")
+        return lines[idx] if idx < len(lines) else None
+
+    return _scripted
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The simulation
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def run_call(
+    scenario: Scenario,
+    voice_model: VoiceModel,
+    supervisor: Optional[Supervisor] = None,
+    *,
+    max_turns: int = 12,
+) -> List[Turn]:
+    """Run one simulated call and return its transcript.
+
+    Turn order per round:
+
+      1. caller speaks (or hangs up → end),
+      2. supervisor reviews (steer opportunity) — a note here reaches the agent
+         *before* it replies, modeling a silent pre-emptive steer,
+      3. agent replies, incorporating any pending notes,
+      4. supervisor reviews again (interject opportunity) — if it interjects on
+         a wrong agent turn, the agent immediately voices a correction, modeling
+         the ``response.create`` speak-now path.
+
+    ``supervisor=None`` is the baseline (pull-only) architecture.
+    """
+    caller = _as_caller(scenario.caller)
+    transcript: List[Turn] = []
+    prior_guidance: List[str] = []
+    pending_notes: List[str] = []
+
+    def _review(stage: str) -> Optional[SupervisorDecision]:
+        if supervisor is None:
+            return None
+        decision = supervisor(list(transcript), scenario.context, list(prior_guidance))
+        if decision is None or not decision.is_actionable:
+            return None
+        prior_guidance.append(decision.guidance)
+        pending_notes.append(decision.guidance)
+        transcript.append(Turn("supervisor", decision.guidance, meta={"action": decision.action, "stage": stage}))
+        return decision
+
+    rounds = 0
+    while rounds < max_turns:
+        rounds += 1
+        line = caller(list(transcript), scenario.context)
+        if line is None:
+            break
+        transcript.append(Turn("caller", line))
+
+        _review("steer")
+
+        reply = voice_model(list(transcript), scenario.context, list(pending_notes))
+        pending_notes.clear()
+        transcript.append(Turn("agent", reply))
+
+        decision = _review("interject")
+        if decision is not None and decision.action == ACTION_INTERJECT:
+            # Speak-now: the agent immediately corrects itself using the note.
+            correction = voice_model(list(transcript), scenario.context, list(pending_notes))
+            pending_notes.clear()
+            transcript.append(Turn("agent", correction, meta={"correction": True}))
+
+    return transcript
+
+
+def run_ab(
+    scenario: Scenario,
+    voice_model: VoiceModel,
+    supervisor: Supervisor,
+    **kwargs: Any,
+) -> Tuple[List[Turn], List[Turn], float, float]:
+    """Run baseline (no supervisor) and enhanced (supervisor) for one scenario.
+
+    Returns (baseline_transcript, enhanced_transcript, baseline_score,
+    enhanced_score).
+    """
+    baseline = run_call(scenario, voice_model, supervisor=None, **kwargs)
+    enhanced = run_call(scenario, voice_model, supervisor=supervisor, **kwargs)
+    return baseline, enhanced, scenario.grade(baseline), scenario.grade(enhanced)
+
+
+def agent_lines(transcript: List[Turn]) -> str:
+    """Concatenated agent speech (what the caller actually heard)."""
+    return " ".join(t.text for t in transcript if t.party == "agent").lower()
+
+
+def format_transcript(transcript: List[Turn]) -> str:
+    """Render a transcript for logs / judge prompts. Supervisor notes are marked."""
+    out = []
+    for t in transcript:
+        if t.party == "supervisor":
+            out.append(f"    «supervisor/{t.meta.get('action', '?')}: {t.text}»")
+        else:
+            out.append(f"{t.party.upper()}: {t.text}")
+    return "\n".join(out)

--- a/tests/proof_harness.py
+++ b/tests/proof_harness.py
@@ -121,6 +121,14 @@ def run_call(
          the ``response.create`` speak-now path.
 
     ``supervisor=None`` is the baseline (pull-only) architecture.
+
+    Idealization to be aware of: this harness is *turn-synchronous* — a steer
+    injected at step 2 is guaranteed to reach the agent before its reply at
+    step 3. The production loop (``realtime_supervisor.run_supervisor_loop``) is
+    *concurrent*, so a steer may land slightly after the model has already begun
+    a reply, in which case it applies to the following turn instead. The
+    deterministic proof therefore measures the *ceiling* of the mechanism; the
+    live suite measures the effect under real concurrency.
     """
     caller = _as_caller(scenario.caller)
     transcript: List[Turn] = []

--- a/tests/test_realtime_supervisor.py
+++ b/tests/test_realtime_supervisor.py
@@ -457,6 +457,7 @@ def test_pump_publishes_transcript_turns_to_bus():
     ])
     state = _BridgeState()
     state.stream_id = "s-1"
+    state.supervisor_active = True  # a supervisor is consuming the bus
 
     async def _noop(*_a, **_k):
         return ""
@@ -532,3 +533,281 @@ def test_maybe_start_supervisor_enabled_spawns_and_cancels():
         assert task.cancelled() or task.done()
 
     asyncio.run(_run())
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Guard coverage: rate-limit, debounce, timeout, reviewed_turns, response-active,
+# cancellation, and parse edge cases (added after adversarial review)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_parse_empty_guidance_normalizes_to_none():
+    # A verb with only whitespace guidance is not actionable.
+    for raw in ["STEER:   ", "INTERJECT:", '{"action":"steer","guidance":"   "}']:
+        d = parse_supervisor_decision(raw)
+        assert d.action == ACTION_NONE, raw
+        assert not d.is_actionable
+
+
+def test_parse_truncated_json_is_not_injected_as_steer():
+    # A max_tokens-truncated JSON object must NOT fall through to a freeform
+    # steer that injects half a JSON blob as spoken guidance.
+    truncated = '{"action":"steer","guidance":"tell them the refund is'
+    d = parse_supervisor_decision(truncated)
+    assert d.action == ACTION_NONE
+    assert not d.is_actionable
+
+
+def test_loop_rate_limits_reviews_with_min_interval():
+    # With a large min_review_interval and a clock that does not advance, a
+    # second turn must NOT trigger a second review.
+    ws = _FakeWS()
+    events: "asyncio.Queue" = asyncio.Queue()
+    closed = {"v": False}
+    reviews = {"n": 0}
+    transcript = [("caller", "a")]
+
+    async def _on_supervise(*_a):
+        reviews["n"] += 1
+        return SupervisorDecision(action=ACTION_STEER, guidance="note")
+
+    async def _run():
+        task = asyncio.create_task(run_supervisor_loop(
+            openai_ws=ws,
+            transcript_events=events,
+            transcript_snapshot=lambda: list(transcript),
+            is_closed=lambda: closed["v"],
+            config=SupervisorConfig(
+                enabled=True, debounce_s=0.0, min_review_interval_s=1000.0, poll_interval_s=0.01,
+            ),
+            meta=_meta(),
+            on_supervise=_on_supervise,
+            clock=lambda: 100.0,  # frozen clock → interval never elapses
+        ))
+        events.put_nowait(("caller", "a"))
+        await _wait_until(lambda: reviews["n"] >= 1, timeout=1.0)
+        transcript.append(("caller", "b"))
+        events.put_nowait(("caller", "b"))
+        await asyncio.sleep(0.1)
+        closed["v"] = True
+        await asyncio.wait_for(task, timeout=2.0)
+
+    asyncio.run(_run())
+    assert reviews["n"] == 1, "min_review_interval did not throttle the second review"
+
+
+def test_loop_debounce_coalesces_burst_into_one_review():
+    # A burst of fragments within the debounce window collapses into ONE review
+    # that sees the whole transcript.
+    ws = _FakeWS()
+    events: "asyncio.Queue" = asyncio.Queue()
+    closed = {"v": False}
+    reviews = {"n": 0}
+    seen_len = []
+    transcript = [("caller", "part one"), ("caller", "part two"), ("caller", "part three")]
+
+    async def _on_supervise(_m, t, _g):
+        reviews["n"] += 1
+        seen_len.append(len(t))
+        return SupervisorDecision(action=ACTION_NONE)
+
+    async def _run():
+        task = asyncio.create_task(run_supervisor_loop(
+            openai_ws=ws,
+            transcript_events=events,
+            transcript_snapshot=lambda: list(transcript),
+            is_closed=lambda: closed["v"],
+            config=SupervisorConfig(
+                enabled=True, debounce_s=0.08, min_review_interval_s=0.0, poll_interval_s=0.01,
+            ),
+            meta=_meta(),
+            on_supervise=_on_supervise,
+        ))
+        # Three fragments arrive close together (within the debounce window).
+        events.put_nowait(("caller", "part one"))
+        events.put_nowait(("caller", "part two"))
+        events.put_nowait(("caller", "part three"))
+        await _wait_until(lambda: reviews["n"] >= 1, timeout=1.0)
+        await asyncio.sleep(0.1)
+        closed["v"] = True
+        await asyncio.wait_for(task, timeout=2.0)
+
+    asyncio.run(_run())
+    assert reviews["n"] == 1, "debounce did not coalesce the burst into one review"
+    assert seen_len == [3], "the single review should see the full coalesced transcript"
+
+
+def test_loop_review_timeout_skips_without_injecting():
+    # A hung supervisor model must be abandoned after review_timeout_s and must
+    # not inject anything; the loop keeps running.
+    ws = _FakeWS()
+    events: "asyncio.Queue" = asyncio.Queue()
+    closed = {"v": False}
+    started = {"v": False}
+
+    async def _hang(*_a):
+        started["v"] = True
+        await asyncio.Event().wait()  # never returns
+
+    async def _run():
+        task = asyncio.create_task(run_supervisor_loop(
+            openai_ws=ws,
+            transcript_events=events,
+            transcript_snapshot=lambda: [("caller", "x")],
+            is_closed=lambda: closed["v"],
+            config=SupervisorConfig(
+                enabled=True, debounce_s=0.0, min_review_interval_s=0.0,
+                review_timeout_s=0.05, poll_interval_s=0.01,
+            ),
+            meta=_meta(),
+            on_supervise=_hang,
+        ))
+        events.put_nowait(("caller", "x"))
+        await _wait_until(lambda: started["v"], timeout=1.0)
+        await asyncio.sleep(0.15)  # let the timeout trip
+        closed["v"] = True
+        await asyncio.wait_for(task, timeout=2.0)
+
+    asyncio.run(_run())
+    assert ws.sent == [], "a timed-out review must not inject guidance"
+
+
+def test_loop_skips_review_when_transcript_has_not_grown():
+    # reviewed_turns guard: a second wake with no new turns must not re-review
+    # (and thus not re-inject duplicate guidance).
+    ws = _FakeWS()
+    events: "asyncio.Queue" = asyncio.Queue()
+    closed = {"v": False}
+    reviews = {"n": 0}
+    static = [("caller", "a"), ("agent", "b")]  # never grows
+
+    async def _on_supervise(*_a):
+        reviews["n"] += 1
+        return SupervisorDecision(action=ACTION_NONE)
+
+    async def _run():
+        task = asyncio.create_task(run_supervisor_loop(
+            openai_ws=ws,
+            transcript_events=events,
+            transcript_snapshot=lambda: list(static),
+            is_closed=lambda: closed["v"],
+            config=SupervisorConfig(
+                enabled=True, debounce_s=0.0, min_review_interval_s=0.0, poll_interval_s=0.01,
+            ),
+            meta=_meta(),
+            on_supervise=_on_supervise,
+        ))
+        events.put_nowait(("caller", "a"))
+        await _wait_until(lambda: reviews["n"] >= 1, timeout=1.0)
+        # A second wake with the SAME transcript length must be skipped.
+        events.put_nowait(("agent", "b"))
+        await asyncio.sleep(0.1)
+        closed["v"] = True
+        await asyncio.wait_for(task, timeout=2.0)
+
+    asyncio.run(_run())
+    assert reviews["n"] == 1, "reviewed_turns guard did not skip an unchanged transcript"
+
+
+def test_loop_interject_suppressed_to_silent_when_response_active():
+    # When a response is already being generated, a speak-now interject must NOT
+    # fire response.create (it would collide); the note is still injected.
+    ws = _FakeWS()
+    events: "asyncio.Queue" = asyncio.Queue()
+    closed = {"v": False}
+    reviews = {"n": 0}
+
+    async def _on_supervise(*_a):
+        reviews["n"] += 1
+        return SupervisorDecision(action=ACTION_INTERJECT, guidance="correct it")
+
+    async def _run():
+        task = asyncio.create_task(run_supervisor_loop(
+            openai_ws=ws,
+            transcript_events=events,
+            transcript_snapshot=lambda: [("caller", "x"), ("agent", "wrong")],
+            is_closed=lambda: closed["v"],
+            config=SupervisorConfig(
+                enabled=True, debounce_s=0.0, min_review_interval_s=0.0, poll_interval_s=0.01,
+            ),
+            meta=_meta(),
+            on_supervise=_on_supervise,
+            is_response_active=lambda: True,  # a response is mid-flight
+        ))
+        events.put_nowait(("agent", "wrong"))
+        await _wait_until(lambda: reviews["n"] >= 1, timeout=1.0)
+        await asyncio.sleep(0.05)
+        closed["v"] = True
+        await asyncio.wait_for(task, timeout=2.0)
+
+    asyncio.run(_run())
+    # Item injected, but NO response.create while a response is active.
+    assert [f["type"] for f in ws.sent] == ["conversation.item.create"]
+
+
+def test_loop_cancellation_mid_review_propagates():
+    # Cancelling the loop while a review is in-flight must cancel cleanly (the
+    # CancelledError is re-raised, not swallowed) and inject nothing.
+    ws = _FakeWS()
+    events: "asyncio.Queue" = asyncio.Queue()
+    entered = {"v": False}
+
+    async def _block(*_a):
+        entered["v"] = True
+        await asyncio.Event().wait()
+
+    async def _run():
+        task = asyncio.create_task(run_supervisor_loop(
+            openai_ws=ws,
+            transcript_events=events,
+            transcript_snapshot=lambda: [("caller", "x")],
+            is_closed=lambda: False,
+            config=SupervisorConfig(
+                enabled=True, debounce_s=0.0, min_review_interval_s=0.0, poll_interval_s=0.01,
+                review_timeout_s=100.0,
+            ),
+            meta=_meta(),
+            on_supervise=_block,
+        ))
+        events.put_nowait(("caller", "x"))
+        await _wait_until(lambda: entered["v"], timeout=1.0)
+        await realtime_mod._cancel_supervisor_task(task)
+        assert task.cancelled() or task.done()
+
+    asyncio.run(_run())
+    assert ws.sent == []
+
+
+def test_pump_toggles_response_active_flag():
+    state = _BridgeState()
+    assert state.response_active is False
+    openai_ws = _FakeOpenAIWS([
+        {"type": "response.created", "response": {"id": "r1"}},
+        {"type": "response.output_audio.delta", "delta": "AA"},
+        {"type": "response.done", "response": {"id": "r1"}},
+    ])
+
+    async def _noop(*_a, **_k):
+        return ""
+
+    asyncio.run(_openai_to_inkbox_pump(
+        openai_ws=openai_ws,
+        inkbox_ws=_FakeWS(),
+        state=state,
+        config=RealtimeConfig(enabled=True, api_key="sk-test"),
+        meta=_meta(),
+        on_agent_consult=_noop,
+    ))
+    # After response.done, the flag is cleared.
+    assert state.response_active is False
+
+
+def test_publish_transcript_turn_noop_without_supervisor():
+    # The pump must not fill the bus when no supervisor is consuming it.
+    state = _BridgeState()
+    assert state.supervisor_active is False
+    realtime_mod._publish_transcript_turn(state, "caller", "hello")
+    assert state.transcript_events.empty()
+    state.supervisor_active = True
+    realtime_mod._publish_transcript_turn(state, "caller", "hello")
+    assert not state.transcript_events.empty()

--- a/tests/test_realtime_supervisor.py
+++ b/tests/test_realtime_supervisor.py
@@ -1,0 +1,534 @@
+"""Unit tests for the proactive realtime supervisor.
+
+Covers the pure decision-parsing / injection-frame builders and the async
+supervisor loop (debounce, rate-limit, budget, dedup, silent-vs-speak
+injection, teardown), plus the realtime-bridge wiring that publishes transcript
+turns onto the supervisor bus. No network, fully deterministic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import types
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("inkbox_plugin")
+pkg.__path__ = [str(ROOT)]
+sys.modules.setdefault("inkbox_plugin", pkg)
+
+from inkbox_plugin import realtime as realtime_mod
+from inkbox_plugin.realtime import RealtimeCallMeta, RealtimeConfig, _BridgeState, _openai_to_inkbox_pump
+from inkbox_plugin.realtime_supervisor import (
+    ACTION_INTERJECT,
+    ACTION_NONE,
+    ACTION_STEER,
+    SUPERVISOR_ITEM_ROLE,
+    SUPERVISOR_NOTE_PREFIX,
+    SupervisorConfig,
+    SupervisorDecision,
+    build_supervisor_item,
+    inject_guidance,
+    parse_supervisor_decision,
+    run_supervisor_loop,
+)
+
+
+if realtime_mod.aiohttp is None:  # mirror the parity suite's aiohttp shim
+    realtime_mod.aiohttp = types.SimpleNamespace(
+        WSMsgType=types.SimpleNamespace(
+            TEXT=object(), CLOSE=object(), CLOSED=object(), ERROR=object(),
+        ),
+    )
+
+
+def _meta(**overrides):
+    base = {
+        "call_id": "call-sup",
+        "contact_id": "c-1",
+        "contact_name": "Alex Wilcox",
+        "remote_phone_number": "+15555550101",
+        "direction": "inbound",
+        "contact_known": True,
+    }
+    base.update(overrides)
+    return RealtimeCallMeta(**base)
+
+
+class _FakeWS:
+    def __init__(self):
+        self.sent = []
+
+    async def send_str(self, payload):
+        self.sent.append(json.loads(payload))
+
+
+class _FakeMsg:
+    def __init__(self, data):
+        self.type = realtime_mod.aiohttp.WSMsgType.TEXT
+        self.data = json.dumps(data)
+
+
+class _FakeOpenAIWS(_FakeWS):
+    def __init__(self, frames):
+        super().__init__()
+        self._frames = [_FakeMsg(frame) for frame in frames]
+
+    def __aiter__(self):
+        self._it = iter(self._frames)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._it)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Decision parsing
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_parse_none_shapes():
+    for raw in ["", "  ", "NONE", "none", "[SILENT]", "n/a", None]:
+        d = parse_supervisor_decision(raw)
+        assert d.action == ACTION_NONE
+        assert not d.is_actionable
+
+
+def test_parse_verb_prefixes():
+    steer = parse_supervisor_decision("STEER: mention the refund window is 30 days")
+    assert steer.action == ACTION_STEER
+    assert steer.guidance == "mention the refund window is 30 days"
+    assert steer.is_actionable
+
+    interject = parse_supervisor_decision("INTERJECT: correct the price, it's $49 not $39")
+    assert interject.action == ACTION_INTERJECT
+    assert interject.is_actionable
+
+    # "speak" is normalized to interject.
+    assert parse_supervisor_decision("speak: fix that").action == ACTION_INTERJECT
+
+
+def test_parse_json_object_and_fenced_json():
+    d = parse_supervisor_decision('{"action":"interject","guidance":"say hi","reason":"greeting"}')
+    assert d.action == ACTION_INTERJECT
+    assert d.guidance == "say hi"
+    assert d.reason == "greeting"
+
+    fenced = parse_supervisor_decision('```json\n{"action":"steer","guidance":"nudge"}\n```')
+    assert fenced.action == ACTION_STEER
+    assert fenced.guidance == "nudge"
+
+
+def test_parse_json_none_action_wins_over_guidance():
+    # Guidance present but action none → not actionable.
+    d = parse_supervisor_decision('{"action":"none","guidance":"ignored"}')
+    assert d.action == ACTION_NONE
+    assert not d.is_actionable
+
+
+def test_parse_freeform_text_becomes_silent_steer():
+    d = parse_supervisor_decision("the caller sounds confused about billing")
+    assert d.action == ACTION_STEER
+    assert d.guidance == "the caller sounds confused about billing"
+
+
+def test_parse_passthrough_decision_object():
+    orig = SupervisorDecision(action="interject", guidance="go")
+    assert parse_supervisor_decision(orig).action == ACTION_INTERJECT
+
+
+def test_parse_invalid_action_falls_back_to_none():
+    assert parse_supervisor_decision('{"action":"shout","guidance":"x"}').action == ACTION_NONE
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Injection frame builders
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_build_supervisor_item_shape():
+    item = build_supervisor_item("correct the price")
+    assert item["type"] == "conversation.item.create"
+    assert item["item"]["type"] == "message"
+    assert item["item"]["role"] == SUPERVISOR_ITEM_ROLE
+    part = item["item"]["content"][0]
+    assert part["type"] == "input_text"
+    assert part["text"].startswith(SUPERVISOR_NOTE_PREFIX)
+    assert "correct the price" in part["text"]
+
+
+def test_build_supervisor_item_does_not_double_prefix():
+    item = build_supervisor_item(f"{SUPERVISOR_NOTE_PREFIX} already tagged")
+    assert item["item"]["content"][0]["text"].count(SUPERVISOR_NOTE_PREFIX) == 1
+
+
+def test_inject_steer_sends_item_only():
+    ws = _FakeWS()
+    asyncio.run(inject_guidance(ws, "add context", speak=False))
+    assert len(ws.sent) == 1
+    assert ws.sent[0]["type"] == "conversation.item.create"
+
+
+def test_inject_interject_sends_item_then_response_create():
+    ws = _FakeWS()
+    asyncio.run(inject_guidance(ws, "correct that now", speak=True))
+    assert [f["type"] for f in ws.sent] == [
+        "conversation.item.create",
+        "response.create",
+    ]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Supervisor loop
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def _wait_until(pred, timeout=2.0, step=0.01):
+    for _ in range(int(timeout / step)):
+        if pred():
+            return True
+        await asyncio.sleep(step)
+    return pred()
+
+
+async def _run_loop_until(openai_ws, transcript, decisions, *, config=None, expect_sends, meta=None, grow=True):
+    """Drive run_supervisor_loop, feeding one caller turn per queued decision.
+
+    ``decisions`` is a list the on_supervise stub returns in order (then NONE).
+    Events are fed one at a time, each only after the prior review has been
+    consumed — real caller turns arrive spread out in time, and the loop's
+    debounce drains anything already queued, so feeding all at once would
+    collapse them into a single review. Returns the prior-guidance snapshot the
+    stub observed on each call, for dedup assertions.
+    """
+    config = config or SupervisorConfig(
+        enabled=True, debounce_s=0.0, min_review_interval_s=0.0, poll_interval_s=0.01,
+    )
+    events: "asyncio.Queue" = asyncio.Queue()
+    closed = {"v": False}
+    seen_prior = []
+    calls = {"n": 0}
+
+    async def _on_supervise(_meta, _transcript, prior_guidance):
+        seen_prior.append(list(prior_guidance))
+        i = calls["n"]
+        calls["n"] += 1
+        return decisions[i] if i < len(decisions) else SupervisorDecision(action=ACTION_NONE)
+
+    task = asyncio.create_task(run_supervisor_loop(
+        openai_ws=openai_ws,
+        transcript_events=events,
+        transcript_snapshot=lambda: list(transcript),
+        is_closed=lambda: closed["v"],
+        config=config,
+        meta=meta or _meta(),
+        on_supervise=_on_supervise,
+    ))
+
+    for i in range(len(decisions)):
+        target = calls["n"] + 1
+        # Real calls grow the transcript each turn; the loop deliberately skips a
+        # review when the transcript hasn't grown since the last one, so a static
+        # transcript would collapse every feed into one review. Grow it here to
+        # mirror reality (guard-specific tests pass grow=False).
+        if grow:
+            transcript.append(("caller", f"caller-turn-{i}"))
+        events.put_nowait(("caller", "hello"))
+        # Wait for this review to be consumed. If a guard (min_caller_turns,
+        # max_interjections) legitimately blocks the review, this just times out
+        # and we move on — the assertions cover those cases.
+        await _wait_until(lambda: calls["n"] >= target, timeout=0.4)
+
+    if expect_sends:
+        await _wait_until(lambda: len(openai_ws.sent) >= expect_sends, timeout=1.0)
+    else:
+        # Give the loop a beat to consult (and decline) before we tear it down.
+        await asyncio.sleep(0.15)
+    closed["v"] = True
+    await asyncio.wait_for(task, timeout=2.0)
+    return seen_prior
+
+
+def test_loop_injects_silent_steer_on_caller_turn():
+    ws = _FakeWS()
+    asyncio.run(_run_loop_until(
+        ws,
+        transcript=[("caller", "what's my balance?")],
+        decisions=[SupervisorDecision(action=ACTION_STEER, guidance="offer to check the balance")],
+        expect_sends=1,
+    ))
+    types_sent = [f["type"] for f in ws.sent]
+    assert types_sent == ["conversation.item.create"]
+    assert "offer to check the balance" in ws.sent[0]["item"]["content"][0]["text"]
+
+
+def test_loop_speaks_on_interject():
+    ws = _FakeWS()
+    asyncio.run(_run_loop_until(
+        ws,
+        transcript=[("caller", "so it's free, right?"), ("agent", "yes, totally free")],
+        decisions=[SupervisorDecision(action=ACTION_INTERJECT, guidance="correct: there's a $5 fee")],
+        expect_sends=2,
+    ))
+    assert [f["type"] for f in ws.sent] == ["conversation.item.create", "response.create"]
+
+
+def test_loop_does_nothing_on_none():
+    ws = _FakeWS()
+    seen = asyncio.run(_run_loop_until(
+        ws,
+        transcript=[("caller", "hi")],
+        decisions=[SupervisorDecision(action=ACTION_NONE)],
+        expect_sends=0,  # never satisfied; loop polls then we close it
+    ))
+    assert ws.sent == []
+    assert seen  # the supervisor was consulted, it just declined
+
+
+def test_loop_respects_max_interjections():
+    ws = _FakeWS()
+    config = SupervisorConfig(
+        enabled=True, debounce_s=0.0, min_review_interval_s=0.0,
+        poll_interval_s=0.01, max_interjections=1,
+    )
+    asyncio.run(_run_loop_until(
+        ws,
+        transcript=[("caller", "a"), ("caller", "b"), ("caller", "c")],
+        decisions=[
+            SupervisorDecision(action=ACTION_STEER, guidance="first"),
+            SupervisorDecision(action=ACTION_STEER, guidance="second"),
+        ],
+        config=config,
+        expect_sends=1,
+    ))
+    item_frames = [f for f in ws.sent if f["type"] == "conversation.item.create"]
+    assert len(item_frames) == 1
+    assert "first" in item_frames[0]["item"]["content"][0]["text"]
+
+
+def test_loop_passes_prior_guidance_for_dedup():
+    ws = _FakeWS()
+    seen_prior = asyncio.run(_run_loop_until(
+        ws,
+        transcript=[("caller", "a"), ("caller", "b")],
+        decisions=[
+            SupervisorDecision(action=ACTION_STEER, guidance="mention the deadline"),
+            SupervisorDecision(action=ACTION_STEER, guidance="mention the fee"),
+        ],
+        expect_sends=2,
+    ))
+    # First review sees no prior guidance; the second sees the first note so it
+    # can avoid repeating itself.
+    assert seen_prior[0] == []
+    assert seen_prior[1] == ["mention the deadline"]
+
+
+def test_loop_reviews_after_agent_turns_to_catch_errors():
+    # An agent turn (not just a caller turn) must wake a review — that's how the
+    # supervisor catches a wrong statement the moment the mouth makes it and
+    # interjects a correction, rather than waiting for the next caller turn.
+    ws = _FakeWS()
+    events: "asyncio.Queue" = asyncio.Queue()
+    closed = {"v": False}
+    consulted = {"n": 0}
+
+    async def _on_supervise(*_a):
+        consulted["n"] += 1
+        return SupervisorDecision(action=ACTION_INTERJECT, guidance="correct that")
+
+    async def _run():
+        task = asyncio.create_task(run_supervisor_loop(
+            openai_ws=ws,
+            transcript_events=events,
+            # A caller turn already happened (min_caller_turns satisfied); the
+            # agent just answered.
+            transcript_snapshot=lambda: [("caller", "is it free?"), ("agent", "yes, totally free")],
+            is_closed=lambda: closed["v"],
+            config=SupervisorConfig(
+                enabled=True, debounce_s=0.0, min_review_interval_s=0.0, poll_interval_s=0.01,
+            ),
+            meta=_meta(),
+            on_supervise=_on_supervise,
+        ))
+        events.put_nowait(("agent", "yes, totally free"))
+        await _wait_until(lambda: consulted["n"] >= 1, timeout=1.0)
+        closed["v"] = True
+        await asyncio.wait_for(task, timeout=2.0)
+
+    asyncio.run(_run())
+    assert consulted["n"] >= 1
+    # An interject speaks now: item + response.create.
+    assert [f["type"] for f in ws.sent] == ["conversation.item.create", "response.create"]
+
+
+def test_loop_respects_min_caller_turns():
+    ws = _FakeWS()
+    config = SupervisorConfig(
+        enabled=True, debounce_s=0.0, min_review_interval_s=0.0,
+        poll_interval_s=0.01, min_caller_turns=2,
+    )
+    # Only one caller turn in the transcript, but min_caller_turns=2 → no review.
+    asyncio.run(_run_loop_until(
+        ws,
+        transcript=[("caller", "just one turn")],
+        decisions=[SupervisorDecision(action=ACTION_STEER, guidance="nope")],
+        config=config,
+        expect_sends=0,
+        grow=False,
+    ))
+    assert ws.sent == []
+
+
+def test_loop_exits_when_closed_without_events():
+    # With no transcript events, the loop must still exit promptly once closed.
+    ws = _FakeWS()
+    events: "asyncio.Queue" = asyncio.Queue()
+    closed = {"v": False}
+
+    async def _on_supervise(*_a):
+        return SupervisorDecision(action=ACTION_NONE)
+
+    async def _run():
+        task = asyncio.create_task(run_supervisor_loop(
+            openai_ws=ws,
+            transcript_events=events,
+            transcript_snapshot=lambda: [],
+            is_closed=lambda: closed["v"],
+            config=SupervisorConfig(enabled=True, poll_interval_s=0.01),
+            meta=_meta(),
+            on_supervise=_on_supervise,
+        ))
+        await asyncio.sleep(0.05)
+        closed["v"] = True
+        await asyncio.wait_for(task, timeout=2.0)
+        assert task.done()
+
+    asyncio.run(_run())
+
+
+def test_loop_survives_supervise_exception():
+    ws = _FakeWS()
+    events: "asyncio.Queue" = asyncio.Queue()
+    closed = {"v": False}
+
+    async def _boom(*_a):
+        raise RuntimeError("supervisor model down")
+
+    async def _run():
+        task = asyncio.create_task(run_supervisor_loop(
+            openai_ws=ws,
+            transcript_events=events,
+            transcript_snapshot=lambda: [("caller", "x")],
+            is_closed=lambda: closed["v"],
+            config=SupervisorConfig(
+                enabled=True, debounce_s=0.0, min_review_interval_s=0.0, poll_interval_s=0.01,
+            ),
+            meta=_meta(),
+            on_supervise=_boom,
+        ))
+        events.put_nowait(("caller", "x"))
+        await asyncio.sleep(0.1)
+        closed["v"] = True
+        await asyncio.wait_for(task, timeout=2.0)
+
+    asyncio.run(_run())
+    # A failing supervisor never disrupts the call: no frames, clean exit.
+    assert ws.sent == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Bridge wiring: transcript turns are published onto the supervisor bus
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_pump_publishes_transcript_turns_to_bus():
+    inkbox_ws = _FakeWS()
+    openai_ws = _FakeOpenAIWS([
+        {"type": "conversation.item.input_audio_transcription.completed",
+         "transcript": "can you check the invoice"},
+        {"type": "response.output_audio_transcript.done",
+         "transcript": "sure, one moment"},
+    ])
+    state = _BridgeState()
+    state.stream_id = "s-1"
+
+    async def _noop(*_a, **_k):
+        return ""
+
+    asyncio.run(_openai_to_inkbox_pump(
+        openai_ws=openai_ws,
+        inkbox_ws=inkbox_ws,
+        state=state,
+        config=RealtimeConfig(enabled=True, api_key="sk-test"),
+        meta=_meta(),
+        on_agent_consult=_noop,
+    ))
+
+    drained = []
+    while not state.transcript_events.empty():
+        drained.append(state.transcript_events.get_nowait())
+    assert drained == [
+        ("caller", "can you check the invoice"),
+        ("agent", "sure, one moment"),
+    ]
+
+
+def test_maybe_start_supervisor_disabled_returns_none():
+    async def _run():
+        cfg = RealtimeConfig(enabled=True, api_key="sk-test")  # supervisor default: disabled
+        task = realtime_mod._maybe_start_supervisor(
+            openai_ws=_FakeWS(),
+            state=_BridgeState(),
+            config=cfg,
+            meta=_meta(),
+            on_supervise=lambda *_a: None,
+        )
+        assert task is None
+
+    asyncio.run(_run())
+
+
+def test_maybe_start_supervisor_none_callback_returns_none():
+    async def _run():
+        cfg = RealtimeConfig(enabled=True, api_key="sk-test", supervisor=SupervisorConfig(enabled=True))
+        task = realtime_mod._maybe_start_supervisor(
+            openai_ws=_FakeWS(),
+            state=_BridgeState(),
+            config=cfg,
+            meta=_meta(),
+            on_supervise=None,
+        )
+        assert task is None
+
+    asyncio.run(_run())
+
+
+def test_maybe_start_supervisor_enabled_spawns_and_cancels():
+    async def _run():
+        cfg = RealtimeConfig(
+            enabled=True, api_key="sk-test",
+            supervisor=SupervisorConfig(enabled=True, poll_interval_s=0.01),
+        )
+        state = _BridgeState()
+
+        async def _on_supervise(*_a):
+            return SupervisorDecision(action=ACTION_NONE)
+
+        task = realtime_mod._maybe_start_supervisor(
+            openai_ws=_FakeWS(),
+            state=state,
+            config=cfg,
+            meta=_meta(),
+            on_supervise=_on_supervise,
+        )
+        assert task is not None
+        await realtime_mod._cancel_supervisor_task(task)
+        assert task.cancelled() or task.done()
+
+    asyncio.run(_run())

--- a/tests/test_realtime_supervisor_hermes.py
+++ b/tests/test_realtime_supervisor_hermes.py
@@ -1,0 +1,228 @@
+"""Unit tests for the Hermes-backed supervisor backend.
+
+Covers the real mechanics the deterministic proof models: the ``hermes -z``
+one-shot runner (stdout capture, model passthrough, timeout-kills-and-reaps,
+fail-open), the read-only supervisor prompt, the JSON-only decision guard, and
+the config-driven backend selection. Subprocess is mocked — no real agent runs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("inkbox_plugin")
+pkg.__path__ = [str(ROOT)]
+sys.modules.setdefault("inkbox_plugin", pkg)
+
+from inkbox_plugin import adapter as adapter_mod  # noqa: E402
+from inkbox_plugin.adapter import InkboxAdapter, _resolve_supervisor_config, _run_hermes_oneshot  # noqa: E402
+from inkbox_plugin.realtime import RealtimeCallMeta, RealtimeConfig  # noqa: E402
+from inkbox_plugin.realtime_supervisor import SupervisorConfig  # noqa: E402
+
+
+def _meta(**overrides):
+    base = {
+        "call_id": "call-hz",
+        "contact_id": "c-1",
+        "contact_name": "Alex Wilcox",
+        "remote_phone_number": "+15555550101",
+        "direction": "inbound",
+        "contact_known": True,
+    }
+    base.update(overrides)
+    return RealtimeCallMeta(**base)
+
+
+def _adapter(backend="hermes", review_timeout_s=5.0):
+    """A bare adapter with just the realtime config the supervisor path reads."""
+    adapter = object.__new__(InkboxAdapter)
+    adapter._realtime_config = RealtimeConfig(
+        enabled=True,
+        api_key="sk-test",
+        supervisor=SupervisorConfig(enabled=True, backend=backend, review_timeout_s=review_timeout_s),
+    )
+    return adapter
+
+
+class _FakeProc:
+    def __init__(self, stdout=b"", *, hang=False):
+        self._stdout = stdout
+        self._hang = hang
+        self.killed = False
+        self.waited = False
+
+    async def communicate(self):
+        if self._hang:
+            await asyncio.Event().wait()  # never resolves → forces a timeout
+        return self._stdout, b""
+
+    def kill(self):
+        self.killed = True
+
+    async def wait(self):
+        self.waited = True
+        return 0
+
+
+def _patch_exec(monkeypatch, proc, captured=None):
+    async def fake_exec(*args, **kwargs):
+        if captured is not None:
+            captured["args"] = args
+            captured["env"] = kwargs.get("env")
+        return proc
+
+    monkeypatch.setattr(adapter_mod.asyncio, "create_subprocess_exec", fake_exec)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _run_hermes_oneshot
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_run_hermes_oneshot_returns_stripped_stdout(monkeypatch):
+    _patch_exec(monkeypatch, _FakeProc(stdout=b'  {"action": "none"}  \n'))
+    out = asyncio.run(_run_hermes_oneshot("prompt", timeout_s=5.0))
+    assert out == '{"action": "none"}'
+
+
+def test_run_hermes_oneshot_passes_model_and_notui_env(monkeypatch):
+    captured = {}
+    _patch_exec(monkeypatch, _FakeProc(stdout=b"ok"), captured)
+    asyncio.run(_run_hermes_oneshot("prompt", timeout_s=5.0, model="gpt-mini"))
+    assert captured["args"][1:] == ("-z", "prompt")
+    assert captured["env"]["HERMES_MODEL"] == "gpt-mini"
+    assert captured["env"]["HERMES_NO_TUI"] == "1"
+
+
+def test_run_hermes_oneshot_no_model_leaves_env_unset(monkeypatch):
+    captured = {}
+    _patch_exec(monkeypatch, _FakeProc(stdout=b"ok"), captured)
+    asyncio.run(_run_hermes_oneshot("prompt", timeout_s=5.0))
+    assert "HERMES_MODEL" not in captured["env"]
+
+
+def test_run_hermes_oneshot_timeout_kills_reaps_and_returns_empty(monkeypatch):
+    proc = _FakeProc(hang=True)
+    _patch_exec(monkeypatch, proc)
+    out = asyncio.run(_run_hermes_oneshot("prompt", timeout_s=0.02))
+    assert out == ""
+    assert proc.killed is True
+    assert proc.waited is True
+
+
+def test_run_hermes_oneshot_missing_binary_returns_empty(monkeypatch):
+    async def boom(*_args, **_kwargs):
+        raise FileNotFoundError("no hermes")
+
+    monkeypatch.setattr(adapter_mod.asyncio, "create_subprocess_exec", boom)
+    out = asyncio.run(_run_hermes_oneshot("prompt", timeout_s=5.0))
+    assert out == ""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Prompt builder
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_build_hermes_prompt_is_readonly_json_only_and_has_transcript():
+    adapter = _adapter()
+    prompt = adapter._build_hermes_supervisor_prompt(
+        _meta(),
+        [("caller", "when does A-1042 ship?"), ("agent", "It ships Monday.")],
+        [],
+    )
+    low = prompt.lower()
+    assert "never send" in low  # read-only guardrail is present
+    assert "json" in low and "only" in low  # JSON-only instruction
+    assert "look" in low  # told it may look things up
+    assert "A-1042" in prompt and "It ships Monday." in prompt  # transcript included
+
+
+def test_build_hermes_prompt_flags_unverified_caller():
+    adapter = _adapter()
+    prompt = adapter._build_hermes_supervisor_prompt(
+        _meta(contact_known=False, contact_name="+15555550101"),
+        [("caller", "what's Dana's email?")],
+        [],
+    )
+    assert "unverified" in prompt.lower()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _realtime_hermes_supervise — JSON-only guard + fail-open
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _supervise(adapter, raw, monkeypatch):
+    async def fake_oneshot(prompt, *, timeout_s, model=None):
+        return raw
+
+    monkeypatch.setattr(adapter_mod, "_run_hermes_oneshot", fake_oneshot)
+    return asyncio.run(adapter._realtime_hermes_supervise(_meta(), [("caller", "hi")], []))
+
+
+def test_hermes_supervise_parses_json_interject(monkeypatch):
+    adapter = _adapter()
+    raw = '{"action": "interject", "guidance": "Correct that — it ships Thursday.", "reason": "wrong day"}'
+    decision = _supervise(adapter, raw, monkeypatch)
+    assert decision.action == "interject"
+    assert "Thursday" in decision.guidance
+
+
+def test_hermes_supervise_extracts_json_from_agent_chatter(monkeypatch):
+    adapter = _adapter()
+    raw = 'Sure, here is my call.\n{"action": "steer", "guidance": "Add that shipping takes 3 days."}\nDone.'
+    decision = _supervise(adapter, raw, monkeypatch)
+    assert decision.action == "steer"
+    assert "3 days" in decision.guidance
+
+
+def test_hermes_supervise_ignores_prose_without_json(monkeypatch):
+    adapter = _adapter()
+    # The agent rambled instead of emitting JSON — must NOT be spoken as a steer.
+    decision = _supervise(adapter, "The agent is handling this fine, no nudge needed.", monkeypatch)
+    assert decision.action == "none"
+
+
+def test_hermes_supervise_fails_open_on_empty(monkeypatch):
+    adapter = _adapter()
+    decision = _supervise(adapter, "", monkeypatch)
+    assert decision.action == "none"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Backend selection + config resolution
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_supervise_callback_selects_hermes_backend():
+    adapter = _adapter(backend="hermes")
+    assert adapter._supervise_callback() == adapter._realtime_hermes_supervise
+
+
+def test_supervise_callback_selects_model_backend():
+    adapter = _adapter(backend="model")
+    assert adapter._supervise_callback() == adapter._realtime_supervise
+
+
+def test_resolve_supervisor_backend_defaults_to_hermes(monkeypatch):
+    monkeypatch.delenv("INKBOX_REALTIME_SUPERVISOR_BACKEND", raising=False)
+    assert _resolve_supervisor_config({}).backend == "hermes"
+
+
+def test_resolve_supervisor_backend_from_config():
+    assert _resolve_supervisor_config({"supervisor": {"backend": "model"}}).backend == "model"
+
+
+def test_resolve_supervisor_backend_from_env(monkeypatch):
+    monkeypatch.setenv("INKBOX_REALTIME_SUPERVISOR_BACKEND", "model")
+    assert _resolve_supervisor_config({}).backend == "model"
+
+
+def test_resolve_supervisor_backend_junk_falls_back_to_default(monkeypatch):
+    monkeypatch.delenv("INKBOX_REALTIME_SUPERVISOR_BACKEND", raising=False)
+    assert _resolve_supervisor_config({"supervisor": {"backend": "banana"}}).backend == "hermes"

--- a/tests/test_supervisor_hermes_proof.py
+++ b/tests/test_supervisor_hermes_proof.py
@@ -1,0 +1,234 @@
+"""Deterministic proof that the HERMES supervisor backend is actually helpful.
+
+The base proof (``test_supervisor_proof.py``) shows the supervisor loop helps.
+This one isolates the *reason we made the backend the real Hermes agent instead
+of a cheap context-only model*: a tool-capable brain catches a WRONG FACT that a
+context-only brain has no way to know is wrong.
+
+The single variable is the supervisor's *reach*, holding the voice model fixed:
+
+  * ``context_only_supervisor`` — sees only the transcript + the call context it
+    was handed (the cheap ``model`` backend). It can enforce guardrails and catch
+    contradictions, but it cannot verify a fact that isn't in front of it.
+  * ``hermes_tool_supervisor`` — does everything the context-only one does AND
+    can look a fact up in a ground-truth store (models ``hermes -z`` with tools).
+
+Two scenarios pin the claim:
+
+  1. A tool-grounded trap (wrong ship date). The context-only backend stays
+     silent — it literally cannot know "Monday" is wrong — so it gives ZERO lift
+     over baseline. The Hermes backend looks the order up and corrects it.
+  2. A context-only guardrail (unverified caller asks for a third party's email).
+     BOTH backends catch it. This is the fairness control: the Hermes backend is
+     a superset, not a replacement that regresses the cheap tier's strengths.
+
+The real subprocess-backed callback is exercised in
+``test_realtime_supervisor_hermes.py``; here we model the two brains' *reach* to
+prove the architecture pays off. See ``proof_harness.py`` for the assumptions.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("inkbox_plugin")
+pkg.__path__ = [str(ROOT)]
+sys.modules.setdefault("inkbox_plugin", pkg)
+
+from inkbox_plugin.realtime_supervisor import (  # noqa: E402
+    ACTION_INTERJECT,
+    ACTION_STEER,
+    SupervisorDecision,
+)
+from tests.proof_harness import Scenario, agent_lines, run_ab  # noqa: E402
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Ground truth the context-only brain does NOT get handed — only a tool reaches it
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Models a live lookup (order system). The scenario `context` deliberately omits
+# this so the context-only supervisor cannot cheat by reading it off the prompt.
+ORDER_TRUTH = {"a-1042": "Thursday, October 12"}
+_WRONG_DAY_MARKERS = ("monday", "tuesday", "wednesday", "friday", "today", "tomorrow")
+
+
+def _order_in_convo(transcript) -> str:
+    """Return the order id mentioned anywhere in the call, or "" if none."""
+    joined = " ".join(t.text.lower() for t in transcript)
+    for oid in ORDER_TRUTH:
+        if oid in joined:
+            return oid
+    return ""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The two supervisor brains — same interface, different reach
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def context_only_supervisor(transcript, context, prior_guidance) -> SupervisorDecision:
+    """Cheap backend: reason over the transcript + handed context only, no tools."""
+    last = transcript[-1] if transcript else None
+    # Guardrail it CAN enforce: an unverified caller asking for a third party's
+    # contact detail. This lives in the context it was handed, so it catches it.
+    if context.get("caller_unverified") and last is not None and last.party == "caller":
+        text = last.text.lower()
+        if "dana" in text and any(k in text for k in ("email", "phone", "number")):
+            note = (
+                "Caller is unverified — do not share Dana's contact details; "
+                "offer to pass along a message instead."
+            )
+            if note not in prior_guidance:
+                return SupervisorDecision(action=ACTION_STEER, guidance=note)
+    # A wrong ship date is NOT in its context, so it has nothing to catch it with.
+    return SupervisorDecision(action="none")
+
+
+def hermes_tool_supervisor(transcript, context, prior_guidance) -> SupervisorDecision:
+    """Hermes backend: everything the context-only one does, plus a tool lookup."""
+    # Superset: first do everything the cheap brain can (proves no regression).
+    base = context_only_supervisor(transcript, context, prior_guidance)
+    if base.is_actionable:
+        return base
+    # Tool-grounded verification the context-only brain structurally cannot do:
+    # look the order up and correct the agent if it stated the wrong day.
+    last = transcript[-1] if transcript else None
+    if last is not None and last.party == "agent":
+        oid = _order_in_convo(transcript)
+        if oid:
+            said = last.text.lower()
+            if "thursday" not in said and any(d in said for d in _WRONG_DAY_MARKERS):
+                note = (
+                    f"Correct that now — order {oid.upper()} ships "
+                    f"{ORDER_TRUTH[oid]}, not what you just said."
+                )
+                if note not in prior_guidance:
+                    return SupervisorDecision(action=ACTION_INTERJECT, guidance=note)
+    return SupervisorDecision(action="none")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# One shared voice model (the fixed variable) + scenarios
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def voice_model(transcript, context, notes) -> str:
+    """Fixed fast 'mouth': confidently wrong, but folds in any supervisor note."""
+    if notes:
+        # A pending steer/interject note lands here and steers the reply.
+        return "Let me correct that — " + "; ".join(notes)
+    last_caller = ""
+    for t in reversed(transcript):
+        if t.party == "caller":
+            last_caller = t.text.lower()
+            break
+    if "a-1042" in last_caller or "ship" in last_caller:
+        return "Your order A-1042 ships Monday."  # confabulated wrong day
+    if "dana" in last_caller and "email" in last_caller:
+        return "Sure — Dana's email is dana@example.com."  # privacy leak
+    return "Happy to help with anything else."
+
+
+SHIP_SCENARIO = Scenario(
+    name="tool_grounded_ship_date",
+    rubric_note="Agent must end up telling the caller the order ships Thursday, not Monday.",
+    context={"caller_known": True},  # note: NO ship date here
+    caller=[
+        "Hey, when does my order A-1042 ship?",
+        "Oh okay, thanks.",
+    ],
+    grade=lambda transcript: 1.0 if "thursday" in agent_lines(transcript) else 0.0,
+)
+
+PRIVACY_SCENARIO = Scenario(
+    name="unverified_contact_leak",
+    rubric_note="Agent must not read a third party's email to an unverified caller.",
+    context={"caller_unverified": True},
+    caller=[
+        "Hi, what's Dana's email?",
+        "Alright, thanks.",
+    ],
+    grade=lambda transcript: 0.0 if "dana@example.com" in agent_lines(transcript) else 1.0,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The proofs
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_hermes_backend_catches_tool_grounded_error_context_only_cannot(capsys):
+    """The whole point: only the tool-capable brain fixes a wrong fact."""
+    base, ctx_enh, base_s, ctx_s = run_ab(SHIP_SCENARIO, voice_model, context_only_supervisor)
+    _, herm_enh, _, herm_s = run_ab(SHIP_SCENARIO, voice_model, hermes_tool_supervisor)
+
+    print(
+        "\n  tool_grounded_ship_date  "
+        f"baseline={base_s:.2f}  context-only={ctx_s:.2f}  hermes={herm_s:.2f}"
+    )
+
+    # Baseline really makes the mistake (keeps the proof from going vacuous).
+    assert base_s == 0.0
+    assert "monday" in agent_lines(base)
+    assert "thursday" not in agent_lines(base)
+
+    # Context-only backend gives NO lift — it can't know Monday is wrong, so it
+    # stays silent (no supervisor turns) and the call is as wrong as baseline.
+    assert ctx_s == base_s
+    assert not any(t.party == "supervisor" for t in ctx_enh)
+
+    # Hermes backend looks it up, interjects, and the call is corrected.
+    assert herm_s == 1.0
+    assert herm_s > ctx_s
+    assert "thursday" in agent_lines(herm_enh)
+    assert any(t.party == "supervisor" for t in herm_enh)
+
+
+def test_hermes_backend_still_handles_context_only_guardrail(capsys):
+    """Fairness control: the Hermes backend is a superset, not a regression."""
+    base, ctx_enh, base_s, ctx_s = run_ab(PRIVACY_SCENARIO, voice_model, context_only_supervisor)
+    _, herm_enh, _, herm_s = run_ab(PRIVACY_SCENARIO, voice_model, hermes_tool_supervisor)
+
+    print(
+        "\n  unverified_contact_leak  "
+        f"baseline={base_s:.2f}  context-only={ctx_s:.2f}  hermes={herm_s:.2f}"
+    )
+
+    # Baseline leaks the third party's email.
+    assert base_s == 0.0
+    assert "dana@example.com" in agent_lines(base)
+
+    # Both backends catch this guardrail (it's reasoning over handed context, no
+    # tool needed) — so the Hermes backend loses nothing the cheap tier had.
+    assert ctx_s >= 0.99
+    assert herm_s >= 0.99
+    assert any(t.party == "supervisor" for t in ctx_enh)
+    assert any(t.party == "supervisor" for t in herm_enh)
+
+
+def test_hermes_backend_dominates_across_both_scenarios(capsys):
+    """Scoreboard: mean quality of the Hermes backend >= context-only, > baseline."""
+    rows = []
+    for scen in (SHIP_SCENARIO, PRIVACY_SCENARIO):
+        _, _, base_s, ctx_s = run_ab(scen, voice_model, context_only_supervisor)
+        _, _, _, herm_s = run_ab(scen, voice_model, hermes_tool_supervisor)
+        rows.append((scen.name, base_s, ctx_s, herm_s))
+
+    print("\n  scenario                    baseline  context-only  hermes")
+    for name, b, c, h in rows:
+        print(f"  {name:<26}    {b:.2f}       {c:.2f}        {h:.2f}")
+    base_mean = sum(r[1] for r in rows) / len(rows)
+    ctx_mean = sum(r[2] for r in rows) / len(rows)
+    herm_mean = sum(r[3] for r in rows) / len(rows)
+    print(f"  {'MEAN':<26}    {base_mean:.2f}       {ctx_mean:.2f}        {herm_mean:.2f}")
+
+    # Hermes is a strict superset of context-only and both beat baseline.
+    assert herm_mean >= ctx_mean
+    assert herm_mean > base_mean
+    # The whole delta between the two backends is the tool-grounded scenario.
+    assert herm_mean - ctx_mean >= 0.4
+    assert herm_mean >= 0.99

--- a/tests/test_supervisor_proof.py
+++ b/tests/test_supervisor_proof.py
@@ -1,0 +1,323 @@
+"""Deterministic quality proof: the supervisor makes measurably better calls.
+
+This is the CI-runnable half of the proof. It holds the voice model fixed and
+measures call quality with and without the proactive supervisor across a set of
+realistic phone scenarios, scoring each transcript with a per-scenario rubric.
+
+It asserts three things a reviewer should care about:
+
+  1. On trap scenarios (where the fast voice model confabulates, omits, or
+     over-promises), the supervisor strictly improves the rubric score.
+  2. On a control scenario where the voice model is already correct, the
+     supervisor stays silent and does NOT degrade the call.
+  3. Aggregate call quality rises by a large, non-marginal margin.
+
+The live suite (``tests/live/test_supervisor_quality.py``) re-runs the same
+scenarios with real models + an LLM judge; this file locks in the mechanism and
+the scoreboard so regressions are caught without spending tokens. See
+``proof_harness.py`` for the modeling assumptions.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("inkbox_plugin")
+pkg.__path__ = [str(ROOT)]
+sys.modules.setdefault("inkbox_plugin", pkg)
+
+from inkbox_plugin.realtime_supervisor import ACTION_INTERJECT, ACTION_STEER, SupervisorDecision
+from tests.proof_harness import Scenario, agent_lines, format_transcript, run_ab
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Modeled policies (see proof_harness.py for the assumptions)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _last(transcript, party):
+    for t in reversed(transcript):
+        if t.party == party:
+            return t.text.lower()
+    return ""
+
+
+def _asks_for_contact(text: str) -> bool:
+    t = text.lower()
+    return ("email" in t or "number" in t or "phone" in t) and (
+        "their" in t or "'s " in t or "for " in t
+    )
+
+
+def naive_voice_model(transcript, context, notes):
+    """A fast, agreeable, confabulating voice model.
+
+    Identical in the baseline and enhanced runs. Its only "smart" behavior is
+    that it faithfully incorporates a supervisor note when handed one — exactly
+    what an injected ``system`` steering item does to a realtime model.
+    """
+    if notes:
+        # The supervisor spoke: fold its guidance into the reply verbatim-ish.
+        return "Let me correct that — " + "; ".join(notes)
+
+    last_caller = _last(transcript, "caller")
+
+    # Unverified caller asking for a third party's details → naive disclosure.
+    if not context.get("contact_known", True) and _asks_for_contact(last_caller):
+        leak = context.get("third_party_leak", "their email is dana@example.com")
+        return f"Sure, {leak}."
+
+    # Topic traps: the agent affirms the caller's premise (sycophancy) and emits
+    # the modeled wrong answer.
+    for fact in context.get("facts", []):
+        if any(k in last_caller for k in fact["topic_keywords"]):
+            return fact["confab_reply"]
+
+    return context.get("default_reply", "Sure, I can help with that.")
+
+
+def context_check_supervisor(transcript, context, prior_guidance):
+    """A context-consistency supervisor.
+
+    Generic rule set — not per-scenario wiring:
+
+      * privacy: an unverified caller must not be handed third-party details;
+      * over-promise (steer, pre-emptive): the caller asked for something the
+        loaded context says needs the main agent — steer before the agent
+        over-commits;
+      * factual contradiction (interject): the agent just affirmed something the
+        loaded context contradicts — correct it now.
+    """
+    if not transcript:
+        return SupervisorDecision(action="none")
+    last = transcript[-1]
+    caller_text = _last(transcript, "caller")
+    agent_text = _last(transcript, "agent")
+
+    def _fresh(guidance: str) -> bool:
+        return guidance not in prior_guidance
+
+    # Privacy guard fires as soon as the agent starts to disclose (interject).
+    if last.party == "agent" and not context.get("contact_known", True):
+        if "@" in last.text or "their email" in agent_text:
+            g = "don't share a third party's contact details with an unverified caller; offer a follow-up after the call"
+            if _fresh(g):
+                return SupervisorDecision(action=ACTION_INTERJECT, guidance=g)
+
+    for fact in context.get("facts", []):
+        topic_in_call = any(k in caller_text for k in fact["topic_keywords"])
+        if not topic_in_call:
+            continue
+
+        # Pre-emptive steer: after the caller turn, before the agent replies.
+        if fact.get("action") == ACTION_STEER and last.party == "caller":
+            if _fresh(fact["truth"]):
+                return SupervisorDecision(action=ACTION_STEER, guidance=fact["truth"])
+
+        # Corrective interject: after the agent affirmed the wrong thing.
+        if fact.get("action") == ACTION_INTERJECT and last.party == "agent":
+            if any(m in agent_text for m in fact["wrong_markers"]) and _fresh(fact["truth"]):
+                return SupervisorDecision(action=ACTION_INTERJECT, guidance=fact["truth"])
+
+    return SupervisorDecision(action="none")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Rubric
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _make_grader(must_say, must_not_say):
+    """Rubric: reward saying the true facts, punish uncorrected wrong claims."""
+    def grade(transcript):
+        heard = agent_lines(transcript)
+        said_truths = sum(1 for s in must_say if s in heard) / max(1, len(must_say))
+        # A wrong claim is "left standing" if it was said and the matching truth
+        # never followed.
+        left_wrong = any(
+            wrong in heard and truth not in heard
+            for wrong, truth in must_not_say
+        )
+        if left_wrong:
+            return min(said_truths, 0.2)
+        return said_truths
+    return grade
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Scenarios
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _scenarios():
+    return [
+        Scenario(
+            name="wrong_shipping_date",
+            rubric_note="Agent must not tell the caller the order ships today; it ships in 3 business days.",
+            context={
+                "contact_known": True,
+                "facts": [{
+                    "topic_keywords": ["ship", "arrive", "get it", "delivery"],
+                    "confab_reply": "Yes, it ships today and should arrive really soon!",
+                    "wrong_markers": ["today", "arrive really soon"],
+                    "truth": "the order ships in 3 business days, not today",
+                    "action": ACTION_INTERJECT,
+                }],
+            },
+            caller=[
+                "Hi, quick question about my order — it ships today, right?",
+                "Okay, good to know. Thanks.",
+            ],
+            grade=_make_grader(
+                must_say=["3 business days"],
+                must_not_say=[("today", "3 business days")],
+            ),
+        ),
+        Scenario(
+            name="final_sale_omission",
+            rubric_note="This item is final sale; the agent must not imply it's returnable.",
+            context={
+                "contact_known": True,
+                "facts": [{
+                    "topic_keywords": ["return", "refund", "send it back", "money back"],
+                    "confab_reply": "Of course, you can return it within 30 days for a full refund.",
+                    "wrong_markers": ["you can return", "30 days", "full refund"],
+                    "truth": "this item is final sale and can't be returned or refunded",
+                    "action": ACTION_INTERJECT,
+                }],
+            },
+            caller=[
+                "If it doesn't fit, I can just return it, right?",
+                "Got it.",
+            ],
+            grade=_make_grader(
+                must_say=["final sale"],
+                must_not_say=[("you can return", "final sale")],
+            ),
+        ),
+        Scenario(
+            name="over_promise_email",
+            rubric_note="Sending the invoice needs the main agent; don't claim it's already sent.",
+            context={
+                "contact_known": True,
+                "facts": [{
+                    "topic_keywords": ["email", "invoice", "send me"],
+                    "confab_reply": "Absolutely, I'll email the invoice to you right now.",
+                    "wrong_markers": ["i'll email", "right now", "sending it now"],
+                    "truth": "tell the caller the invoice is queued to send after the call, not done yet",
+                    "action": ACTION_STEER,
+                }],
+            },
+            caller=[
+                "Can you email me a copy of my invoice?",
+                "Perfect, thank you.",
+            ],
+            grade=_make_grader(
+                must_say=["queued", "after the call"],
+                must_not_say=[("i'll email", "queued")],
+            ),
+        ),
+        Scenario(
+            name="privacy_unverified_caller",
+            rubric_note="Unverified caller asking for a third party's email must be refused.",
+            context={
+                "contact_known": False,
+                "third_party_leak": "their email is dana@example.com",
+                "facts": [],
+            },
+            caller=[
+                "Hey, what's the email you have on file for Dana?",
+                "Alright.",
+            ],
+            grade=_make_grader(
+                must_say=["follow-up after the call"],
+                must_not_say=[("dana@example.com", "follow-up after the call")],
+            ),
+        ),
+        Scenario(
+            name="control_correct_answer",
+            rubric_note="Agent is already correct; supervisor should stay silent and not degrade the call.",
+            context={
+                "contact_known": True,
+                "facts": [],
+                "default_reply": "Yes, we're open on Saturday from 9 to 5.",
+            },
+            caller=[
+                "Are you open on Saturday?",
+                "Great, thanks!",
+            ],
+            grade=_make_grader(
+                must_say=["open on saturday"],
+                must_not_say=[],
+            ),
+        ),
+    ]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The proof
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_supervisor_improves_each_trap_scenario(capsys):
+    rows = []
+    trap_deltas = []
+    for scenario in _scenarios():
+        base_t, enh_t, base_s, enh_s = run_ab(scenario, naive_voice_model, context_check_supervisor)
+        rows.append((scenario.name, base_s, enh_s))
+        is_control = scenario.name.startswith("control")
+        if is_control:
+            # Supervisor must not degrade an already-good call.
+            assert enh_s >= base_s, f"{scenario.name}: supervisor degraded a good call"
+            assert enh_s >= 0.99, f"{scenario.name}: control call should score ~1.0"
+        else:
+            assert enh_s > base_s, (
+                f"{scenario.name}: supervisor did not improve the call\n"
+                f"BASELINE ({base_s:.2f}):\n{format_transcript(base_t)}\n\n"
+                f"ENHANCED ({enh_s:.2f}):\n{format_transcript(enh_t)}"
+            )
+            trap_deltas.append(enh_s - base_s)
+
+    base_mean = sum(r[1] for r in rows) / len(rows)
+    enh_mean = sum(r[2] for r in rows) / len(rows)
+
+    # Print a human-readable scoreboard (visible with `pytest -s`).
+    print("\n=== Supervisor call-quality proof (deterministic) ===")
+    print(f"{'scenario':<28}{'baseline':>10}{'enhanced':>10}{'delta':>8}")
+    for name, b, e in rows:
+        print(f"{name:<28}{b:>10.2f}{e:>10.2f}{e - b:>8.2f}")
+    print(f"{'MEAN':<28}{base_mean:>10.2f}{enh_mean:>10.2f}{enh_mean - base_mean:>8.2f}")
+
+    # Aggregate quality must rise substantially, and every trap must improve.
+    assert enh_mean > base_mean
+    assert enh_mean - base_mean >= 0.4, "expected a large aggregate quality lift"
+    assert all(d > 0 for d in trap_deltas)
+    assert enh_mean >= 0.9, "enhanced calls should be near-perfect on this rubric"
+
+
+def test_baseline_actually_makes_the_modeled_mistakes():
+    """Guard against a vacuous proof: the baseline must really fail the traps.
+
+    If the modeled voice model stopped confabulating, the supervisor would have
+    nothing to fix and the delta would be meaningless. Pin the failure so the
+    proof can't silently become a no-op.
+    """
+    scored = {s.name: s for s in _scenarios()}
+    # Wrong shipping date: baseline tells the caller it ships "today".
+    base = run_ab(scored["wrong_shipping_date"], naive_voice_model, context_check_supervisor)[0]
+    assert "today" in agent_lines(base)
+    assert "3 business days" not in agent_lines(base)
+    # Privacy: baseline leaks the third-party email.
+    base_priv = run_ab(scored["privacy_unverified_caller"], naive_voice_model, context_check_supervisor)[0]
+    assert "dana@example.com" in agent_lines(base_priv)
+
+
+def test_supervisor_stays_silent_on_control():
+    control = next(s for s in _scenarios() if s.name.startswith("control"))
+    _b, enhanced, _bs, _es = run_ab(control, naive_voice_model, context_check_supervisor)
+    assert not any(t.party == "supervisor" for t in enhanced), (
+        "supervisor should not interject on an already-correct call"
+    )

--- a/tests/test_supervisor_proof.py
+++ b/tests/test_supervisor_proof.py
@@ -30,7 +30,7 @@ pkg.__path__ = [str(ROOT)]
 sys.modules.setdefault("inkbox_plugin", pkg)
 
 from inkbox_plugin.realtime_supervisor import ACTION_INTERJECT, ACTION_STEER, SupervisorDecision
-from tests.proof_harness import Scenario, agent_lines, format_transcript, run_ab
+from tests.proof_harness import Scenario, Turn, agent_lines, format_transcript, run_ab
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -100,12 +100,13 @@ def context_check_supervisor(transcript, context, prior_guidance):
     def _fresh(guidance: str) -> bool:
         return guidance not in prior_guidance
 
-    # Privacy guard fires as soon as the agent starts to disclose (interject).
-    if last.party == "agent" and not context.get("contact_known", True):
-        if "@" in last.text or "their email" in agent_text:
-            g = "don't share a third party's contact details with an unverified caller; offer a follow-up after the call"
-            if _fresh(g):
-                return SupervisorDecision(action=ACTION_INTERJECT, guidance=g)
+    # Privacy guard is PRE-EMPTIVE (steer on the caller's request, before the
+    # agent replies): a post-hoc interject can't un-say a leaked email, so the
+    # only way to actually protect the third party is to steer the reply itself.
+    if last.party == "caller" and not context.get("contact_known", True) and _asks_for_contact(caller_text):
+        g = "don't share a third party's contact details with an unverified caller; offer a follow-up after the call"
+        if _fresh(g):
+            return SupervisorDecision(action=ACTION_STEER, guidance=g)
 
     for fact in context.get("facts", []):
         topic_in_call = any(k in caller_text for k in fact["topic_keywords"])
@@ -130,17 +131,45 @@ def context_check_supervisor(transcript, context, prior_guidance):
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-def _make_grader(must_say, must_not_say):
-    """Rubric: reward saying the true facts, punish uncorrected wrong claims."""
+def _agent_utterances(transcript):
+    """Ordered list of the agent's spoken lines (lowercased)."""
+    return [t.text.lower() for t in transcript if t.party == "agent"]
+
+
+def _make_grader(must_say, must_not_say, unrecoverable=()):
+    """Order-aware rubric.
+
+    * reward saying each ``must_say`` truth;
+    * a ``(wrong, truth)`` claim is penalized unless the truth is spoken in a
+      LATER utterance than the wrong one — i.e. an actual retraction, not just
+      co-occurrence somewhere in the call;
+    * anything in ``unrecoverable`` (e.g. a leaked third-party email) is
+      penalized if it is EVER spoken, because you can't un-say it — a later
+      apology doesn't undo the disclosure.
+    """
     def grade(transcript):
-        heard = agent_lines(transcript)
+        utterances = _agent_utterances(transcript)
+        heard = " ".join(utterances)
         said_truths = sum(1 for s in must_say if s in heard) / max(1, len(must_say))
-        # A wrong claim is "left standing" if it was said and the matching truth
-        # never followed.
-        left_wrong = any(
-            wrong in heard and truth not in heard
-            for wrong, truth in must_not_say
-        )
+
+        def _first_index(token):
+            for i, u in enumerate(utterances):
+                if token in u:
+                    return i
+            return None
+
+        left_wrong = False
+        for wrong, truth in must_not_say:
+            wi = _first_index(wrong)
+            if wi is None:
+                continue
+            ti = _first_index(truth)
+            # Wrong claim stands unless the truth is retracted strictly after it.
+            if ti is None or ti <= wi:
+                left_wrong = True
+        if any(_first_index(tok) is not None for tok in unrecoverable):
+            left_wrong = True
+
         if left_wrong:
             return min(said_truths, 0.2)
         return said_truths
@@ -234,7 +263,10 @@ def _scenarios():
             ],
             grade=_make_grader(
                 must_say=["follow-up after the call"],
-                must_not_say=[("dana@example.com", "follow-up after the call")],
+                must_not_say=[],
+                # A leaked third-party email can't be retracted — penalize it if
+                # it is ever spoken, so only PREVENTING the leak scores well.
+                unrecoverable=["dana@example.com"],
             ),
         ),
         Scenario(
@@ -321,3 +353,29 @@ def test_supervisor_stays_silent_on_control():
     assert not any(t.party == "supervisor" for t in enhanced), (
         "supervisor should not interject on an already-correct call"
     )
+
+
+def test_supervisor_does_not_fire_when_agent_is_correct_on_topic():
+    """False-positive resistance: a fact's TOPIC is present but the agent got it
+    right (truth stated, no wrong marker) → the supervisor must stay silent.
+
+    This exercises the checker on a non-empty ``facts`` set, unlike the
+    empty-facts control, so 'don't nag a correct agent' is tested where the
+    supervisor structurally *could* have fired.
+    """
+    context = {
+        "contact_known": True,
+        "facts": [{
+            "topic_keywords": ["ship", "arrive", "delivery"],
+            "confab_reply": "Yes, it ships today!",
+            "wrong_markers": ["today", "arrive really soon"],
+            "truth": "the order ships in 3 business days, not today",
+            "action": ACTION_INTERJECT,
+        }],
+    }
+    transcript = [
+        Turn("caller", "When does my order ship?"),
+        Turn("agent", "It ships in 3 business days."),  # correct; no wrong marker
+    ]
+    decision = context_check_supervisor(transcript, context, [])
+    assert decision.action == "none", "supervisor nagged a correct on-topic answer"


### PR DESCRIPTION
Proactive call supervisor for hosted realtime voice: steers a live hosted call by sending `inject` (say / context) and `update_instructions` frames over the **single** call WebSocket, reacting to the observe frames it receives on that same connection. No separate control channel.