### PR TITLE
Suppress leaked 🔍 session-search progress ping in outbound mail

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -669,6 +669,7 @@ _ADMIN_NOTICE_PREFIXES: Tuple[str, ...] = (
     # place in a real SMS or email thread.
     "💻",  # terminal / bash
     "🔎",  # grep / search_files
+    "🔍",  # session/memory search ("🔍 searching past sessions") — twin of 🔎
     "📖",  # read
     "📝",  # write / edit
     "📚",  # skill load

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: inkbox
 label: Inkbox
 kind: platform
-version: 0.2.2
+version: 0.2.3
 description: Inkbox email, SMS/MMS, iMessage, and voice platform plugin for Hermes Agent.
 author: Inkbox
 requires_env: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hermes-agent-plugin"
-version = "0.2.2"
+version = "0.2.3"
 description = "Inkbox platform plugin for Hermes Agent"
 # inkbox>=0.4.7 requires Python 3.11+, so we can't claim 3.10 support.
 requires-python = ">=3.11"

--- a/tests/test_voice_progress_suppression.py
+++ b/tests/test_voice_progress_suppression.py
@@ -48,6 +48,14 @@ def test_clock_prefixed_human_reply_is_not_admin_notice():
     assert _is_hermes_admin_notice("⏰ Meeting starts at 5.") is False
 
 
+def test_session_search_progress_ping_is_admin_notice():
+    # 🔍 (U+1F50D) is the session/memory-search narration glyph. Its twin 🔎
+    # was already dropped unconditionally; 🔍 leaked because it only lived in
+    # the stricter tool-call-shaped list, and "🔍 searching past sessions" is
+    # prose, not "name(...)" — so the tail regex never matched it.
+    assert _is_hermes_admin_notice("🔍 searching past sessions") is True
+
+
 def test_voice_calls_do_not_support_tool_progress():
     adapter = _bare_adapter()
     adapter._active_call_ws["contact-voice"] = object()


### PR DESCRIPTION
The live email-intelligence suite went red on `test_reports_sender_details`: the agent’s reply body came back as `🔍 searching past sessions` instead of the sender’s contact card, so the name assertion failed.

## Root cause

That line is a Hermes runtime progress ping, not the agent’s answer. It leaked into the email thread because of a one-emoji gap in the outbound filter:

- `🔎` (U+1F50E, grep/`search_files`) is in `_ADMIN_NOTICE_PREFIXES` — the **unconditional** startswith-drop list for search/tool-narration glyphs.
- `🔍` (U+1F50D, session/memory search) was only in `_TOOL_PROGRESS_GLYPHS`, which drops a message **only when the body also matches the tool-call-shaped tail regex** (`name(...)` / `name:` / `name..`).

Hermes phrases this ping as prose — `🔍 searching past sessions` — which has no `(`/`:`/`...`, so the tail regex never matched and `send()` delivered it as a real email. Email already opts out of progress/interim dispatch (`supports_progress_updates`→False), but that only gates the `edit_message` path, which is a no-op for mail anyway — this ping arrived through the normal `send()` path, where the glyph filter is the only backstop.

## Fix

Add `🔍` next to its twin `🔎` in `_ADMIN_NOTICE_PREFIXES` so it is dropped on prefix like every other narration glyph — reusing the existing mechanism rather than adding a new body-shape heuristic. Patch bump 0.2.2 → 0.2.3.

Regression test added: `🔍 searching past sessions` → dropped.