### PR TITLE
Clarify first-run Inkbox setup failures

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -134,6 +134,7 @@ from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageTyp
 from gateway.platforms.helpers import redact_phone
 try:
     from .config import INKBOX_BASE_URL_DEFAULT, inkbox_client_kwargs
+    from .diagnostics import inkbox_api_error_message, missing_config_message, is_inkbox_auth_error, is_inkbox_identity_error
     from .webhook_providers import match_provider
     from .realtime import (
         DEFAULT_MODEL as REALTIME_DEFAULT_MODEL,
@@ -147,6 +148,7 @@ try:
     )
 except ImportError:  # pragma: no cover - direct local import/test fallback
     from config import INKBOX_BASE_URL_DEFAULT, inkbox_client_kwargs
+    from diagnostics import inkbox_api_error_message, missing_config_message, is_inkbox_auth_error, is_inkbox_identity_error
     from webhook_providers import match_provider
     from realtime import (
         DEFAULT_MODEL as REALTIME_DEFAULT_MODEL,
@@ -1433,17 +1435,17 @@ class InkboxAdapter(BasePlatformAdapter):
             )
             return False
         if not self._api_key:
-            logger.warning("[Inkbox] INKBOX_API_KEY not set")
+            logger.warning("[Inkbox] %s", missing_config_message("INKBOX_API_KEY"))
             return False
         if not self._identity_handle:
-            logger.warning("[Inkbox] INKBOX_IDENTITY not set")
+            logger.warning("[Inkbox] %s", missing_config_message("INKBOX_IDENTITY"))
             return False
         if self._require_signature and not self._signing_key:
             logger.warning(
                 "[Inkbox] INKBOX_SIGNING_KEY not set and "
                 "INKBOX_REQUIRE_SIGNATURE is enabled; refusing to start. "
-                "Generate a signing key in https://inkbox.ai/console/signing-keys "
-                "or set INKBOX_REQUIRE_SIGNATURE=false for local-only testing.",
+                "Generate one with `hermes inkbox setup` or set "
+                "INKBOX_REQUIRE_SIGNATURE=false for local-only testing.",
             )
             return False
 
@@ -1513,8 +1515,12 @@ class InkboxAdapter(BasePlatformAdapter):
         # PATCH the identity's mailboxes + phone numbers to point at this server.
         try:
             await asyncio.to_thread(self._patch_identity_objects)
-        except Exception:
-            logger.exception("[Inkbox] Failed to register webhook receivers")
+        except Exception as exc:
+            if is_inkbox_auth_error(exc) or is_inkbox_identity_error(exc):
+                logger.error("[Inkbox] %s", inkbox_api_error_message(exc, "registering webhook receivers"))
+                logger.debug("[Inkbox] Failed to register webhook receivers", exc_info=True)
+            else:
+                logger.exception("[Inkbox] Failed to register webhook receivers")
             await self._cleanup()
             self._release_platform_lock()
             return False
@@ -1650,8 +1656,12 @@ class InkboxAdapter(BasePlatformAdapter):
             )
             self._tunnel = None
             return False
-        except Exception:
-            logger.exception("[Inkbox] Failed to open SDK tunnel")
+        except Exception as exc:
+            if is_inkbox_auth_error(exc) or is_inkbox_identity_error(exc):
+                logger.error("[Inkbox] %s", inkbox_api_error_message(exc, "opening the SDK tunnel"))
+                logger.debug("[Inkbox] Failed to open SDK tunnel", exc_info=True)
+            else:
+                logger.exception("[Inkbox] Failed to open SDK tunnel")
             self._tunnel = None
             return False
 

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -1,0 +1,57 @@
+"""Shared setup and runtime diagnostics for the Inkbox Hermes plugin."""
+
+from __future__ import annotations
+
+from typing import Any
+
+SETUP_COMMAND = "hermes inkbox setup"
+SETUP_HINT = (
+    "Run `hermes inkbox setup` to create or connect an Inkbox identity and "
+    "write INKBOX_API_KEY, INKBOX_IDENTITY, and INKBOX_SIGNING_KEY."
+)
+
+
+def missing_config_message(name: str) -> str:
+    return f"{name} is not set. {SETUP_HINT}"
+
+
+def _status_code(exc: BaseException) -> int | None:
+    for attr in ("status_code", "status", "code"):
+        value: Any = getattr(exc, attr, None)
+        if value is None:
+            continue
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def is_inkbox_auth_error(exc: BaseException) -> bool:
+    status = _status_code(exc)
+    if status in {401, 403}:
+        return True
+    message = str(exc).lower()
+    return "401" in message or "403" in message or "unauthorized" in message or "forbidden" in message
+
+
+def is_inkbox_identity_error(exc: BaseException) -> bool:
+    status = _status_code(exc)
+    if status == 404:
+        return True
+    message = str(exc).lower()
+    return "404" in message or "not found" in message
+
+
+def inkbox_api_error_message(exc: BaseException, action: str) -> str:
+    if is_inkbox_auth_error(exc):
+        return (
+            f"Inkbox authentication failed while {action}: {exc}. "
+            "Re-run `hermes inkbox setup` or set a valid INKBOX_API_KEY/INKBOX_IDENTITY pair."
+        )
+    if is_inkbox_identity_error(exc):
+        return (
+            f"Inkbox identity lookup failed while {action}: {exc}. "
+            "Re-run `hermes inkbox setup` or check that INKBOX_IDENTITY belongs to the configured API key."
+        )
+    return f"{exc}. {SETUP_HINT}"

--- a/doctor.py
+++ b/doctor.py
@@ -7,8 +7,10 @@ from typing import Any, Dict, List
 
 try:
     from .config import inkbox_client_kwargs, object_summary, read_config
+    from .diagnostics import inkbox_api_error_message, missing_config_message
 except ImportError:  # pragma: no cover - direct local import/test fallback
     from config import inkbox_client_kwargs, object_summary, read_config
+    from diagnostics import inkbox_api_error_message, missing_config_message
 
 
 def run_doctor() -> Dict[str, Any]:
@@ -19,13 +21,13 @@ def run_doctor() -> Dict[str, Any]:
         findings.append({
             "id": "inkbox/config-missing-api-key",
             "severity": "error",
-            "message": "INKBOX_API_KEY is not set.",
+            "message": missing_config_message("INKBOX_API_KEY"),
         })
     if not cfg.identity:
         findings.append({
             "id": "inkbox/config-missing-identity",
             "severity": "error",
-            "message": "INKBOX_IDENTITY is not set.",
+            "message": missing_config_message("INKBOX_IDENTITY"),
         })
     if not cfg.signing_key:
         findings.append({
@@ -66,7 +68,7 @@ def run_doctor() -> Dict[str, Any]:
             findings.append({
                 "id": "inkbox/api-check-failed",
                 "severity": "error",
-                "message": str(exc),
+                "message": inkbox_api_error_message(exc, "checking the Inkbox API"),
             })
 
     summary["ok"] = not any(f["severity"] == "error" for f in findings)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,82 @@
+import sys
+import types
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("inkbox_plugin")
+pkg.__path__ = [str(ROOT)]
+sys.modules.setdefault("inkbox_plugin", pkg)
+
+from inkbox_plugin import doctor
+from inkbox_plugin.diagnostics import inkbox_api_error_message, is_inkbox_auth_error, missing_config_message
+
+
+def _clear_inkbox_env(monkeypatch):
+    for name in (
+        "INKBOX_API_KEY",
+        "INKBOX_IDENTITY",
+        "INKBOX_SIGNING_KEY",
+        "INKBOX_BASE_URL",
+        "INKBOX_PUBLIC_URL",
+        "INKBOX_REALTIME_API_KEY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_missing_config_messages_point_to_setup():
+    message = missing_config_message("INKBOX_API_KEY")
+
+    assert "INKBOX_API_KEY is not set" in message
+    assert "hermes inkbox setup" in message
+
+
+def test_auth_error_message_classifies_unauthorized_setup_failure():
+    exc = RuntimeError("HTTP 401: Unauthorized")
+
+    assert is_inkbox_auth_error(exc)
+    message = inkbox_api_error_message(exc, "opening the SDK tunnel")
+    assert "authentication failed" in message
+    assert "valid INKBOX_API_KEY/INKBOX_IDENTITY pair" in message
+    assert "hermes inkbox setup" in message
+
+
+def test_identity_error_message_points_to_identity_key_pairing():
+    exc = RuntimeError("HTTP 404: identity not found")
+
+    message = inkbox_api_error_message(exc, "checking the Inkbox API")
+    assert "identity lookup failed" in message
+    assert "INKBOX_IDENTITY belongs to the configured API key" in message
+    assert "hermes inkbox setup" in message
+
+
+def test_doctor_missing_config_findings_include_setup_hint(monkeypatch):
+    _clear_inkbox_env(monkeypatch)
+
+    summary = doctor.run_doctor()
+
+    messages = {finding["id"]: finding["message"] for finding in summary["findings"]}
+    assert "hermes inkbox setup" in messages["inkbox/config-missing-api-key"]
+    assert "hermes inkbox setup" in messages["inkbox/config-missing-identity"]
+
+
+def test_doctor_api_check_failure_is_actionable(monkeypatch):
+    _clear_inkbox_env(monkeypatch)
+    monkeypatch.setenv("INKBOX_API_KEY", "ApiKey_fake")
+    monkeypatch.setenv("INKBOX_IDENTITY", "fake-agent")
+
+    class FakeInkbox:
+        def __init__(self, **_kwargs):
+            pass
+
+        def whoami(self):
+            raise RuntimeError("HTTP 401: Unauthorized")
+
+    monkeypatch.setitem(sys.modules, "inkbox", types.SimpleNamespace(Inkbox=FakeInkbox))
+
+    summary = doctor.run_doctor()
+
+    api_finding = next(finding for finding in summary["findings"] if finding["id"] == "inkbox/api-check-failed")
+    assert "authentication failed" in api_finding["message"]
+    assert "valid INKBOX_API_KEY/INKBOX_IDENTITY pair" in api_finding["message"]
+    assert "hermes inkbox setup" in api_finding["message"]


### PR DESCRIPTION
## Summary
- Add shared setup/auth diagnostic helpers for Inkbox first-run failures.
- Make `hermes inkbox doctor` point missing config and API auth failures back to `hermes inkbox setup`.
- Make gateway startup log actionable messages for missing config, invalid credentials, and identity pairing failures while keeping traces at debug level.

Fixes #42

## How this was found
While testing the plugin from actual Hermes usage, I installed Hermes fresh, symlinked/enabled this plugin, and installed the plugin dependencies into the Hermes venv. That path registered the plugin correctly, but the first-run failure modes were hard to act on:

- With no Inkbox config, `hermes inkbox doctor` only reported missing env vars without pointing users to the setup command.
- With fake credentials, `hermes gateway run` reached Inkbox tunnel bootstrap and failed with `HTTP 401: Unauthorized`; the useful recovery step was not surfaced in the gateway log line.
- Hermes then continued with no connected platforms, which is expected host behavior, but the plugin-owned diagnostic message needed to say whether this was setup/auth/identity pairing rather than a generic tunnel failure.

## Validation
- `uv run ruff check .`
- `uv run pytest -q`
- `hermes inkbox doctor` with missing Inkbox env
- `hermes inkbox doctor` with fake credentials
- `hermes gateway run` with fake credentials

## Notes
- Not tested with valid live Inkbox credentials or successful tunnel provisioning.
