### PR TITLE
realtime: log stop reason + caller media frame count at call teardown

### DIFF
--- a/realtime.py
+++ b/realtime.py
@@ -471,6 +471,9 @@ class _BridgeState:
     # Inkbox-assigned stream id from the `start` event; echoed on outbound
     # media / audio_done frames.
     stream_id: Optional[str] = None
+    # Caller media frames received from Inkbox. Zero at teardown means caller
+    # audio never reached the bridge — a server-side media-path failure.
+    caller_media_frames: int = 0
     # Monotonic timestamp of the first hang_up_call ("armed"). A second call
     # within HANGUP_CONFIRM_WINDOW_S fires the real hangup. None = not yet armed.
     hangup_armed_at: Optional[float] = None
@@ -1006,15 +1009,44 @@ async def _inkbox_to_openai_pump(
                     await _maybe_send_greeting(openai_ws, state, meta)
                 payload_b64 = (frame.get("media") or {}).get("payload")
                 if payload_b64:
+                    state.caller_media_frames += 1
                     await openai_ws.send_str(json.dumps({
                         "type": "input_audio_buffer.append",
                         "audio": payload_b64,
                     }))
             elif event in {"stop", "closed", "hangup"}:
-                logger.info("[Inkbox realtime] Inkbox WS signaled %s", event)
+                logger.info(
+                    "[Inkbox realtime] Inkbox WS signaled %s (reason=%s) after %d caller media frame(s)",
+                    event,
+                    frame.get("reason") or "unspecified",
+                    state.caller_media_frames,
+                )
+                _warn_if_no_caller_media(state, meta)
                 return
         elif msg.type in {aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR}:
+            logger.info(
+                "[Inkbox realtime] Inkbox WS transport closed (%s) after %d caller media frame(s)",
+                msg.type.name,
+                state.caller_media_frames,
+            )
+            _warn_if_no_caller_media(state, meta)
             return
+
+
+def _warn_if_no_caller_media(state: _BridgeState, meta: RealtimeCallMeta) -> None:
+    """Flag calls that ended before any caller audio reached the bridge.
+
+    The greeting can play to the callee over the outbound leg even when the
+    server never streams caller media back, so from the transcript alone this
+    failure looks like the caller "said nothing". Make it unambiguous.
+    """
+    if state.caller_media_frames or not state.greeting_triggered:
+        return
+    logger.warning(
+        "[Inkbox realtime] call_id=%s ended without any caller media frames "
+        "reaching the bridge — caller audio was never streamed to the client WS",
+        meta.call_id,
+    )
 
 
 async def _openai_to_inkbox_pump(

--- a/tests/test_realtime_bridge_parity.py
+++ b/tests/test_realtime_bridge_parity.py
@@ -770,3 +770,52 @@ def test_adapter_realtime_post_call_actions_enqueues_without_auto_skill():
     assert events[0].raw_message["event"] == "realtime_post_call_actions"
     assert events[0].raw_message["consult_results"][0]["result"] == "Email sent to Dima."
     assert getattr(events[0], "auto_skill", None) is None
+
+
+def test_inkbox_stop_frame_logs_reason_and_caller_media_count(caplog):
+    import logging
+
+    from inkbox_plugin.realtime import _inkbox_to_openai_pump
+
+    state = _BridgeState()
+    openai_ws = _FakeWS()
+    inkbox_ws = _FakeOpenAIWS([
+        {"event": "start", "stream_id": "stream-1"},
+        {"event": "media", "media": {"payload": "AAAA"}},
+        {"event": "media", "media": {"payload": "BBBB"}},
+        {"event": "stop", "reason": "carrier_hangup"},
+    ])
+
+    with caplog.at_level(logging.INFO):
+        asyncio.run(_inkbox_to_openai_pump(inkbox_ws, openai_ws, state, _meta()))
+
+    assert state.caller_media_frames == 2
+    messages = " | ".join(record.getMessage() for record in caplog.records)
+    assert "signaled stop (reason=carrier_hangup) after 2 caller media frame(s)" in messages
+    # Caller audio arrived, so the zero-media warning must not fire.
+    assert "without any caller media frames" not in messages
+
+
+def test_stop_with_no_caller_media_after_greeting_warns(caplog):
+    import logging
+
+    from inkbox_plugin.realtime import _inkbox_to_openai_pump
+
+    state = _BridgeState()
+    openai_ws = _FakeWS()
+    # Greeting fires on `start`, then the server stops the stream without ever
+    # sending a single caller media frame — the failure mode of inkbox-ai/
+    # hermes-agent-plugin#44.
+    inkbox_ws = _FakeOpenAIWS([
+        {"event": "start", "stream_id": "stream-1"},
+        {"event": "stop"},
+    ])
+
+    with caplog.at_level(logging.INFO):
+        asyncio.run(_inkbox_to_openai_pump(inkbox_ws, openai_ws, state, _meta()))
+
+    assert state.caller_media_frames == 0
+    messages = " | ".join(record.getMessage() for record in caplog.records)
+    assert "signaled stop (reason=unspecified) after 0 caller media frame(s)" in messages
+    warning = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert any("without any caller media frames" in r.getMessage() for r in warning)


### PR DESCRIPTION
## What

Diagnostics for #44. The bridge previously logged only `Inkbox WS signaled stop`, discarding the stop frame's `reason` and keeping no record of whether any caller audio ever arrived.

## Why

In #44, realtime outbound calls die seconds after the greeting. The post-call transcript makes that failure look like the caller simply said nothing — the greeting plays over the outbound leg even when the server never streams caller media back, so the two cases are indistinguishable from the logs today.

## Changes

- `_BridgeState.caller_media_frames` counts caller media frames received from Inkbox.
- The `stop`/`closed`/`hangup` handler logs the frame's `reason` (`unspecified` when absent) and the media frame count; the transport-close path logs the same count.
- When a greeted call tears down with **zero** caller media frames, a WARNING states explicitly that caller audio never reached the client WS.

With this in place, the failing calls in #44 would log `signaled stop (reason=...) after 0 caller media frame(s)` plus the warning — one log line to distinguish a server-side media-path failure from a silent caller, and the `reason` gives the server team something to correlate.

## Testing

- Two new unit tests in `tests/test_realtime_bridge_parity.py` (stop with media frames logs reason+count and does not warn; greeted stop with zero frames warns).
- Full suite: 191 passed. `ruff check` clean.
