### PR TITLE
realtime: call-teardown diagnostics + auto-confirm armed hangup after goodbye

### DIFF
--- a/realtime.py
+++ b/realtime.py
@@ -1430,6 +1430,10 @@ async def _dispatch_tool_call(
         # have the model say goodbye instead of dropping the line mid-farewell.
         if armed is None or (now - armed) > HANGUP_CONFIRM_WINDOW_S:
             state.hangup_armed_at = now
+            logger.info(
+                "[Inkbox realtime] hang_up_call armed for call_id=%s — awaiting goodbye + confirm call",
+                meta.call_id,
+            )
             # Default create_response=True so the model speaks the goodbye.
             await _submit_tool_result(openai_ws, call_id, {
                 "status": "confirm_goodbye",
@@ -1443,6 +1447,11 @@ async def _dispatch_tool_call(
 
         # Second attempt within the window → perform the real hangup.
         reason = (args.get("reason") or "").strip()
+        logger.info(
+            "[Inkbox realtime] hang_up_call confirmed for call_id=%s (reason=%s) — sending stop frame",
+            meta.call_id,
+            reason or "unspecified",
+        )
         # Inkbox ends the call on a `stop` event; `hangup` is ignored server-side.
         stop_frame: Dict[str, Any] = {"event": "stop"}
         if reason:

--- a/realtime.py
+++ b/realtime.py
@@ -103,6 +103,12 @@ HANGUP_CONFIRM_WINDOW_S = 60.0
 # audio time to play out instead of being clipped by immediate teardown.
 HANGUP_CLOSE_DELAY_S = 2.0
 
+# When a hangup is armed and the goodbye response finishes playing, the model
+# has no further turn to issue the confirming hang_up_call — realtime models
+# idle until the caller speaks, leaving the line open. Auto-confirm after this
+# grace window unless the caller barges in (which disarms the hangup).
+HANGUP_AUTO_CONFIRM_DELAY_S = 2.5
+
 # OpenAI Realtime must be reachable before the Inkbox websocket is accepted in
 # raw-media mode. If this preflight fails, the adapter can still accept the
 # same phone call with Inkbox STT/TTS enabled.
@@ -477,6 +483,9 @@ class _BridgeState:
     # Monotonic timestamp of the first hang_up_call ("armed"). A second call
     # within HANGUP_CONFIRM_WINDOW_S fires the real hangup. None = not yet armed.
     hangup_armed_at: Optional[float] = None
+    # Auto-confirm task spawned when the goodbye response finishes while a
+    # hangup is armed; kept here so it isn't garbage-collected mid-sleep.
+    hangup_auto_task: Optional["asyncio.Task[None]"] = None
     # In-flight consult_agent dispatches. The consult tool runs the full
     # main agent loop (seconds), so it is dispatched as a background task to keep
     # the OpenAI→Inkbox audio pump flowing; we track the tasks here so they can
@@ -1049,6 +1058,55 @@ def _warn_if_no_caller_media(state: _BridgeState, meta: RealtimeCallMeta) -> Non
     )
 
 
+def _cancel_hangup_auto_confirm(state: _BridgeState) -> None:
+    if state.hangup_auto_task is not None and not state.hangup_auto_task.done():
+        state.hangup_auto_task.cancel()
+    state.hangup_auto_task = None
+
+
+async def _send_stop_and_close(
+    state: _BridgeState,
+    inkbox_ws: Any,
+    openai_ws: Any,
+    stop_frame: Dict[str, Any],
+    *,
+    delay: float,
+) -> None:
+    try:
+        if delay > 0:
+            await asyncio.sleep(delay)
+        await inkbox_ws.send_str(json.dumps(stop_frame))
+    except Exception as exc:
+        logger.debug("[Inkbox realtime] hangup frame send failed: %s", exc)
+    state.closed = True
+    await _maybe_close_ws(inkbox_ws)
+    await _maybe_close_ws(openai_ws)
+
+
+async def _auto_confirm_hangup(
+    state: _BridgeState, inkbox_ws: Any, openai_ws: Any, meta: RealtimeCallMeta,
+) -> None:
+    """Confirm an armed hangup once the goodbye has played out.
+
+    After the arm step the model speaks its goodbye and then has no turn in
+    which to issue the confirming hang_up_call — realtime models idle until
+    the caller speaks next, leaving the line open indefinitely. Once the
+    goodbye response finishes playing, wait a short grace window (a caller
+    barge-in disarms via the speech_started handler) and end the call.
+    """
+    await asyncio.sleep(HANGUP_AUTO_CONFIRM_DELAY_S)
+    if state.closed or state.hangup_armed_at is None:
+        return
+    logger.info(
+        "[Inkbox realtime] auto-confirming armed hangup for call_id=%s — goodbye played, no caller barge-in",
+        meta.call_id,
+    )
+    stop_frame: Dict[str, Any] = {"event": "stop", "reason": "goodbye complete"}
+    if state.stream_id:
+        stop_frame["stream_id"] = state.stream_id
+    await _send_stop_and_close(state, inkbox_ws, openai_ws, stop_frame, delay=0)
+
+
 async def _openai_to_inkbox_pump(
     *,
     openai_ws: Any,
@@ -1138,6 +1196,9 @@ async def _openai_to_inkbox_pump(
             # protocol.
             delta_b64 = frame.get("delta") or ""
             if delta_b64:
+                # Goodbye audio is still streaming — hold any pending
+                # auto-confirm so the farewell isn't clipped mid-word.
+                _cancel_hangup_auto_confirm(state)
                 out = {
                     "event": "media",
                     "media": {"payload": delta_b64, "track": "outbound"},
@@ -1159,9 +1220,25 @@ async def _openai_to_inkbox_pump(
                 await inkbox_ws.send_str(json.dumps(done))
             except Exception:
                 pass
+            # A hangup is armed and the (goodbye) response just finished
+            # playing. The model has no further turn in which to issue the
+            # confirming hang_up_call, so confirm it ourselves after a grace
+            # window; a caller barge-in disarms it.
+            if state.hangup_armed_at is not None:
+                _cancel_hangup_auto_confirm(state)
+                state.hangup_auto_task = asyncio.create_task(
+                    _auto_confirm_hangup(state, inkbox_ws, openai_ws, meta),
+                )
 
         # Caller started speaking (barge-in) — drop any queued outbound audio.
         elif ftype == "input_audio_buffer.speech_started":
+            if state.hangup_armed_at is not None:
+                state.hangup_armed_at = None
+                _cancel_hangup_auto_confirm(state)
+                logger.info(
+                    "[Inkbox realtime] hangup disarmed for call_id=%s — caller spoke during the goodbye window",
+                    meta.call_id,
+                )
             try:
                 await inkbox_ws.send_str(json.dumps({"event": "clear"}))
             except Exception:
@@ -1469,14 +1546,9 @@ async def _dispatch_tool_call(
             },
             create_response=False,
         )
-        try:
-            await asyncio.sleep(HANGUP_CLOSE_DELAY_S)
-            await inkbox_ws.send_str(json.dumps(stop_frame))
-        except Exception as exc:
-            logger.debug("[Inkbox realtime] hangup frame send failed: %s", exc)
-        state.closed = True
-        await _maybe_close_ws(inkbox_ws)
-        await _maybe_close_ws(openai_ws)
+        await _send_stop_and_close(
+            state, inkbox_ws, openai_ws, stop_frame, delay=HANGUP_CLOSE_DELAY_S,
+        )
         return
 
     if name == AGENT_CONSULT_TOOL_NAME:

--- a/realtime.py
+++ b/realtime.py
@@ -471,6 +471,9 @@ class _BridgeState:
     # Inkbox-assigned stream id from the `start` event; echoed on outbound
     # media / audio_done frames.
     stream_id: Optional[str] = None
+    # Caller media frames received from Inkbox. Zero at teardown means caller
+    # audio never reached the bridge — a server-side media-path failure.
+    caller_media_frames: int = 0
     # Monotonic timestamp of the first hang_up_call ("armed"). A second call
     # within HANGUP_CONFIRM_WINDOW_S fires the real hangup. None = not yet armed.
     hangup_armed_at: Optional[float] = None
@@ -1006,15 +1009,44 @@ async def _inkbox_to_openai_pump(
                     await _maybe_send_greeting(openai_ws, state, meta)
                 payload_b64 = (frame.get("media") or {}).get("payload")
                 if payload_b64:
+                    state.caller_media_frames += 1
                     await openai_ws.send_str(json.dumps({
                         "type": "input_audio_buffer.append",
                         "audio": payload_b64,
                     }))
             elif event in {"stop", "closed", "hangup"}:
-                logger.info("[Inkbox realtime] Inkbox WS signaled %s", event)
+                logger.info(
+                    "[Inkbox realtime] Inkbox WS signaled %s (reason=%s) after %d caller media frame(s)",
+                    event,
+                    frame.get("reason") or "unspecified",
+                    state.caller_media_frames,
+                )
+                _warn_if_no_caller_media(state, meta)
                 return
         elif msg.type in {aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR}:
+            logger.info(
+                "[Inkbox realtime] Inkbox WS transport closed (%s) after %d caller media frame(s)",
+                msg.type.name,
+                state.caller_media_frames,
+            )
+            _warn_if_no_caller_media(state, meta)
             return
+
+
+def _warn_if_no_caller_media(state: _BridgeState, meta: RealtimeCallMeta) -> None:
+    """Flag calls that ended before any caller audio reached the bridge.
+
+    The greeting can play to the callee over the outbound leg even when the
+    server never streams caller media back, so from the transcript alone this
+    failure looks like the caller "said nothing". Make it unambiguous.
+    """
+    if state.caller_media_frames or not state.greeting_triggered:
+        return
+    logger.warning(
+        "[Inkbox realtime] call_id=%s ended without any caller media frames "
+        "reaching the bridge — caller audio was never streamed to the client WS",
+        meta.call_id,
+    )
 
 
 async def _openai_to_inkbox_pump(

--- a/realtime.py
+++ b/realtime.py
@@ -30,8 +30,9 @@ The bridge:
      turn so the main agent can execute them (send email, create note, etc.).
    - ``edit_post_call_action`` / ``delete_post_call_action`` — modify queued
      after-call work while the call is still live.
-   - ``hang_up_call`` — a two-step hangup that lets the model say goodbye
-     before closing the phone leg.
+   - ``hang_up_call`` — arms a hangup so the model can say goodbye; the call
+     ends automatically once the goodbye plays out (a second call also
+     confirms immediately).
 
 The shape mirrors Inkbox's channel-plugin ``RealtimeCallWebSocket``.
 """
@@ -93,9 +94,10 @@ CONTACT_READ_NOTES_MAX_CHARS = 200
 # runs; longer values risk dead air, shorter values cut off legitimate work.
 DEFAULT_CONSULT_TIMEOUT_S = 300.0
 
-# A hang_up_call is a two-step confirm: the first call arms the hangup and asks
-# the model to say goodbye; a second call within this window actually ends the
-# call. Past the window, a lone call re-arms (treated as a fresh first attempt).
+# hang_up_call arms the hangup and asks the model to say goodbye; the armed
+# hangup then auto-confirms once the goodbye plays out. A second tool call
+# within this window also confirms immediately. Past the window, a lone call
+# re-arms (treated as a fresh first attempt).
 HANGUP_CONFIRM_WINDOW_S = 60.0
 
 # After the confirmed hang_up_call, keep the phone leg open briefly before
@@ -314,11 +316,11 @@ def _hang_up_call_tool_schema() -> Dict[str, Any]:
         "type": "function",
         "name": HANG_UP_CALL_TOOL_NAME,
         "description": (
-            "End the live phone call. This is a TWO-STEP tool: the first call "
-            "does NOT hang up — it prompts you to say a short goodbye. After "
-            "you have said goodbye, call hang_up_call a second time to actually "
-            "end the call. Use it only when the caller asks to hang up, says "
-            "goodbye, or the conversation is clearly complete."
+            "End the live phone call. Calling this arms the hangup and prompts "
+            "you to say a short goodbye; once your goodbye finishes playing, "
+            "the call ends automatically — you do not need to call this tool "
+            "again. Use it only when the caller asks to hang up, says goodbye, "
+            "or the conversation is clearly complete."
         ),
         "parameters": {
             "type": "object",
@@ -477,8 +479,8 @@ class _BridgeState:
     # Inkbox-assigned stream id from the `start` event; echoed on outbound
     # media / audio_done frames.
     stream_id: Optional[str] = None
-    # Caller media frames received from Inkbox. Zero at teardown means caller
-    # audio never reached the bridge — a server-side media-path failure.
+    # Caller media frames received from Inkbox. Zero at teardown means no
+    # caller audio ever reached the bridge.
     caller_media_frames: int = 0
     # Monotonic timestamp of the first hang_up_call ("armed"). A second call
     # within HANGUP_CONFIRM_WINDOW_S fires the real hangup. None = not yet armed.
@@ -592,9 +594,9 @@ def build_realtime_instructions(
         f"previously registered after-call action, call {DELETE_POST_CALL_ACTION_TOOL_NAME} "
         f"for that action so it is not executed twice after hangup.",
         f"If the caller asks to hang up, says goodbye, or the conversation is "
-        f"clearly complete, call {HANG_UP_CALL_TOOL_NAME}. The first call arms "
-        f"hangup and asks you to say goodbye; after the goodbye, call it once "
-        f"more to end the phone call.",
+        f"clearly complete, call {HANG_UP_CALL_TOOL_NAME} and then say a brief "
+        f"goodbye. The call ends automatically once your goodbye finishes "
+        f"playing; you do not need to call the tool again.",
         f"Do not call {AGENT_CONSULT_TOOL_NAME} for greetings, caller identity at "
         f"call start, or generic chat.",
     ])
@@ -1045,15 +1047,15 @@ async def _inkbox_to_openai_pump(
 def _warn_if_no_caller_media(state: _BridgeState, meta: RealtimeCallMeta) -> None:
     """Flag calls that ended before any caller audio reached the bridge.
 
-    The greeting can play to the callee over the outbound leg even when the
-    server never streams caller media back, so from the transcript alone this
-    failure looks like the caller "said nothing". Make it unambiguous.
+    The greeting can play to the callee over the outbound leg even when no
+    caller media arrives, so from the transcript alone this failure looks
+    like the caller "said nothing". Make it unambiguous.
     """
     if state.caller_media_frames or not state.greeting_triggered:
         return
     logger.warning(
-        "[Inkbox realtime] call_id=%s ended without any caller media frames "
-        "reaching the bridge — caller audio was never streamed to the client WS",
+        "[Inkbox realtime] call_id=%s ended with zero caller media frames "
+        "received on the client WS",
         meta.call_id,
     )
 
@@ -1516,13 +1518,16 @@ async def _dispatch_tool_call(
                 "status": "confirm_goodbye",
                 "message": (
                     "Don't hang up yet. Say a brief, natural goodbye to the "
-                    "caller now, then call hang_up_call once more to actually "
-                    "end the call."
+                    "caller now; the call will end automatically once your "
+                    "goodbye finishes playing."
                 ),
             })
             return
 
-        # Second attempt within the window → perform the real hangup.
+        # Second attempt within the window → perform the real hangup. Cancel
+        # any pending auto-confirm so the manual path racing it can't send a
+        # second stop frame.
+        _cancel_hangup_auto_confirm(state)
         reason = (args.get("reason") or "").strip()
         logger.info(
             "[Inkbox realtime] hang_up_call confirmed for call_id=%s (reason=%s) — sending stop frame",

--- a/tests/test_realtime_bridge_parity.py
+++ b/tests/test_realtime_bridge_parity.py
@@ -770,3 +770,52 @@ def test_adapter_realtime_post_call_actions_enqueues_without_auto_skill():
     assert events[0].raw_message["event"] == "realtime_post_call_actions"
     assert events[0].raw_message["consult_results"][0]["result"] == "Email sent to Dima."
     assert getattr(events[0], "auto_skill", None) is None
+
+
+def test_inkbox_stop_frame_logs_reason_and_caller_media_count(caplog):
+    import logging
+
+    from inkbox_plugin.realtime import _inkbox_to_openai_pump
+
+    state = _BridgeState()
+    openai_ws = _FakeWS()
+    inkbox_ws = _FakeOpenAIWS([
+        {"event": "start", "stream_id": "stream-1"},
+        {"event": "media", "media": {"payload": "AAAA"}},
+        {"event": "media", "media": {"payload": "BBBB"}},
+        {"event": "stop", "reason": "carrier_hangup"},
+    ])
+
+    with caplog.at_level(logging.INFO):
+        asyncio.run(_inkbox_to_openai_pump(inkbox_ws, openai_ws, state, _meta()))
+
+    assert state.caller_media_frames == 2
+    messages = " | ".join(record.getMessage() for record in caplog.records)
+    assert "signaled stop (reason=carrier_hangup) after 2 caller media frame(s)" in messages
+    # Caller audio arrived, so the zero-media warning must not fire.
+    assert "without any caller media frames" not in messages
+
+
+def test_stop_with_no_caller_media_after_greeting_warns(caplog):
+    import logging
+
+    from inkbox_plugin.realtime import _inkbox_to_openai_pump
+
+    state = _BridgeState()
+    openai_ws = _FakeWS()
+    # Greeting fires on `start`, then the server stops the stream without ever
+    # sending a single caller media frame — the failure mode of inkbox-ai/
+    # hermes-agent-plugin#44.
+    inkbox_ws = _FakeOpenAIWS([
+        {"event": "start", "stream_id": "stream-1"},
+        {"event": "stop"},
+    ])
+
+    with caplog.at_level(logging.INFO):
+        asyncio.run(_inkbox_to_openai_pump(inkbox_ws, openai_ws, state, _meta()))
+
+    assert state.caller_media_frames == 0
+    messages = " | ".join(record.getMessage() for record in caplog.records)
+    assert "signaled stop (reason=unspecified) after 0 caller media frame(s)" in messages
+    warning = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert any("without any caller media frames" in r.getMessage() for r in warning)

--- a/tests/test_realtime_bridge_parity.py
+++ b/tests/test_realtime_bridge_parity.py
@@ -819,3 +819,73 @@ def test_stop_with_no_caller_media_after_greeting_warns(caplog):
     assert "signaled stop (reason=unspecified) after 0 caller media frame(s)" in messages
     warning = [r for r in caplog.records if r.levelname == "WARNING"]
     assert any("without any caller media frames" in r.getMessage() for r in warning)
+
+
+def test_auto_confirm_hangup_fires_after_goodbye_when_armed(monkeypatch):
+    from inkbox_plugin.realtime import _auto_confirm_hangup
+
+    state = _BridgeState()
+    state.hangup_armed_at = 123.0
+    state.stream_id = "stream-9"
+    openai_ws = _FakeWS()
+    inkbox_ws = _FakeWS()
+
+    async def _no_sleep(_delay):
+        return None
+
+    monkeypatch.setattr(realtime_mod.asyncio, "sleep", _no_sleep)
+    asyncio.run(_auto_confirm_hangup(state, inkbox_ws, openai_ws, _meta()))
+
+    assert inkbox_ws.sent == [{
+        "event": "stop",
+        "reason": "goodbye complete",
+        "stream_id": "stream-9",
+    }]
+    assert state.closed is True
+    assert inkbox_ws.closed is True
+    assert openai_ws.closed is True
+
+
+def test_auto_confirm_hangup_is_a_noop_when_disarmed(monkeypatch):
+    from inkbox_plugin.realtime import _auto_confirm_hangup
+
+    state = _BridgeState()
+    state.hangup_armed_at = None  # caller barged in; speech_started disarmed it
+    openai_ws = _FakeWS()
+    inkbox_ws = _FakeWS()
+
+    async def _no_sleep(_delay):
+        return None
+
+    monkeypatch.setattr(realtime_mod.asyncio, "sleep", _no_sleep)
+    asyncio.run(_auto_confirm_hangup(state, inkbox_ws, openai_ws, _meta()))
+
+    assert inkbox_ws.sent == []
+    assert state.closed is False
+    assert inkbox_ws.closed is False
+
+
+def test_speech_started_disarms_pending_hangup():
+    from inkbox_plugin.realtime import _openai_to_inkbox_pump
+
+    state = _BridgeState()
+    state.hangup_armed_at = 123.0
+    inkbox_ws = _FakeWS()
+    openai_ws = _FakeOpenAIWS([
+        {"type": "input_audio_buffer.speech_started"},
+    ])
+
+    async def _consult(_query, _meta):
+        return ""
+
+    asyncio.run(_openai_to_inkbox_pump(
+        openai_ws=openai_ws,
+        inkbox_ws=inkbox_ws,
+        state=state,
+        config=RealtimeConfig(enabled=True, api_key="k"),
+        meta=_meta(),
+        on_agent_consult=_consult,
+    ))
+
+    assert state.hangup_armed_at is None
+    assert {"event": "clear"} in inkbox_ws.sent

--- a/tests/test_realtime_bridge_parity.py
+++ b/tests/test_realtime_bridge_parity.py
@@ -793,7 +793,7 @@ def test_inkbox_stop_frame_logs_reason_and_caller_media_count(caplog):
     messages = " | ".join(record.getMessage() for record in caplog.records)
     assert "signaled stop (reason=carrier_hangup) after 2 caller media frame(s)" in messages
     # Caller audio arrived, so the zero-media warning must not fire.
-    assert "without any caller media frames" not in messages
+    assert "zero caller media frames" not in messages
 
 
 def test_stop_with_no_caller_media_after_greeting_warns(caplog):
@@ -818,7 +818,7 @@ def test_stop_with_no_caller_media_after_greeting_warns(caplog):
     messages = " | ".join(record.getMessage() for record in caplog.records)
     assert "signaled stop (reason=unspecified) after 0 caller media frame(s)" in messages
     warning = [r for r in caplog.records if r.levelname == "WARNING"]
-    assert any("without any caller media frames" in r.getMessage() for r in warning)
+    assert any("zero caller media frames" in r.getMessage() for r in warning)
 
 
 def test_auto_confirm_hangup_fires_after_goodbye_when_armed(monkeypatch):
@@ -889,3 +889,50 @@ def test_speech_started_disarms_pending_hangup():
 
     assert state.hangup_armed_at is None
     assert {"event": "clear"} in inkbox_ws.sent
+
+
+def test_manual_confirm_cancels_pending_auto_confirm(monkeypatch):
+    # A model that does manually confirm while the auto-confirm grace timer
+    # is pending must cancel it — otherwise the racing task can emit a second
+    # stop frame after the manual path already ended the call.
+    state = _BridgeState()
+    state.stream_id = "stream-42"
+    openai_ws = _FakeWS()
+    inkbox_ws = _FakeWS()
+
+    async def _no_sleep(_delay):
+        return None
+
+    monkeypatch.setattr(realtime_mod.asyncio, "sleep", _no_sleep)
+
+    async def _dispatch():
+        await _dispatch_tool_call(
+            openai_ws=openai_ws,
+            call_id="hangup-call",
+            name=HANG_UP_CALL_TOOL_NAME,
+            arguments_json=json.dumps({"reason": "caller said goodbye"}),
+            state=state,
+            config=RealtimeConfig(enabled=True, api_key="sk-test"),
+            meta=_meta(),
+            on_agent_consult=_noop_consult,
+            inkbox_ws=inkbox_ws,
+        )
+
+    async def _run():
+        await _dispatch()  # arm
+        # Simulate the goodbye's audio.done having spawned the grace timer.
+        state.hangup_auto_task = asyncio.ensure_future(asyncio.Event().wait())
+        pending = state.hangup_auto_task
+        await _dispatch()  # manual confirm
+        try:
+            await pending  # yield so the cancellation propagates
+        except asyncio.CancelledError:
+            pass
+        return pending
+
+    pending = asyncio.run(_run())
+
+    assert pending.cancelled()
+    assert state.hangup_auto_task is None
+    stop_frames = [f for f in inkbox_ws.sent if f.get("event") == "stop"]
+    assert len(stop_frames) == 1


### PR DESCRIPTION
## What

Diagnostics for #44. The bridge previously logged only `Inkbox WS signaled stop`, discarding the stop frame's `reason` and keeping no record of whether any caller audio ever arrived.

## Why

In #44, realtime outbound calls die seconds after the greeting. The post-call transcript makes that failure look like the caller simply said nothing — the greeting plays over the outbound leg even when no caller media arrives, so the two cases are indistinguishable from the logs today.

## Changes

- `_BridgeState.caller_media_frames` counts caller media frames received from Inkbox.
- The `stop`/`closed`/`hangup` handler logs the frame's `reason` (`unspecified` when absent) and the media frame count; the transport-close path logs the same count.
- When a greeted call tears down with **zero** caller media frames, a WARNING states explicitly that caller audio never reached the client WS.

With this in place, the failing calls in #44 would log `signaled stop (reason=...) after 0 caller media frame(s)` plus the warning — one log line to distinguish a call that received no caller media from one with a silent caller, and the `reason` gives the server team something to correlate.

## Testing

- Two new unit tests in `tests/test_realtime_bridge_parity.py` (stop with media frames logs reason+count and does not warn; greeted stop with zero frames warns).
- Full suite: 191 passed. `ruff check` clean.

## Update: hangup auto-confirm (second + third commits)

Live testing surfaced a second problem: the two-step `hang_up_call` relies on the model issuing the confirming second call after speaking its goodbye, but realtime models idle until the caller speaks next. Observed on a live call: the agent armed the hangup, said its goodbye, then sat on the open line for 18 seconds — the confirm only fired after the callee spoke again.

New behavior:

- When a hangup is armed and the goodbye response finishes playing (`response.output_audio.done`), the bridge auto-confirms after a 2.5s grace window (`HANGUP_AUTO_CONFIRM_DELAY_S`).
- Outbound audio deltas hold the pending auto-confirm, so a long goodbye is never clipped.
- A caller barge-in (`speech_started`) disarms the hangup entirely — "wait, one more thing" still works, and the model can re-arm later.
- Arm/confirm steps are now logged, so a stalled hangup is visible in the gateway log.

Suite is now 194 passed; ruff clean.
