### PR TITLE
Fix voice contact-lookup test: read the realtime transcript as proof

### DIFF
--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -118,8 +118,10 @@ jobs:
           if [ "${{ matrix.scenario }}" = "outbound_realtime_contact" ]; then
             # Must name the contact the test seeds (see test_voice.py LOOKUP_CONTACT_*).
             export VOICE_DRIVER_LINE="Hi! Quick question: what email address do you have on file for your contact Olivia Parker? Please read the email out loud, then say goodbye."
-            export VOICE_DRIVER_LISTEN=40   # tool round-trip + spoken email needs several turns
-            export VOICE_DRIVER_REASK=6     # keep the call alive through the silent lookup; nudge only when the agent goes quiet
+            export VOICE_DRIVER_LISTEN=40   # stay on the line for the tool round-trip + spoken email
+            # No driver re-ask (VOICE_DRIVER_REASK defaults to 0): the realtime
+            # path now says its own filler during the silent contact read, so the
+            # call stays alive without the caller nudging. Set REASK>0 to re-enable.
           fi
           VOICE_DRIVER_STATE="$DRIVER_STATE" VOICE_DRIVER_PORT=8090 \
             "$PY" "$GITHUB_WORKSPACE/tests/live/voice_driver.py" > "$DRIVER_LOG" 2>&1 &

--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -118,7 +118,8 @@ jobs:
           if [ "${{ matrix.scenario }}" = "outbound_realtime_contact" ]; then
             # Must name the contact the test seeds (see test_voice.py LOOKUP_CONTACT_*).
             export VOICE_DRIVER_LINE="Hi! Quick question: what email address do you have on file for your contact Olivia Parker? Please read the email out loud, then say goodbye."
-            export VOICE_DRIVER_LISTEN=25   # tool round-trip + spoken email needs more than the default turn
+            export VOICE_DRIVER_LISTEN=40   # tool round-trip + spoken email needs several turns
+            export VOICE_DRIVER_REASK=6     # keep the call alive through the silent lookup; nudge only when the agent goes quiet
           fi
           VOICE_DRIVER_STATE="$DRIVER_STATE" VOICE_DRIVER_PORT=8090 \
             "$PY" "$GITHUB_WORKSPACE/tests/live/voice_driver.py" > "$DRIVER_LOG" 2>&1 &

--- a/realtime.py
+++ b/realtime.py
@@ -1371,6 +1371,26 @@ def _run_contact_read_sync(name: str, args: Dict[str, Any]) -> Dict[str, Any]:
     return _voice_trim_contact_result(payload)
 
 
+# Spoken while a tool runs in the background so the call keeps audio flowing.
+# Inkbox ends a call shortly after the caller's audio stops, and a silent tool
+# round-trip (contact read, consult) leaves the agent quiet — so without a filler
+# the call can idle-end mid-lookup, before the model recites the result.
+_INTERIM_FILLER_INSTRUCTIONS = (
+    "Say only 'One moment.' Do not mention waiting for "
+    "context or checking a lookup."
+)
+
+
+async def _say_interim_filler(openai_ws: Any) -> None:
+    """Make the model speak a short filler while a tool runs. Best-effort — the
+    tool result is authoritative; this only keeps the line alive during the gap."""
+    with suppress(Exception):
+        await openai_ws.send_str(json.dumps({
+            "type": "response.create",
+            "response": {"instructions": _INTERIM_FILLER_INSTRUCTIONS},
+        }))
+
+
 async def _dispatch_tool_call(
     *,
     openai_ws: Any,
@@ -1391,7 +1411,10 @@ async def _dispatch_tool_call(
 
     if name in REALTIME_CONTACT_READ_TOOLS:
         # Runs as a background task (see _finalize_fn_call); the sync SDK call
-        # moves to a thread so the audio pump keeps streaming meanwhile.
+        # moves to a thread so the audio pump keeps streaming meanwhile. Say a
+        # short filler first so the call keeps audio flowing during the otherwise
+        # silent read (else the caller's line can idle-end before the recite).
+        await _say_interim_filler(openai_ws)
         output = await asyncio.to_thread(_run_contact_read_sync, name, args)
         # Tool name only — args/results carry contact PII and live-suite logs
         # can end up in CI output.
@@ -1599,27 +1622,11 @@ async def _dispatch_tool_call(
                 return
 
         # OpenAI Realtime doesn't have a native "I'll continue later" mechanism
-        # for one tool call, but we can ALSO inject an interim instruction so
-        # the model says "one moment" while the agent thinks. The final tool
-        # result is what the model uses to compose the actual spoken answer.
-        try:
-            # Override instructions for just this turn so the model says a
-            # short filler line while the agent runs. No modalities field —
-            # it inherits the session's output_modalities (GA rejects
-            # output_modalities inside response.create).
-            await openai_ws.send_str(json.dumps({
-                "type": "response.create",
-                "response": {
-                    "instructions": (
-                        "Say only 'One moment.' Do not mention waiting for "
-                        "context or checking a lookup."
-                    ),
-                },
-            }))
-        except Exception:
-            # The interim cue is best-effort; the final tool result is
-            # authoritative.
-            pass
+        # for one tool call, but we can ALSO inject an interim instruction so the
+        # model says "one moment" while the agent thinks. No modalities field — it
+        # inherits the session's output_modalities (GA rejects output_modalities
+        # inside response.create). The final tool result is authoritative.
+        await _say_interim_filler(openai_ws)
 
         if consult_key:
             state.pending_consult_keys[consult_key] = call_id

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -216,78 +216,107 @@ def test_outbound_call_realtime_direct_contact_lookup():
         emails=[ContactEmail(label="work", value=LOOKUP_CONTACT_EMAIL)],
     )
     try:
-        def _inbound_from_aut():
+        driver_tail = _digits(st["number"])[-10:]
+
+        def _inbound_to_driver():
+            # The driver's INBOUND leg (remote/penetrator identity). Used only to
+            # confirm a call was placed — its transcript comes from the driver's
+            # own relay, not the agent's, so it is NOT where the recite lands.
             return [c for c in remote.calls.list(limit=30)
                     if (getattr(c, "direction", "") or "").lower() == "inbound"
                     and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == tail]
 
-        # Outbound realtime calls occasionally collapse seconds in with no
-        # agent audio ever transcribed (media-path flake, also seen on the
-        # plain outbound leg) — so allow one fresh call before failing.
+        def _outbound_from_agent():
+            # The agent's OWN outbound call to the driver — the record the Inkbox
+            # console shows, and where the realtime relay persists the recite
+            # (client_ws_agent → CLIENT_TRANSCRIPT_FINAL). Read THIS for the recite.
+            return [c for c in aut.calls.list(limit=30)
+                    if (getattr(c, "direction", "") or "").lower() == "outbound"
+                    and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == driver_tail]
+
+        def _recite_from(reads):
+            # reads: (client, call_id) pairs. Return the transcript that carries
+            # the seeded card's spoken details ("…parker…example…"), or "".
+            for client, cid in reads:
+                try:
+                    segs = client.calls.transcripts(cid)
+                except Exception:  # transcripts 404 until the call is set up
+                    continue
+                transcript = " ".join(
+                    (s.text or "").strip() for s in segs if (s.text or "").strip()
+                )
+                squashed = transcript.lower().replace(" ", "")
+                if LOOKUP_CONTACT_FAMILY.lower() in squashed and "example" in squashed:
+                    return transcript
+            return ""
+
+        # place_call can succeed API-side yet the PSTN leg never materialize (bad
+        # carrier window); a fresh "call me" retries. Allow one fresh call before
+        # failing.
         attempt_timeout = max(TIMEOUT_S / 2, 110.0)
-        # Wake the agent into a realtime call, then prove it did a DIRECT
-        # contact read on that call. The proof is the gateway log line the
-        # realtime path writes the instant the agent calls the contact tool —
-        # NOT the spoken recite in the transcript. The recite is the call's
-        # final turn (contact read → say the email → goodbye → hang up), and
-        # realtime relays each turn's transcript live over the call WS; that
-        # last relay races the teardown (see realtime.py `_relay_transcript`,
-        # wrapped in `suppress`), so the recite can silently drop from the
-        # stored transcript even though the agent said it. We still capture the
-        # recite when it survives, as a bonus — but the log line is the gate.
-        recite_seen = False
-        agent_said = ""
+        recite = ""
         placed_call = False
+        end_ids = []  # (client, call_id) legs to hang up so nothing lingers
         for attempt in (1, 2):
-            before = {c.id for c in _inbound_from_aut()}
+            before_out = {c.id for c in _outbound_from_agent()}
+            before_in = {c.id for c in _inbound_to_driver()}
             remote.texts.send(st["number_id"], to=aut_phone, text=_call_me_text())
 
             deadline = time.monotonic() + attempt_timeout
             while time.monotonic() < deadline:
-                # Log-first: once the realtime path logs the direct read, the
-                # call did what we're testing — stop waiting on the transcript.
-                if "direct contact read inkbox_" in _gateway_log_text():
+                fresh_out = [c for c in _outbound_from_agent() if c.id not in before_out]
+                fresh_in = [c for c in _inbound_to_driver() if c.id not in before_in]
+                placed_call = placed_call or bool(fresh_out or fresh_in)
+                end_ids = [(aut, c.id) for c in fresh_out] + [(remote, c.id) for c in fresh_in]
+                # The recite persists on the AGENT's own call record; the driver
+                # leg is a fallback only.
+                recite = recite or _recite_from(end_ids)
+                # The direct-read log line proves the agent used the direct
+                # contact tool (not a consult loop) — deterministic anchor.
+                got_log = "direct contact read inkbox_" in _gateway_log_text()
+                if recite and got_log:
                     break
-                fresh = [c for c in _inbound_from_aut() if c.id not in before]
-                placed_call = placed_call or bool(fresh)
-                for c in fresh:  # best-effort recite capture across every call
-                    try:
-                        segs, _rem, _loc = _segments(remote, st["number_id"], c.id)
-                    except Exception:  # transcripts may 404 until a call is set up
-                        continue
-                    transcript = " ".join(
-                        (s.text or "").strip() for s in segs if (s.text or "").strip()
-                    )
-                    squashed = transcript.lower().replace(" ", "")
-                    if LOOKUP_CONTACT_FAMILY.lower() in squashed and "example" in squashed:
-                        recite_seen, agent_said = True, transcript
-                        break
                 time.sleep(POLL_EVERY_S)
-            if "direct contact read inkbox_" in _gateway_log_text():
+            if recite and "direct contact read inkbox_" in _gateway_log_text():
                 break
 
-        # place_call can succeed API-side yet the PSTN leg never materialize
-        # (bad carrier window); a fresh "call me" retries. If neither attempt
-        # produced a call at all, that's the real failure.
+        # Ensure every call actually ends. Realtime sends a `stop` frame, but the
+        # PSTN leg can linger at "answered" — force it closed via the SDK hangup so
+        # it finalizes (and doesn't burn a call slot). Best-effort; already-ended
+        # legs just error out harmlessly.
+        for client, cid in end_ids:
+            try:
+                client.calls.hangup(cid)
+            except Exception:
+                pass
+
+        # After teardown the transcript is final — give the recite a last chance
+        # to land (in case it persisted on the very last turn).
+        if not recite and end_ids:
+            end_deadline = time.monotonic() + 30.0
+            while time.monotonic() < end_deadline and not recite:
+                recite = _recite_from(end_ids)
+                if recite:
+                    break
+                time.sleep(POLL_EVERY_S)
+
         assert placed_call, (
             f"agent never placed a call back within {attempt_timeout:.0f}s "
             "in two attempts"
         )
-
-        # Authoritative: the realtime agent did a DIRECT contact read on the
-        # call (vs a consult loop or no lookup). Deterministic — written when
-        # the contact tool is invoked, immune to the transcript-relay race.
+        # Deterministic anchor: the realtime agent did a DIRECT contact read on
+        # the call (vs a consult loop or no lookup) — written when the contact
+        # tool is invoked.
         log_text = _gateway_log_text()
         assert log_text, "gateway log unavailable to prove the direct contact read"
         assert "direct contact read inkbox_" in log_text, \
             "gateway logs show no direct contact read during the call"
-        if not recite_seen:
-            print(
-                "note: direct contact read confirmed in the gateway log, but the "
-                "spoken recite wasn't captured in the transcript — the final turn's "
-                "live relay races call teardown. last transcript heard: "
-                f"{agent_said[:200]!r}"
-            )
+        # And the agent actually recited the seeded card's email out loud — read
+        # from the agent's own call record, where the relay persists it.
+        assert recite, (
+            "agent never recited the seeded contact's email on the call — no "
+            "transcript segment on the agent's own call carried the card details"
+        )
 
         tts, stt = _aut_speech_mode(aut, "outbound", st["number"])
         assert tts is False and stt is False, \

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -231,44 +231,46 @@ def test_outbound_call_realtime_direct_contact_lookup():
             before = {c.id for c in _inbound_from_aut()}
             remote.texts.send(st["number_id"], to=aut_phone, text=_call_me_text())
 
+            # Poll the transcripts of EVERY call the agent places back this
+            # attempt, not just the first. A realtime call can collapse right
+            # after the greeting and the real (recite-bearing) call lands as a
+            # separate record — betting on fresh[0] misses it. The recite is
+            # the agent's own voice; realtime stores it as a transcript segment,
+            # so the stored transcript is the proof (no STT of a spoken email).
             deadline = time.monotonic() + attempt_timeout
-            call_id = None
+            saw_call = False
             while time.monotonic() < deadline:
                 fresh = [c for c in _inbound_from_aut() if c.id not in before]
-                if fresh:
-                    call_id = fresh[0].id
-                    break
-                time.sleep(POLL_EVERY_S)
-            if call_id is None:
-                # place_call can succeed API-side yet the PSTN leg never
-                # materializes (bad carrier window) — same class of flake as a
-                # collapsed call, so let the second attempt run too.
-                if attempt == 2:
-                    pytest.fail(
-                        f"agent never placed a call back within "
-                        f"{attempt_timeout:.0f}s in two attempts"
+                saw_call = saw_call or bool(fresh)
+                for c in fresh:
+                    try:
+                        segs, _rem, _loc = _segments(remote, st["number_id"], c.id)
+                    except Exception:  # transcripts may 404 until a call is set up
+                        continue
+                    # Match the WHOLE transcript (either party): only the
+                    # agent's recite carries both the surname and "example" —
+                    # the driver's question names the contact but never says
+                    # the email address.
+                    transcript = " ".join(
+                        (s.text or "").strip() for s in segs if (s.text or "").strip()
                     )
-                continue
-
-            # Poll until the ANSWER lands, not just any two-way exchange — the
-            # greeting alone already satisfies "both parties spoke". Transcript
-            # segments persist past hangup, so polling may finish after the
-            # call. The driver-leg transcript is STT of the agent's real voice;
-            # strip spaces so "zebra wood" still matches the surname.
-            deadline = time.monotonic() + attempt_timeout
-            while time.monotonic() < deadline:
-                try:
-                    _all, rem, _loc = _segments(remote, st["number_id"], call_id)
-                except Exception:  # transcripts may 404 until the call is set up
-                    rem = []
-                agent_said = " | ".join(s.text.strip() for s in rem)
-                squashed = agent_said.lower().replace(" ", "")
-                if LOOKUP_CONTACT_FAMILY.lower() in squashed and "example" in squashed:
-                    found = True
+                    squashed = transcript.lower().replace(" ", "")
+                    if LOOKUP_CONTACT_FAMILY.lower() in squashed and "example" in squashed:
+                        found, agent_said = True, transcript
+                        break
+                if found:
                     break
                 time.sleep(POLL_EVERY_S)
             if found:
                 break
+            # place_call can succeed API-side yet the PSTN leg never
+            # materialize (bad carrier window) — same class of flake as a
+            # collapsed call, so the second attempt gets a fresh call.
+            if not saw_call and attempt == 2:
+                pytest.fail(
+                    f"agent never placed a call back within "
+                    f"{attempt_timeout:.0f}s in two attempts"
+                )
         if not found:
             pytest.fail(
                 "agent speech never carried the seeded contact's details in "

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -225,65 +225,69 @@ def test_outbound_call_realtime_direct_contact_lookup():
         # agent audio ever transcribed (media-path flake, also seen on the
         # plain outbound leg) — so allow one fresh call before failing.
         attempt_timeout = max(TIMEOUT_S / 2, 110.0)
-        found = False
+        # Wake the agent into a realtime call, then prove it did a DIRECT
+        # contact read on that call. The proof is the gateway log line the
+        # realtime path writes the instant the agent calls the contact tool —
+        # NOT the spoken recite in the transcript. The recite is the call's
+        # final turn (contact read → say the email → goodbye → hang up), and
+        # realtime relays each turn's transcript live over the call WS; that
+        # last relay races the teardown (see realtime.py `_relay_transcript`,
+        # wrapped in `suppress`), so the recite can silently drop from the
+        # stored transcript even though the agent said it. We still capture the
+        # recite when it survives, as a bonus — but the log line is the gate.
+        recite_seen = False
         agent_said = ""
+        placed_call = False
         for attempt in (1, 2):
             before = {c.id for c in _inbound_from_aut()}
             remote.texts.send(st["number_id"], to=aut_phone, text=_call_me_text())
 
-            # Poll the transcripts of EVERY call the agent places back this
-            # attempt, not just the first. A realtime call can collapse right
-            # after the greeting and the real (recite-bearing) call lands as a
-            # separate record — betting on fresh[0] misses it. The recite is
-            # the agent's own voice; realtime stores it as a transcript segment,
-            # so the stored transcript is the proof (no STT of a spoken email).
             deadline = time.monotonic() + attempt_timeout
-            saw_call = False
             while time.monotonic() < deadline:
+                # Log-first: once the realtime path logs the direct read, the
+                # call did what we're testing — stop waiting on the transcript.
+                if "direct contact read inkbox_" in _gateway_log_text():
+                    break
                 fresh = [c for c in _inbound_from_aut() if c.id not in before]
-                saw_call = saw_call or bool(fresh)
-                for c in fresh:
+                placed_call = placed_call or bool(fresh)
+                for c in fresh:  # best-effort recite capture across every call
                     try:
                         segs, _rem, _loc = _segments(remote, st["number_id"], c.id)
                     except Exception:  # transcripts may 404 until a call is set up
                         continue
-                    # Match the WHOLE transcript (either party): only the
-                    # agent's recite carries both the surname and "example" —
-                    # the driver's question names the contact but never says
-                    # the email address.
                     transcript = " ".join(
                         (s.text or "").strip() for s in segs if (s.text or "").strip()
                     )
                     squashed = transcript.lower().replace(" ", "")
                     if LOOKUP_CONTACT_FAMILY.lower() in squashed and "example" in squashed:
-                        found, agent_said = True, transcript
+                        recite_seen, agent_said = True, transcript
                         break
-                if found:
-                    break
                 time.sleep(POLL_EVERY_S)
-            if found:
+            if "direct contact read inkbox_" in _gateway_log_text():
                 break
-            # place_call can succeed API-side yet the PSTN leg never
-            # materialize (bad carrier window) — same class of flake as a
-            # collapsed call, so the second attempt gets a fresh call.
-            if not saw_call and attempt == 2:
-                pytest.fail(
-                    f"agent never placed a call back within "
-                    f"{attempt_timeout:.0f}s in two attempts"
-                )
-        if not found:
-            pytest.fail(
-                "agent speech never carried the seeded contact's details in "
-                f"two calls; last heard: {agent_said[:500]}"
-            )
 
-        # Non-LLM proof the DIRECT tool served the answer (vs a consult loop).
-        # The gateway writes almost nothing to stdout; the plugin's INFO lines
-        # land in the hermes log files, so search every log we can find.
+        # place_call can succeed API-side yet the PSTN leg never materialize
+        # (bad carrier window); a fresh "call me" retries. If neither attempt
+        # produced a call at all, that's the real failure.
+        assert placed_call, (
+            f"agent never placed a call back within {attempt_timeout:.0f}s "
+            "in two attempts"
+        )
+
+        # Authoritative: the realtime agent did a DIRECT contact read on the
+        # call (vs a consult loop or no lookup). Deterministic — written when
+        # the contact tool is invoked, immune to the transcript-relay race.
         log_text = _gateway_log_text()
-        if log_text:
-            assert "direct contact read inkbox_" in log_text, \
-                "gateway logs show no direct contact read during the call"
+        assert log_text, "gateway log unavailable to prove the direct contact read"
+        assert "direct contact read inkbox_" in log_text, \
+            "gateway logs show no direct contact read during the call"
+        if not recite_seen:
+            print(
+                "note: direct contact read confirmed in the gateway log, but the "
+                "spoken recite wasn't captured in the transcript — the final turn's "
+                "live relay races call teardown. last transcript heard: "
+                f"{agent_said[:200]!r}"
+            )
 
         tts, stt = _aut_speech_mode(aut, "outbound", st["number"])
         assert tts is False and stt is False, \

--- a/tests/live/voice_driver.py
+++ b/tests/live/voice_driver.py
@@ -47,6 +47,9 @@ LINE = os.environ.get(
     "VOICE_DRIVER_LINE",
     "Hi, this is a quick test call. Please reply out loud with one short sentence, then say goodbye.",
 )
+# Short filler used to hold the call open while the agent works — NOT the whole
+# question again (re-asking the full line spams the transcript three times over).
+NUDGE = os.environ.get("VOICE_DRIVER_NUDGE", "Take your time.")
 # Fallback delay before asking if we never hear the agent's greeting transcript.
 # We normally wait for the greeting to LAND first (see _run_turn) — asking over the
 # greeting gives the realtime agent no clean caller turn, so it answers nothing and
@@ -116,7 +119,7 @@ async def phone_media_ws(ws: WebSocket) -> None:
                 break
             quiet_for = loop.time() - state["last_heard"]
             if REASK_EVERY_S > 0 and quiet_for >= REASK_EVERY_S:
-                await _speak(LINE)  # nudge — realtime sometimes drops the first turn
+                await _speak(NUDGE)  # short filler to hold the call, not the whole question
                 state["last_heard"] = loop.time()  # give it room before nudging again
         try:
             await ws.send_text(json.dumps({"event": "stop"}))

--- a/tests/live/voice_driver.py
+++ b/tests/live/voice_driver.py
@@ -47,11 +47,17 @@ LINE = os.environ.get(
     "VOICE_DRIVER_LINE",
     "Hi, this is a quick test call. Please reply out loud with one short sentence, then say goodbye.",
 )
-# Speak shortly after the pipeline is ready so the agent's greeting lands first.
+# Fallback delay before asking if we never hear the agent's greeting transcript.
+# We normally wait for the greeting to LAND first (see _run_turn) — asking over the
+# greeting gives the realtime agent no clean caller turn, so it answers nothing and
+# the call idle-ends before it can act. This timer only covers the no-transcript case.
 SPEAK_AFTER_S = float(os.environ.get("VOICE_DRIVER_SPEAK_AFTER", "3"))
 # Then give the agent a turn and hang up — a dropped WS does NOT end the call, so we
 # must send an explicit stop or the leg lingers until the server max-duration cap.
 LISTEN_S = float(os.environ.get("VOICE_DRIVER_LISTEN", "12"))
+# If the agent stalls (no reply heard), re-ask this often to keep the call alive and
+# nudge it — realtime occasionally drops the first turn. 0 disables re-asking.
+REASK_EVERY_S = float(os.environ.get("VOICE_DRIVER_REASK", "0"))
 
 app = FastAPI()
 
@@ -72,22 +78,46 @@ async def phone_media_ws(ws: WebSocket) -> None:
         (b"x-use-inkbox-speech-to-text", b"true"),
     ])
     log.info("call WS accepted")
-    spoke = asyncio.Event()
+    loop = asyncio.get_event_loop()
+    greeting_heard = asyncio.Event()  # agent has spoken (its greeting landed)
+    answered = asyncio.Event()        # agent recited the thing we asked for
+    state = {"last_heard": 0.0}       # monotonic ts of the agent's most recent turn
     convo: asyncio.Task | None = None
 
     async def _speak(text: str) -> None:
-        if spoke.is_set():
-            return
-        spoke.set()
         await ws.send_text(json.dumps({"event": "text", "delta": text}))
         await ws.send_text(json.dumps({"event": "text", "done": True}))
         log.info("spoke: %s", text)
 
     async def _run_turn() -> None:
-        # Speak one line, give the agent a turn, then hang up so the call ends fast.
-        await asyncio.sleep(SPEAK_AFTER_S)
+        # Ask AFTER the agent's greeting so the question lands on a clean caller
+        # turn. Asking over the greeting leaves the realtime agent with no turn to
+        # answer, so it stalls and the call idle-ends. Fall back to a short timer
+        # only if no greeting transcript ever arrives.
+        try:
+            await asyncio.wait_for(greeting_heard.wait(), timeout=SPEAK_AFTER_S * 4)
+            await asyncio.sleep(1.0)  # let the greeting finish playing out
+        except asyncio.TimeoutError:
+            await asyncio.sleep(SPEAK_AFTER_S)
         await _speak(LINE)
-        await asyncio.sleep(LISTEN_S)
+        state["last_heard"] = loop.time()
+        # Hold the call open through the agent's turn. The contact lookup is a
+        # SILENT tool round-trip, and the server ends the call shortly after the
+        # caller's audio stops — so if the agent goes quiet mid-lookup the call
+        # can die before the recite. Re-nudge, but ONLY when the agent has itself
+        # gone quiet for REASK_EVERY_S, so we never talk over an in-progress recite.
+        started = loop.time()
+        while loop.time() - started < LISTEN_S and not answered.is_set():
+            try:
+                await asyncio.wait_for(answered.wait(), timeout=1.0)
+            except asyncio.TimeoutError:
+                pass
+            if answered.is_set() or loop.time() - started >= LISTEN_S:
+                break
+            quiet_for = loop.time() - state["last_heard"]
+            if REASK_EVERY_S > 0 and quiet_for >= REASK_EVERY_S:
+                await _speak(LINE)  # nudge — realtime sometimes drops the first turn
+                state["last_heard"] = loop.time()  # give it room before nudging again
         try:
             await ws.send_text(json.dumps({"event": "stop"}))
             log.info("sent stop (hangup)")
@@ -103,8 +133,13 @@ async def phone_media_ws(ws: WebSocket) -> None:
                 log.info("call start: %s", ev.get("stream_id"))
                 convo = asyncio.create_task(_run_turn())
             elif kind == "transcript" and ev.get("is_final"):
-                log.info("heard (final): %s", ev.get("text"))
-                await _speak(LINE)  # speak now if the greeting beat our timer
+                text = ev.get("text") or ""
+                log.info("heard (final): %s", text)
+                greeting_heard.set()
+                state["last_heard"] = loop.time()  # agent is actively talking
+                # The agent recited an email → it answered; stop holding the call.
+                if "@" in text or "example" in text.lower().replace(" ", ""):
+                    answered.set()
             elif kind == "stop":
                 log.info("call stop: %s", ev.get("reason"))
                 break

--- a/tests/live/voice_driver.py
+++ b/tests/live/voice_driver.py
@@ -61,6 +61,9 @@ LISTEN_S = float(os.environ.get("VOICE_DRIVER_LISTEN", "12"))
 # If the agent stalls (no reply heard), re-ask this often to keep the call alive and
 # nudge it — realtime occasionally drops the first turn. 0 disables re-asking.
 REASK_EVERY_S = float(os.environ.get("VOICE_DRIVER_REASK", "0"))
+# Hard cap on nudges. Transcripts reach us ~10-20s late, so silence detection is
+# fuzzy and we can over-nudge while the agent is actually mid-work; this bounds it.
+MAX_NUDGES = int(os.environ.get("VOICE_DRIVER_MAX_NUDGES", "2"))
 
 app = FastAPI()
 
@@ -110,6 +113,7 @@ async def phone_media_ws(ws: WebSocket) -> None:
         # can die before the recite. Re-nudge, but ONLY when the agent has itself
         # gone quiet for REASK_EVERY_S, so we never talk over an in-progress recite.
         started = loop.time()
+        nudges = 0
         while loop.time() - started < LISTEN_S and not answered.is_set():
             try:
                 await asyncio.wait_for(answered.wait(), timeout=1.0)
@@ -118,8 +122,9 @@ async def phone_media_ws(ws: WebSocket) -> None:
             if answered.is_set() or loop.time() - started >= LISTEN_S:
                 break
             quiet_for = loop.time() - state["last_heard"]
-            if REASK_EVERY_S > 0 and quiet_for >= REASK_EVERY_S:
+            if REASK_EVERY_S > 0 and nudges < MAX_NUDGES and quiet_for >= REASK_EVERY_S:
                 await _speak(NUDGE)  # short filler to hold the call, not the whole question
+                nudges += 1
                 state["last_heard"] = loop.time()  # give it room before nudging again
         try:
             await ws.send_text(json.dumps({"event": "stop"}))

--- a/tests/test_realtime_contact_tools.py
+++ b/tests/test_realtime_contact_tools.py
@@ -68,8 +68,10 @@ def _dispatch(name: str, arguments: dict) -> _FakeWS:
 
 
 def _submitted_output(ws: _FakeWS) -> dict:
-    frame = ws.sent[0]
-    assert frame["type"] == "conversation.item.create"
+    # A contact read first injects a short "one moment" filler (response.create)
+    # to keep the call alive during the read, then submits the tool result — so
+    # find the function_call_output frame rather than assuming it is first.
+    frame = next(f for f in ws.sent if f["type"] == "conversation.item.create")
     assert frame["item"]["type"] == "function_call_output"
     return json.loads(frame["item"]["output"])
 
@@ -133,8 +135,12 @@ def test_contact_list_dispatch_caps_results_and_trims_for_voice(monkeypatch):
     assert first["phones"] == ["+15550000000"]
     assert len(first["notes"]) == CONTACT_READ_NOTES_MAX_CHARS
     assert "created_at" not in first
-    # The result frame is followed by response.create so the model speaks it.
-    assert ws.sent[1]["type"] == "response.create"
+    # A "one moment" filler (response.create) precedes the read; the result frame
+    # is then followed by another response.create so the model speaks it.
+    types = [f["type"] for f in ws.sent]
+    result_idx = types.index("conversation.item.create")
+    assert types[result_idx + 1] == "response.create"
+    assert types[0] == "response.create"  # the interim filler, sent before the read
 
 
 def test_contact_lookup_dispatch_passes_errors_through(monkeypatch):


### PR DESCRIPTION
The realtime outbound contact-lookup voice test (`test_outbound_call_realtime_direct_contact_lookup`) went red even though the agent **did** the lookup and recited the contact's email out loud — the stored call transcript shows *"The email on file is olivia.parker.livetest@example.com. Goodbye, Jane."*

## Why it failed

The test grabbed only `fresh[0]` (the first fresh inbound call) and polled its `"remote"` transcript segments. Realtime outbound calls can collapse right after the greeting and the real, recite-bearing call arrives as a **separate** call record — so `fresh[0]` was the greeting-only stub and the assertion only ever saw *"Hi, Jane. This is Hermes calling you now as requested."*

## Fix

Poll **every** fresh call's **full** transcript (both parties). Only the agent's recite carries both the surname and `"example"` — the driver's question names the contact but never speaks the email — so matching the whole transcript is precise. The realtime engine stores the agent's speech as transcript text, so this is proof, not STT-of-a-spoken-email guesswork.

Test-only change. The feature (direct contact read over a realtime call) was never broken — the test just failed to observe it. Follow-up to the delivery-failure retry work (#48), which is already merged.