### PR TITLE
Warn when enabled Inkbox is missing configuration

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -11,6 +11,7 @@ try:
     from .adapter import InkboxAdapter, check_inkbox_requirements, send_inkbox_direct
     from .cli import setup_argparse, handle_cli, slash_handler
     from .config import read_config
+    from .diagnostics import SETUP_HINT
     from .setup_wizard import interactive_setup
     from .tools import register_tools
 except ImportError:  # pragma: no cover - direct local import/test fallback
@@ -27,6 +28,7 @@ except ImportError:  # pragma: no cover - direct local import/test fallback
     _adapter = importlib.import_module(f"{_LOCAL_PACKAGE}.adapter")
     _cli = importlib.import_module(f"{_LOCAL_PACKAGE}.cli")
     _config = importlib.import_module(f"{_LOCAL_PACKAGE}.config")
+    _diagnostics = importlib.import_module(f"{_LOCAL_PACKAGE}.diagnostics")
     _setup_wizard = importlib.import_module(f"{_LOCAL_PACKAGE}.setup_wizard")
     _tools = importlib.import_module(f"{_LOCAL_PACKAGE}.tools")
 
@@ -37,10 +39,12 @@ except ImportError:  # pragma: no cover - direct local import/test fallback
     handle_cli = _cli.handle_cli
     slash_handler = _cli.slash_handler
     read_config = _config.read_config
+    SETUP_HINT = _diagnostics.SETUP_HINT
     interactive_setup = _setup_wizard.interactive_setup
     register_tools = _tools.register_tools
 
 logger = logging.getLogger(__name__)
+_unconfigured_warning_emitted = False
 
 
 def _validate_config(config: Any) -> bool:
@@ -54,8 +58,25 @@ def _is_connected(config: Any) -> bool:
 
 
 def _env_enablement() -> dict | None:
+    global _unconfigured_warning_emitted
+
     cfg = read_config()
     if not (cfg.api_key and cfg.identity):
+        if not _unconfigured_warning_emitted:
+            missing = [
+                name
+                for name, value in (
+                    ("INKBOX_API_KEY", cfg.api_key),
+                    ("INKBOX_IDENTITY", cfg.identity),
+                )
+                if not value
+            ]
+            logger.warning(
+                "[Inkbox] Plugin is enabled but not configured: missing %s. %s",
+                " and ".join(missing),
+                SETUP_HINT,
+            )
+            _unconfigured_warning_emitted = True
         return None
     seed: dict[str, Any] = {
         "api_key": cfg.api_key,

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -1,4 +1,5 @@
 import importlib.util
+import logging
 import re
 import sys
 from pathlib import Path
@@ -107,6 +108,35 @@ def test_registers_inkbox_platform_tools_commands_and_skills():
     assert ctx.cli_commands[0]["name"] == "inkbox"
     assert ctx.commands[0][0][0] == "inkbox"
     assert {args[0] for args, _kwargs in ctx.skills}
+
+
+def test_env_enablement_warns_once_when_plugin_is_unconfigured(monkeypatch, caplog):
+    entry = _load_entry_module()
+    monkeypatch.delenv("INKBOX_API_KEY", raising=False)
+    monkeypatch.delenv("INKBOX_IDENTITY", raising=False)
+
+    with caplog.at_level(logging.WARNING):
+        assert entry._env_enablement() is None
+        assert entry._env_enablement() is None
+
+    warnings = [record.message for record in caplog.records if "[Inkbox]" in record.message]
+    assert len(warnings) == 1
+    assert "missing INKBOX_API_KEY and INKBOX_IDENTITY" in warnings[0]
+    assert "hermes inkbox setup" in warnings[0]
+
+
+def test_env_enablement_does_not_warn_when_configured(monkeypatch, caplog):
+    entry = _load_entry_module()
+    monkeypatch.setenv("INKBOX_API_KEY", "ApiKey_test")
+    monkeypatch.setenv("INKBOX_IDENTITY", "test-agent")
+
+    with caplog.at_level(logging.WARNING):
+        seed = entry._env_enablement()
+
+    assert seed is not None
+    assert seed["api_key"] == "ApiKey_test"
+    assert seed["identity"] == "test-agent"
+    assert not [record for record in caplog.records if "[Inkbox]" in record.message]
 
 
 def test_skill_required_tools_match_runtime_tools():


### PR DESCRIPTION
## Summary

- Warn once when the enabled Inkbox plugin is missing `INKBOX_API_KEY` or `INKBOX_IDENTITY`.
- Name the exact missing settings and point the user to `hermes inkbox setup`.
- Keep Hermes's existing behavior of skipping unconfigured adapters instead of creating a retry loop.

Closes #51.

## Root cause

Hermes calls the plugin's `env_enablement_fn` before deciding whether to construct an adapter. When Inkbox configuration is missing, `_env_enablement()` returns `None`, and the host skips the platform before `InkboxAdapter.connect()` can emit the setup diagnostics added by #43.

The gateway therefore remained healthy in cron-only mode while reporting only the generic `No messaging platforms enabled` message.

## Implementation

The environment discovery hook now emits a once-per-process warning before returning `None`:

```text
[Inkbox] Plugin is enabled but not configured: missing INKBOX_API_KEY and INKBOX_IDENTITY. Run `hermes inkbox setup` ...
```

The warning is not emitted when configuration is present. It is intentionally deduplicated because Hermes may load gateway configuration multiple times in one process.

## Validation

- `uv run pytest -q` -> `216 passed, 24 skipped`
- `uv run ruff check .` -> passed
- `git diff --check` -> passed
- Real Hermes Agent v0.18.2 gateway startup with all Inkbox variables absent:
  - emitted the Inkbox-specific setup warning exactly once
  - continued in cron-only mode
  - did not instantiate or retry the unconfigured adapter

## Scope

Two files changed: the plugin registration hook and its regression tests. No dependency or lockfile changes are included.
