### PR TITLE
Prevent duplicate replies to inbound email

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -214,6 +214,13 @@ def _inkbox_platform() -> Platform:
 # wire layer, so subscribing to them would pay signature cost for no behaviour.
 _DESIRED_MAIL_EVENTS: tuple[str, ...] = ("message.received",)
 
+EMAIL_REPLY_DIRECTIVE = (
+    "Your final text response is automatically sent as the reply to this inbound email. "
+    "Do not call inkbox_send_email or another messaging tool to reply to this same message; "
+    "doing so sends a duplicate email and turns the tool receipt into a second reply. "
+    "Use messaging tools only for a separate outbound message to a different recipient or thread."
+)
+
 # Text: inbound plus the four outbound lifecycle transitions are all consumed
 # by _on_text_received / _on_text_lifecycle.
 _DESIRED_TEXT_EVENTS: tuple[str, ...] = (
@@ -2571,6 +2578,11 @@ class InkboxAdapter(BasePlatformAdapter):
         # (system prompt and/or extra skills) for this contact.
         channel_prompt, auto_skill = self._resolve_channel_overrides(
             "email", chat_id, "inkbox:inkbox-troubleshooting"
+        )
+        channel_prompt = (
+            f"{EMAIL_REPLY_DIRECTIVE}\n\n{channel_prompt}"
+            if channel_prompt
+            else EMAIL_REPLY_DIRECTIVE
         )
         event = MessageEvent(
             text=tagged,

--- a/tests/test_email_self_guard.py
+++ b/tests/test_email_self_guard.py
@@ -172,6 +172,36 @@ def test_unknown_inbound_email_uses_thread_session_key(monkeypatch):
     assert events[0].source.thread_id == "email:thread-1"
     assert adapter._last_inbound_modality["email:thread-1"] == "email"
     assert adapter._last_inbound_email["email:thread-1"]["from_address"] == "person@example.com"
+    assert events[0].channel_prompt == adapter_mod.EMAIL_REPLY_DIRECTIVE
+
+
+def test_inbound_email_reply_directive_precedes_operator_prompt(monkeypatch):
+    monkeypatch.setattr(
+        adapter_mod,
+        "web",
+        types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
+    )
+    events = []
+
+    async def _resolve_contact_full(**_kwargs):
+        return None
+
+    async def _enqueue(event):
+        events.append(event)
+
+    adapter = _adapter_for_self_mail_check()
+    adapter._resolve_contact_full = _resolve_contact_full
+    adapter._enqueue = _enqueue
+    adapter._last_inbound_email = {}
+    adapter._last_inbound_modality = {}
+    adapter._resolve_channel_overrides = lambda *_args, **_kwargs: ("CUSTOM EMAIL POLICY", None)
+
+    asyncio.run(adapter._on_mail_received(_mail_envelope("person@example.com")))
+
+    prompt = events[0].channel_prompt
+    assert prompt.startswith(adapter_mod.EMAIL_REPLY_DIRECTIVE)
+    assert prompt.endswith("CUSTOM EMAIL POLICY")
+    assert "Do not call inkbox_send_email" in prompt
 
 
 def test_email_thread_session_reply_uses_stashed_sender(monkeypatch):


### PR DESCRIPTION
Fixes #53.

## What changed

- add a built-in inbound-email directive explaining that the final agent response is automatically delivered on the current thread
- reserve `inkbox_send_email` and other messaging tools for separate recipients or threads
- prepend the safety directive without discarding operator-configured email prompts
- add regression coverage for default and custom-prompt paths

## Why

A live test produced two emails from one inbound request: the requested payload sent through `inkbox_send_email`, followed by the tool success receipt sent through the gateway’s automatic reply path. The adapter did not clearly distinguish current-thread replies from separate outbound email actions.

## Validation

- `uv run pytest -q` — 185 passed, 22 skipped
- `uv run ruff check adapter.py tests/test_email_self_guard.py` — passed
- live pre-fix reproduction confirmed inbound delivery and both outbound emails