### PR TITLE
Suppress expected tunnel idle-cap warnings

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -161,6 +161,25 @@ except ImportError:  # pragma: no cover - direct local import/test fallback
 
 logger = logging.getLogger(__name__)
 
+
+class _ExpectedTunnelIdleFilter(logging.Filter):
+    """Drop the SDK's per-slot warning for a normal idle intake timeout."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        return not (
+            record.name == "inkbox.tunnels"
+            and "/_system/intake slot=" in message
+            and "status=408" in message
+            and "reason='intake-idle-cap'" in message
+        )
+
+
+def _install_tunnel_log_filter() -> None:
+    tunnel_logger = logging.getLogger("inkbox.tunnels")
+    if not any(isinstance(item, _ExpectedTunnelIdleFilter) for item in tunnel_logger.filters):
+        tunnel_logger.addFilter(_ExpectedTunnelIdleFilter())
+
 DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 8765
 DEFAULT_WEBHOOK_PATH = "/webhook"
@@ -1616,6 +1635,8 @@ class InkboxAdapter(BasePlatformAdapter):
         """
         import threading
         from inkbox.tunnels.exceptions import TunnelNotProvisioned
+
+        _install_tunnel_log_filter()
 
         tunnel_name = self._tunnel_name_override or _slugify_for_tunnel(
             self._identity_handle,

--- a/tests/test_tunnel_logging.py
+++ b/tests/test_tunnel_logging.py
@@ -1,0 +1,70 @@
+import logging
+import sys
+import types
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("inkbox_plugin")
+pkg.__path__ = [str(ROOT)]
+sys.modules.setdefault("inkbox_plugin", pkg)
+
+from inkbox_plugin import adapter as adapter_mod
+
+
+def _record(message, *args, level=logging.WARNING):
+    return logging.LogRecord(
+        "inkbox.tunnels",
+        level,
+        __file__,
+        1,
+        message,
+        args,
+        None,
+    )
+
+
+def test_expected_intake_idle_cap_warning_is_filtered():
+    record = _record(
+        "/_system/intake slot=%d -> status=%s reason=%r body=%r",
+        10,
+        "408",
+        "intake-idle-cap",
+        b"",
+    )
+
+    assert adapter_mod._ExpectedTunnelIdleFilter().filter(record) is False
+
+
+def test_other_tunnel_warnings_remain_visible():
+    filter_ = adapter_mod._ExpectedTunnelIdleFilter()
+
+    assert filter_.filter(_record(
+        "/_system/intake slot=%d -> status=%s reason=%r body=%r",
+        10,
+        "401",
+        "owner-token-invalid",
+        b"",
+    )) is True
+    assert filter_.filter(_record("tunnel runtime disconnected")) is True
+
+
+def test_installing_filter_is_idempotent():
+    logger = logging.getLogger("inkbox.tunnels")
+    original_filters = list(logger.filters)
+    try:
+        logger.filters = [
+            item for item in logger.filters
+            if not isinstance(item, adapter_mod._ExpectedTunnelIdleFilter)
+        ]
+
+        adapter_mod._install_tunnel_log_filter()
+        adapter_mod._install_tunnel_log_filter()
+
+        installed = [
+            item for item in logger.filters
+            if isinstance(item, adapter_mod._ExpectedTunnelIdleFilter)
+        ]
+        assert len(installed) == 1
+    finally:
+        logger.filters = original_filters


### PR DESCRIPTION
Fixes #55.

## What changed

- install a narrow log filter before starting the SDK-managed tunnel
- suppress only `inkbox.tunnels` intake warnings with status `408` and reason `intake-idle-cap`
- preserve authentication, connectivity, and all other tunnel warnings
- make filter installation idempotent
- add regression coverage for suppression, warning preservation, and repeated installation

## Why

The SDK recycles idle intake slots as part of normal tunnel operation but currently logs each slot timeout at warning level. A healthy gateway can therefore emit dozens of warning lines at once and bury useful inbound-message and delivery logs.

Lowering the whole logger level would also hide actionable failures, so this PR filters only the known expected condition.

## Validation

- `pytest -q` — 187 passed, 22 skipped
- `ruff check adapter.py tests/test_tunnel_logging.py` — passed
- live pre-fix gateway reproduced repeated warnings across slots 0–31 while email delivery remained healthy