### PR TITLE
feat: track outbound delivery context to correlate async failure webh…

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -246,6 +246,85 @@ SMS_TEXT_BATCH_DELAY_SECONDS = 0.0
 SMS_TEXT_BATCH_MAX_MESSAGES = 8
 SMS_TEXT_BATCH_MAX_CHARS = 4000
 
+_GLOBAL_OUTBOUND_CONTEXT: Dict[str, Dict[str, Any]] = {}
+OUTBOUND_CONTEXT_MAX_ENTRIES = 1000
+OUTBOUND_CONTEXT_TTL = 7200.0  # 2 hours
+OUTBOUND_FAILURE_BODY_SNIPPET_CHARS = 500
+
+
+def save_outbound_context(
+    msg_id: str,
+    channel: str,
+    chat_id: str,
+    recipient: str,
+    body: str,
+    conversation_id: Optional[str] = None,
+    email_thread_id: Optional[str] = None,
+    email_rfc_message_id: Optional[str] = None,
+    email_subject: Optional[str] = None,
+) -> None:
+    """Save metadata for an outbound message to correlate asynchronous failures later."""
+    if not msg_id:
+        return
+    now = time.time()
+
+    # Prune old entries
+    cutoff = now - OUTBOUND_CONTEXT_TTL
+    stale = [k for k, v in list(_GLOBAL_OUTBOUND_CONTEXT.items()) if v.get("at", 0) < cutoff]
+    for k in stale:
+        _GLOBAL_OUTBOUND_CONTEXT.pop(k, None)
+
+    # Enforce maximum entry count
+    if len(_GLOBAL_OUTBOUND_CONTEXT) >= OUTBOUND_CONTEXT_MAX_ENTRIES:
+        sorted_keys = sorted(_GLOBAL_OUTBOUND_CONTEXT.keys(), key=lambda k: _GLOBAL_OUTBOUND_CONTEXT[k].get("at", 0))
+        # pop the oldest to make room
+        for k in sorted_keys[:len(_GLOBAL_OUTBOUND_CONTEXT) - OUTBOUND_CONTEXT_MAX_ENTRIES + 1]:
+            _GLOBAL_OUTBOUND_CONTEXT.pop(k, None)
+
+    # Truncate body snippet to avoid large memory footprint
+    snippet = (body or "").strip()
+    if len(snippet) > OUTBOUND_FAILURE_BODY_SNIPPET_CHARS:
+        snippet = snippet[:OUTBOUND_FAILURE_BODY_SNIPPET_CHARS] + "…"
+
+    _GLOBAL_OUTBOUND_CONTEXT[msg_id] = {
+        "channel": channel,
+        "chat_id": chat_id,
+        "recipient": recipient or "",
+        "body_snippet": snippet,
+        "conversation_id": conversation_id or None,
+        "email_thread_id": email_thread_id or None,
+        "email_rfc_message_id": email_rfc_message_id or None,
+        "email_subject": email_subject or None,
+        "at": now,
+    }
+
+
+def get_outbound_context(msg_id: str) -> Optional[Dict[str, Any]]:
+    """Retrieve outbound context, checking TTL."""
+    if not msg_id:
+        return None
+    ctx = _GLOBAL_OUTBOUND_CONTEXT.get(msg_id)
+    if not ctx:
+        return None
+    if time.time() - ctx.get("at", 0) > OUTBOUND_CONTEXT_TTL:
+        _GLOBAL_OUTBOUND_CONTEXT.pop(msg_id, None)
+        return None
+    return ctx
+
+
+def pop_outbound_context(msg_id: str) -> Optional[Dict[str, Any]]:
+    """Retrieve and remove outbound context for a terminal event."""
+    ctx = get_outbound_context(msg_id)
+    if ctx:
+        _GLOBAL_OUTBOUND_CONTEXT.pop(msg_id, None)
+    return ctx
+
+
+def remove_outbound_context(msg_id: str) -> None:
+    """Remove outbound context (e.g. on terminal success)."""
+    if msg_id:
+        _GLOBAL_OUTBOUND_CONTEXT.pop(msg_id, None)
+
 # ── Outbound delivery-failure feedback loop ────────────────────────────
 #
 # An outbound message can die two ways: rejected synchronously at send
@@ -1606,7 +1685,7 @@ class InkboxAdapter(BasePlatformAdapter):
         # OUTBOUND_FAILURE_MAX_ATTEMPTS. Reset on inbound / delivered / TTL.
         self._outbound_failure_state: Dict[str, Dict[str, float]] = {}
         # outbound message id -> context dictionary tracking sent messages.
-        self._outbound_context: Dict[str, Dict[str, Any]] = {}
+        self._outbound_context = _GLOBAL_OUTBOUND_CONTEXT
         # chat_id → unix timestamp at which the contact's call WS most-recently
         # closed.  send() consults this to drop replies generated during the
         # short window after a call ends — when the agent's last in-call turn
@@ -2205,9 +2284,19 @@ class InkboxAdapter(BasePlatformAdapter):
                 raw_response.get("message_id") or "",
                 raw_response.get("status") or "",
             )
+            msg_id = str(getattr(msg, "id", "")).strip()
+            if msg_id:
+                save_outbound_context(
+                    msg_id=msg_id,
+                    channel="imessage",
+                    chat_id=chat_id,
+                    recipient=to_number or "",
+                    body=caption or "[media attachment]",
+                    conversation_id=conversation_id or "",
+                )
             return SendResult(
                 success=True,
-                message_id=str(getattr(msg, "id", "")),
+                message_id=msg_id,
                 raw_response=raw_response,
             )
         except Exception as exc:
@@ -2547,20 +2636,17 @@ class InkboxAdapter(BasePlatformAdapter):
                 )
                 msg_id = str(getattr(msg, "id", "")).strip()
                 if msg_id:
-                    self._prune_outbound_context()
-                    self._outbound_context[msg_id] = {
-                        "channel": "imessage",
-                        "chat_id": chat_id,
-                        "recipient": to_number or "",
-                        "body_snippet": content,
-                        "conversation_id": conversation_id or "",
-                        "email_thread_id": None,
-                        "email_subject": None,
-                        "at": time.time(),
-                    }
+                    save_outbound_context(
+                        msg_id=msg_id,
+                        channel="imessage",
+                        chat_id=chat_id,
+                        recipient=to_number or "",
+                        body=content,
+                        conversation_id=conversation_id or "",
+                    )
                 return SendResult(
                     success=True,
-                    message_id=str(getattr(msg, "id", "")),
+                    message_id=msg_id,
                     raw_response=raw_response,
                 )
             except Exception as exc:
@@ -2632,20 +2718,17 @@ class InkboxAdapter(BasePlatformAdapter):
                 )
                 msg_id = str(getattr(msg, "id", "")).strip()
                 if msg_id:
-                    self._prune_outbound_context()
-                    self._outbound_context[msg_id] = {
-                        "channel": "sms",
-                        "chat_id": chat_id,
-                        "recipient": to_number or "",
-                        "body_snippet": content,
-                        "conversation_id": conversation_id or "",
-                        "email_thread_id": None,
-                        "email_subject": None,
-                        "at": time.time(),
-                    }
+                    save_outbound_context(
+                        msg_id=msg_id,
+                        channel="sms",
+                        chat_id=chat_id,
+                        recipient=to_number or "",
+                        body=content,
+                        conversation_id=conversation_id or "",
+                    )
                 return SendResult(
                     success=True,
-                    message_id=str(getattr(msg, "id", "")),
+                    message_id=msg_id,
                     raw_response=raw_response,
                 )
             except Exception as exc:
@@ -2714,17 +2797,16 @@ class InkboxAdapter(BasePlatformAdapter):
                 )
                 msg_id = str(getattr(msg, "id", "")).strip()
                 if msg_id:
-                    self._prune_outbound_context()
-                    self._outbound_context[msg_id] = {
-                        "channel": "email",
-                        "chat_id": chat_id,
-                        "recipient": to_addr or "",
-                        "body_snippet": content,
-                        "conversation_id": None,
-                        "email_thread_id": in_reply_to or meta.get("thread_id"),
-                        "email_subject": subject,
-                        "at": time.time(),
-                    }
+                    save_outbound_context(
+                        msg_id=msg_id,
+                        channel="email",
+                        chat_id=chat_id,
+                        recipient=to_addr or "",
+                        body=content,
+                        email_thread_id=meta.get("thread_id") or None,
+                        email_rfc_message_id=in_reply_to or None,
+                        email_subject=subject,
+                    )
                 return SendResult(success=True, message_id=msg_id)
             except Exception as exc:
                 failure = SendResult(success=False, error=f"send_email failed: {exc}")
@@ -3193,14 +3275,20 @@ class InkboxAdapter(BasePlatformAdapter):
         message = (envelope.get("data") or {}).get("message") or {}
         message_id = str(message.get("id") or "").strip()
         direction = str(message.get("direction") or "").strip().lower()
-        if direction and direction != "outbound":
+
+        ctx = get_outbound_context(message_id)
+        if direction == "inbound" and not ctx:
             return web.Response(status=200, text="ok")
+
         to_addresses = [
             _normalize_email_address(addr)
             for addr in (message.get("to_addresses") or [])
             if addr
         ]
         to_address = next((addr for addr in to_addresses if addr), "")
+        if ctx:
+            to_address = ctx.get("recipient") or to_address
+
         if not to_address:
             logger.warning(
                 "[Inkbox] Mail %s webhook had no recipient; not waking agent",
@@ -3223,16 +3311,18 @@ class InkboxAdapter(BasePlatformAdapter):
         if self._dedup_begin(event_key):
             return web.Response(status=200, text="duplicate")
         try:
-            ctx = self._outbound_context.get(message_id) if message_id else None
+            ctx = pop_outbound_context(message_id)
             if ctx:
                 chat_id = ctx.get("chat_id")
                 thread_id = ctx.get("email_thread_id") or message.get("thread_id")
                 to_address = ctx.get("recipient") or to_address
                 subject = ctx.get("email_subject") or subject
                 failed_body = ctx.get("body_snippet") or str(message.get("snippet") or subject or "")
+                rfc_message_id = ctx.get("email_rfc_message_id") or str(message.get("message_id") or "")
                 contact = await self._resolve_contact_full(kind="email", value=to_address) if to_address else None
             else:
                 thread_id = message.get("thread_id")
+                rfc_message_id = str(message.get("message_id") or "")
                 contact = await self._resolve_contact_full(kind="email", value=to_address)
                 chat_id = _chat_id_for_route(
                     contact,
@@ -3249,12 +3339,12 @@ class InkboxAdapter(BasePlatformAdapter):
             # Give send() the threading context for a resend even if the
             # inbound stash predates a restart; the failed message's own
             # RFC 5322 Message-ID keeps a retry on the original thread.
-            self._last_inbound_modality.setdefault(str(chat_id), "email")
-            self._last_inbound_email.setdefault(str(chat_id), {
+            self._last_inbound_modality[str(chat_id)] = "email"
+            self._last_inbound_email[str(chat_id)] = {
                 "subject": subject,
-                "rfc_message_id": str(message.get("message_id") or ""),
+                "rfc_message_id": rfc_message_id,
                 "from_address": to_address,
-            })
+            }
             await self._note_outbound_delivery_failure(
                 mode="email",
                 chat_id=chat_id,
@@ -3943,15 +4033,7 @@ class InkboxAdapter(BasePlatformAdapter):
 
     # ── Outbound delivery-failure feedback loop ────────────────────────
     #
-    def _prune_outbound_context(self) -> None:
-        """Prune outbound context entries older than 2 hours."""
-        if not hasattr(self, "_outbound_context"):
-            self._outbound_context = {}
-        now = time.time()
-        cutoff = now - 7200.0
-        stale = [k for k, v in self._outbound_context.items() if v.get("at", 0) < cutoff]
-        for k in stale:
-            self._outbound_context.pop(k, None)
+    # _prune_outbound_context is fully replaced by get_outbound_context/save_outbound_context.
 
     def _outbound_failure_store(self) -> Dict[str, Dict[str, float]]:
         """Return the failure-counter store, creating it if missing.
@@ -4281,11 +4363,13 @@ class InkboxAdapter(BasePlatformAdapter):
             redact_phone(remote),
             error_code or "",
         )
-        if direction.lower() != "outbound":
+        ctx = get_outbound_context(text_id)
+        if direction.lower() == "inbound" and not ctx:
             return web.Response(status=200, text="ok")
 
         if event_type == "text.delivered":
             self._clear_outbound_failures("sms", conversation_id, remote)
+            remove_outbound_context(text_id)
             return web.Response(status=200, text="ok")
 
         if event_type != "text.delivery_failed":
@@ -4298,7 +4382,7 @@ class InkboxAdapter(BasePlatformAdapter):
         if self._dedup_begin(event_key):
             return web.Response(status=200, text="duplicate")
         try:
-            ctx = self._outbound_context.get(text_id) if text_id else None
+            ctx = pop_outbound_context(text_id)
             if ctx:
                 chat_id = ctx.get("chat_id")
                 conversation_id = ctx.get("conversation_id") or conversation_id
@@ -4564,11 +4648,13 @@ class InkboxAdapter(BasePlatformAdapter):
             redact_phone(remote),
             error_code or "",
         )
-        if direction == "inbound":
+        ctx = get_outbound_context(message_id)
+        if direction == "inbound" and not ctx:
             return web.Response(status=200, text="ok")
 
         if event_type == "imessage.delivered":
             self._clear_outbound_failures("imessage", conversation_id, remote)
+            remove_outbound_context(message_id)
             return web.Response(status=200, text="ok")
 
         if event_type != "imessage.delivery_failed":
@@ -4580,7 +4666,7 @@ class InkboxAdapter(BasePlatformAdapter):
         if self._dedup_begin(event_key):
             return web.Response(status=200, text="duplicate")
         try:
-            ctx = self._outbound_context.get(message_id) if message_id else None
+            ctx = pop_outbound_context(message_id)
             if ctx:
                 chat_id = ctx.get("chat_id")
                 conversation_id = ctx.get("conversation_id") or conversation_id
@@ -5867,11 +5953,21 @@ async def send_inkbox_direct(
                             conversation_id,
                         )
                         return _sms_send_failure_dict(exc)
+                    msg_id = str(getattr(msg, "id", "")).strip()
+                    if msg_id:
+                        save_outbound_context(
+                            msg_id=msg_id,
+                            channel="sms",
+                            chat_id=chat_id,
+                            recipient="",
+                            body=message,
+                            conversation_id=conversation_id,
+                        )
                     return {
                         "success": True,
                         "platform": "inkbox",
                         "chat_id": chat_id,
-                        "message_id": str(getattr(msg, "id", "")),
+                        "message_id": msg_id,
                         "mode": "sms",
                         "conversation_id": conversation_id,
                         "delivery_status": _plain_value(
@@ -5895,11 +5991,20 @@ async def send_inkbox_direct(
                         redact_phone(str(target)),
                     )
                     return _sms_send_failure_dict(exc)
+                msg_id = str(getattr(msg, "id", "")).strip()
+                if msg_id:
+                    save_outbound_context(
+                        msg_id=msg_id,
+                        channel="sms",
+                        chat_id=chat_id,
+                        recipient=target or "",
+                        body=message,
+                    )
                 return {
                     "success": True,
                     "platform": "inkbox",
                     "chat_id": chat_id,
-                    "message_id": str(getattr(msg, "id", "")),
+                    "message_id": msg_id,
                     "mode": "sms",
                     "delivery_status": _plain_value(
                         getattr(msg, "delivery_status", None),
@@ -5936,11 +6041,21 @@ async def send_inkbox_direct(
                         "error": _format_inkbox_imessage_error(fields),
                         **fields,
                     }
+                msg_id = str(getattr(msg, "id", "")).strip()
+                if msg_id:
+                    save_outbound_context(
+                        msg_id=msg_id,
+                        channel="imessage",
+                        chat_id=chat_id,
+                        recipient=str(chat_id) if str(chat_id).startswith("+") else "",
+                        body=message,
+                        conversation_id=conversation_id or "",
+                    )
                 return {
                     "success": True,
                     "platform": "inkbox",
                     "chat_id": chat_id,
-                    "message_id": str(getattr(msg, "id", "")),
+                    "message_id": msg_id,
                     "mode": "imessage",
                     "conversation_id": conversation_id or _plain_value(
                         getattr(msg, "conversation_id", None),
@@ -5964,11 +6079,21 @@ async def send_inkbox_direct(
                     subject=subject or "(no subject)",
                     body_text=message,
                 )
+                msg_id = str(getattr(msg, "id", "")).strip()
+                if msg_id:
+                    save_outbound_context(
+                        msg_id=msg_id,
+                        channel="email",
+                        chat_id=chat_id,
+                        recipient=target or "",
+                        body=message,
+                        email_subject=subject or "(no subject)",
+                    )
                 return {
                     "success": True,
                     "platform": "inkbox",
                     "chat_id": chat_id,
-                    "message_id": str(getattr(msg, "id", "")),
+                    "message_id": msg_id,
                     "mode": "email",
                 }
 

--- a/adapter.py
+++ b/adapter.py
@@ -1605,6 +1605,8 @@ class InkboxAdapter(BasePlatformAdapter):
         # delivery-failure feedback loop can stop waking the agent after
         # OUTBOUND_FAILURE_MAX_ATTEMPTS. Reset on inbound / delivered / TTL.
         self._outbound_failure_state: Dict[str, Dict[str, float]] = {}
+        # outbound message id -> context dictionary tracking sent messages.
+        self._outbound_context: Dict[str, Dict[str, Any]] = {}
         # chat_id → unix timestamp at which the contact's call WS most-recently
         # closed.  send() consults this to drop replies generated during the
         # short window after a call ends — when the agent's last in-call turn
@@ -2543,6 +2545,19 @@ class InkboxAdapter(BasePlatformAdapter):
                     raw_response.get("message_id") or "",
                     raw_response.get("status") or "",
                 )
+                msg_id = str(getattr(msg, "id", "")).strip()
+                if msg_id:
+                    self._prune_outbound_context()
+                    self._outbound_context[msg_id] = {
+                        "channel": "imessage",
+                        "chat_id": chat_id,
+                        "recipient": to_number or "",
+                        "body_snippet": content,
+                        "conversation_id": conversation_id or "",
+                        "email_thread_id": None,
+                        "email_subject": None,
+                        "at": time.time(),
+                    }
                 return SendResult(
                     success=True,
                     message_id=str(getattr(msg, "id", "")),
@@ -2615,6 +2630,19 @@ class InkboxAdapter(BasePlatformAdapter):
                     raw_response.get("message_id") or "",
                     raw_response.get("delivery_status") or raw_response.get("status") or "",
                 )
+                msg_id = str(getattr(msg, "id", "")).strip()
+                if msg_id:
+                    self._prune_outbound_context()
+                    self._outbound_context[msg_id] = {
+                        "channel": "sms",
+                        "chat_id": chat_id,
+                        "recipient": to_number or "",
+                        "body_snippet": content,
+                        "conversation_id": conversation_id or "",
+                        "email_thread_id": None,
+                        "email_subject": None,
+                        "at": time.time(),
+                    }
                 return SendResult(
                     success=True,
                     message_id=str(getattr(msg, "id", "")),
@@ -2684,7 +2712,20 @@ class InkboxAdapter(BasePlatformAdapter):
                     body_text=content,
                     in_reply_to_message_id=in_reply_to or None,
                 )
-                return SendResult(success=True, message_id=str(getattr(msg, "id", "")))
+                msg_id = str(getattr(msg, "id", "")).strip()
+                if msg_id:
+                    self._prune_outbound_context()
+                    self._outbound_context[msg_id] = {
+                        "channel": "email",
+                        "chat_id": chat_id,
+                        "recipient": to_addr or "",
+                        "body_snippet": content,
+                        "conversation_id": None,
+                        "email_thread_id": in_reply_to or meta.get("thread_id"),
+                        "email_subject": subject,
+                        "at": time.time(),
+                    }
+                return SendResult(success=True, message_id=msg_id)
             except Exception as exc:
                 failure = SendResult(success=False, error=f"send_email failed: {exc}")
                 await self._maybe_wake_on_send_rejection(
@@ -3182,13 +3223,29 @@ class InkboxAdapter(BasePlatformAdapter):
         if self._dedup_begin(event_key):
             return web.Response(status=200, text="duplicate")
         try:
-            thread_id = message.get("thread_id")
-            contact = await self._resolve_contact_full(kind="email", value=to_address)
-            chat_id = _chat_id_for_route(
-                contact,
-                _channel_thread_key("email", thread_id),
-                to_address,
-            )
+            ctx = self._outbound_context.get(message_id) if message_id else None
+            if ctx:
+                chat_id = ctx.get("chat_id")
+                thread_id = ctx.get("email_thread_id") or message.get("thread_id")
+                to_address = ctx.get("recipient") or to_address
+                subject = ctx.get("email_subject") or subject
+                failed_body = ctx.get("body_snippet") or str(message.get("snippet") or subject or "")
+                contact = await self._resolve_contact_full(kind="email", value=to_address) if to_address else None
+            else:
+                thread_id = message.get("thread_id")
+                contact = await self._resolve_contact_full(kind="email", value=to_address)
+                chat_id = _chat_id_for_route(
+                    contact,
+                    _channel_thread_key("email", thread_id),
+                    to_address,
+                )
+                failed_body = str(message.get("snippet") or subject or "")
+
+            if not chat_id:
+                logger.warning("[Inkbox] Could not resolve a chat session for email delivery failure; not waking agent")
+                self._dedup_commit(event_key)
+                return web.Response(status=200, text="ok")
+
             # Give send() the threading context for a resend even if the
             # inbound stash predates a restart; the failed message's own
             # RFC 5322 Message-ID keeps a retry on the original thread.
@@ -3204,7 +3261,7 @@ class InkboxAdapter(BasePlatformAdapter):
                 thread_id=_channel_thread_key("email", thread_id),
                 conversation_id=None,
                 target=to_address,
-                failed_body=str(message.get("snippet") or subject or ""),
+                failed_body=failed_body,
                 error_code=str(status) if status else None,
                 error_detail=(
                     f"The email to {to_address}"
@@ -3886,6 +3943,16 @@ class InkboxAdapter(BasePlatformAdapter):
 
     # ── Outbound delivery-failure feedback loop ────────────────────────
     #
+    def _prune_outbound_context(self) -> None:
+        """Prune outbound context entries older than 2 hours."""
+        if not hasattr(self, "_outbound_context"):
+            self._outbound_context = {}
+        now = time.time()
+        cutoff = now - 7200.0
+        stale = [k for k, v in self._outbound_context.items() if v.get("at", 0) < cutoff]
+        for k in stale:
+            self._outbound_context.pop(k, None)
+
     def _outbound_failure_store(self) -> Dict[str, Dict[str, float]]:
         """Return the failure-counter store, creating it if missing.
 
@@ -4231,12 +4298,27 @@ class InkboxAdapter(BasePlatformAdapter):
         if self._dedup_begin(event_key):
             return web.Response(status=200, text="duplicate")
         try:
-            contact = await self._resolve_contact_full(kind="phone", value=remote)
-            chat_id = _chat_id_for_route(
-                contact,
-                _channel_thread_key("sms", conversation_id),
-                remote,
-            )
+            ctx = self._outbound_context.get(text_id) if text_id else None
+            if ctx:
+                chat_id = ctx.get("chat_id")
+                conversation_id = ctx.get("conversation_id") or conversation_id
+                remote = ctx.get("recipient") or remote
+                failed_body = ctx.get("body_snippet") or str(text_msg.get("text") or "")
+                contact = await self._resolve_contact_full(kind="phone", value=remote) if remote else None
+            else:
+                contact = await self._resolve_contact_full(kind="phone", value=remote)
+                chat_id = _chat_id_for_route(
+                    contact,
+                    _channel_thread_key("sms", conversation_id),
+                    remote,
+                )
+                failed_body = str(text_msg.get("text") or "")
+
+            if not chat_id:
+                logger.warning("[Inkbox] Could not resolve a chat session for SMS delivery failure; not waking agent")
+                self._dedup_commit(event_key)
+                return web.Response(status=200, text="ok")
+
             # Make sure the agent's resend can route even if the inbound
             # stash predates a restart: mirror what _on_text_received_once
             # records, without clobbering fresher state.
@@ -4259,7 +4341,7 @@ class InkboxAdapter(BasePlatformAdapter):
                 thread_id=_channel_thread_key("sms", conversation_id),
                 conversation_id=conversation_id or None,
                 target=remote or None,
-                failed_body=str(text_msg.get("text") or ""),
+                failed_body=failed_body,
                 error_code=str(error_code) if error_code else None,
                 error_detail=str(error_detail) if error_detail else None,
                 stage="delivery_failed",
@@ -4498,12 +4580,27 @@ class InkboxAdapter(BasePlatformAdapter):
         if self._dedup_begin(event_key):
             return web.Response(status=200, text="duplicate")
         try:
-            contact = await self._resolve_contact_full(kind="phone", value=remote)
-            chat_id = _chat_id_for_route(
-                contact,
-                _channel_thread_key("imessage", conversation_id),
-                remote,
-            )
+            ctx = self._outbound_context.get(message_id) if message_id else None
+            if ctx:
+                chat_id = ctx.get("chat_id")
+                conversation_id = ctx.get("conversation_id") or conversation_id
+                remote = ctx.get("recipient") or remote
+                failed_body = ctx.get("body_snippet") or str(message.get("content") or message.get("text") or "")
+                contact = await self._resolve_contact_full(kind="phone", value=remote) if remote else None
+            else:
+                contact = await self._resolve_contact_full(kind="phone", value=remote)
+                chat_id = _chat_id_for_route(
+                    contact,
+                    _channel_thread_key("imessage", conversation_id),
+                    remote,
+                )
+                failed_body = str(message.get("content") or message.get("text") or "")
+
+            if not chat_id:
+                logger.warning("[Inkbox] Could not resolve a chat session for iMessage delivery failure; not waking agent")
+                self._dedup_commit(event_key)
+                return web.Response(status=200, text="ok")
+
             # iMessage replies MUST target the conversation id (shared
             # line) — make sure the stash survives a gateway restart.
             if conversation_id:
@@ -4524,7 +4621,7 @@ class InkboxAdapter(BasePlatformAdapter):
                 thread_id=_channel_thread_key("imessage", conversation_id),
                 conversation_id=conversation_id or None,
                 target=remote or None,
-                failed_body=str(message.get("content") or message.get("text") or ""),
+                failed_body=failed_body,
                 error_code=str(error_code) if error_code else None,
                 error_detail=str(error_detail) if error_detail else None,
                 stage="delivery_failed",

--- a/tests/test_delivery_failure_retry.py
+++ b/tests/test_delivery_failure_retry.py
@@ -135,7 +135,8 @@ def _adapter(identity, *, contact=None):
     adapter._last_inbound_sms = {}
     adapter._last_inbound_imessage = {}
     adapter._last_inbound_email = {}
-    adapter._outbound_context = {}
+    adapter_mod._GLOBAL_OUTBOUND_CONTEXT.clear()
+    adapter._outbound_context = adapter_mod._GLOBAL_OUTBOUND_CONTEXT
     adapter._stop_imessage_typing = lambda *_a, **_k: None
     adapter._resolve_channel_overrides = lambda *_a, **_k: (None, None)
 
@@ -571,32 +572,60 @@ def test_budget_expires_after_ttl():
     assert f"attempt=1/{MAX}" in adapter._enqueued[1].text
 
 
-def test_outbound_context_correlation_first_sms():
-    adapter = _adapter(FakeIdentity(), contact={"id": "contact-456", "name": "Alice"})
-    # Seed context
-    adapter._outbound_context["txt-out-2"] = {
-        "channel": "sms",
-        "chat_id": "contact-789",  # Different from the contact-456 resolved via fallback
-        "recipient": "+15555550202",
-        "body_snippet": "Hello Alice!",
-        "conversation_id": "conv-456",
-        "email_thread_id": None,
-        "email_subject": None,
-        "at": time.time(),
+def test_sms_send_to_webhook_correlation_flow():
+    contact = {
+        "id": "contact-123",
+        "name": "Kim",
+        "phones": [types.SimpleNamespace(value="+15555550101", is_primary=True)],
     }
+    adapter = _adapter(FakeIdentity(), contact=contact)
+    adapter._inkbox.contacts.get = lambda _cid: types.SimpleNamespace(**contact)
 
-    envelope = _delivery_failed_envelope(text_id="txt-out-2", conversation_id="conv-456")
-    envelope["data"]["text_message"]["remote_phone_number"] = "+15555550202"
-    envelope["data"]["text_message"]["text"] = "Hello Alice! Extra text"
+    # 1. Send SMS via production path
+    result = asyncio.run(adapter.send(
+        chat_id="contact-123",
+        content="Production path SMS content",
+        metadata={"mode": "sms"},
+    ))
+    assert result.success is True
+    msg_id = result.message_id
+    assert msg_id == "txt-1"
+
+    # Verify context is populated automatically
+    assert msg_id in adapter._outbound_context
+    ctx = adapter._outbound_context[msg_id]
+    assert ctx["channel"] == "sms"
+    assert ctx["chat_id"] == "contact-123"
+    assert ctx["body_snippet"] == "Production path SMS content"
+
+    # 2. Receive incomplete webhook failure (direction is omitted, no remote number)
+    envelope = {
+        "id": "evt-text-1",
+        "event_type": "text.delivery_failed",
+        "data": {
+            "text_message": {
+                "id": msg_id,
+                "conversation_id": "conv-123",
+                "text": "Incomplete webhook text",
+                "delivery_status": "delivery_failed",
+                "error_code": "40002",
+                "error_detail": "Flagged by spam",
+            },
+        },
+    }
 
     response = asyncio.run(adapter._on_text_lifecycle(envelope))
     assert response.status == 200
+
+    # Verify the agent was woken in the correct contact session with the original text snippet
     assert len(adapter._enqueued) == 1
     event = adapter._enqueued[0]
-    # Wakes the chat_id from context (contact-789) not the fallback one (contact-456)
-    assert event.source.chat_id == "contact-789"
-    assert "Hello Alice!" in event.text
-    assert "Hello Alice! Extra text" not in event.text  # uses the body_snippet from context
+    assert event.source.chat_id == "contact-123"
+    assert "Production path SMS content" in event.text
+    assert "Incomplete webhook text" not in event.text
+
+    # Verify terminal cleanup: context is removed after failure
+    assert msg_id not in adapter._outbound_context
 
 
 def test_outbound_context_correlation_unresolved_no_wake():
@@ -612,81 +641,152 @@ def test_outbound_context_correlation_unresolved_no_wake():
     assert adapter._enqueued == []  # Not woken
 
 
-def test_outbound_context_correlation_first_imessage():
-    adapter = _adapter(FakeIdentity(), contact={"id": "contact-456", "name": "Alice"})
-    adapter._outbound_context["imsg-out-2"] = {
-        "channel": "imessage",
-        "chat_id": "contact-789",
-        "recipient": "+15555550202",
-        "body_snippet": "iMessage snippet",
-        "conversation_id": "imsg-conv-2",
-        "email_thread_id": None,
-        "email_subject": None,
-        "at": time.time(),
+def test_imessage_send_to_webhook_correlation_flow():
+    contact = {
+        "id": "contact-123",
+        "name": "Kim",
+        "phones": [types.SimpleNamespace(value="+15555550101", is_primary=True)],
     }
+    adapter = _adapter(FakeIdentity(), contact=contact)
+    adapter._inkbox.contacts.get = lambda _cid: types.SimpleNamespace(**contact)
 
-    response = asyncio.run(adapter._on_imessage_lifecycle({
-        "id": "evt-imsg-2",
+    result = asyncio.run(adapter.send(
+        chat_id="contact-123",
+        content="Production path iMessage content",
+        metadata={"mode": "imessage"},
+    ))
+    assert result.success is True
+    msg_id = result.message_id
+    assert msg_id == "txt-1"
+
+    # 2. Receive incomplete webhook failure
+    envelope = {
+        "id": "evt-imsg-1",
         "event_type": "imessage.delivery_failed",
         "data": {
             "message": {
-                "id": "imsg-out-2",
+                "id": msg_id,
                 "direction": "outbound",
-                "remote_number": "+15555550202",
-                "conversation_id": "imsg-conv-2",
-                "content": "Full iMessage body",
+                "content": "Webhook content",
                 "status": "delivery_failed",
                 "error_code": "OPTED_OUT",
-                "error_detail": "Recipient has opted out.",
             },
         },
-    }))
+    }
+
+    response = asyncio.run(adapter._on_imessage_lifecycle(envelope))
     assert response.status == 200
     assert len(adapter._enqueued) == 1
     event = adapter._enqueued[0]
-    assert event.source.chat_id == "contact-789"
-    assert "iMessage snippet" in event.text
-    assert "Full iMessage body" not in event.text
+    assert event.source.chat_id == "contact-123"
+    assert "Production path iMessage content" in event.text
+    assert msg_id not in adapter._outbound_context
 
 
-def test_outbound_context_correlation_first_email():
-    adapter = _adapter(FakeIdentity(), contact={"id": "contact-456", "name": "Alice"})
-    adapter._outbound_context["mail-out-2"] = {
-        "channel": "email",
-        "chat_id": "contact-789",
-        "recipient": "alice@example.com",
-        "body_snippet": "Email body snippet",
-        "conversation_id": None,
-        "email_thread_id": "thread-2",
-        "email_subject": "Proposed Subject",
-        "at": time.time(),
+def test_imessage_media_send_to_webhook_correlation_flow():
+    contact = {
+        "id": "contact-123",
+        "name": "Kim",
+        "phones": [types.SimpleNamespace(value="+15555550101", is_primary=True)],
+    }
+    adapter = _adapter(FakeIdentity(), contact=contact)
+    adapter._inkbox.contacts.get = lambda _cid: types.SimpleNamespace(**contact)
+
+    # send_image routes to _send_imessage_media when mode is imessage and it's a media route
+    result = asyncio.run(adapter.send_image(
+        chat_id="contact-123",
+        image_url="https://example.com/chart.png",
+        caption="Production path iMessage media caption",
+        metadata={"mode": "imessage"},
+    ))
+    assert result.success is True
+    msg_id = result.message_id
+    assert msg_id == "txt-1"
+
+    # 2. Receive incomplete webhook failure
+    envelope = {
+        "id": "evt-imsg-media",
+        "event_type": "imessage.delivery_failed",
+        "data": {
+            "message": {
+                "id": msg_id,
+                "direction": "outbound",
+                "status": "delivery_failed",
+                "error_code": "OPTED_OUT",
+            },
+        },
     }
 
+    response = asyncio.run(adapter._on_imessage_lifecycle(envelope))
+    assert response.status == 200
+    assert len(adapter._enqueued) == 1
+    event = adapter._enqueued[0]
+    assert event.source.chat_id == "contact-123"
+    assert "Production path iMessage media caption" in event.text
+    assert msg_id not in adapter._outbound_context
+
+
+def test_email_send_to_webhook_correlation_flow():
+    contact = {
+        "id": "contact-123",
+        "name": "Kim",
+        "emails": [types.SimpleNamespace(value="kim@example.com", is_primary=True)],
+    }
+    adapter = _adapter(FakeIdentity(), contact=contact)
+    adapter._inkbox.contacts.get = lambda _cid: types.SimpleNamespace(**contact)
+
+    result = asyncio.run(adapter.send(
+        chat_id="contact-123",
+        content="Production path Email content",
+        metadata={
+            "mode": "email",
+            "thread_id": "inkbox-thread-uuid-1",
+        },
+        reply_to="rfc-msg-id-1",
+    ))
+    assert result.success is True
+    msg_id = result.message_id
+    assert msg_id == "mail-1"
+
+    # Verify thread_id and rfc_message_id are stored separately in context
+    assert msg_id in adapter._outbound_context
+    ctx = adapter._outbound_context[msg_id]
+    assert ctx["email_thread_id"] == "inkbox-thread-uuid-1"
+    assert ctx["email_rfc_message_id"] == "rfc-msg-id-1"
+    assert ctx["email_subject"] == "(no subject)"
+
+    # 2. Receive incomplete webhook failure (missing recipient to verify context lookup bypass)
     envelope = {
-        "id": "evt-mail-2",
+        "id": "evt-mail-bounce-1",
         "event_type": "message.bounced",
         "data": {
             "message": {
-                "id": "mail-out-2",
-                "mailbox_id": "mb-1",
-                "thread_id": "thread-fallback",
-                "message_id": "<out-2@inkboxmail.com>",
+                "id": msg_id,
+                "thread_id": "wrong-thread",
+                "message_id": "<wrong-rfc@inkboxmail.com>",
                 "from_address": "agent@inkboxmail.com",
-                "to_addresses": ["alice@example.com"],
-                "subject": "Fallback Subject",
-                "snippet": "Full Email Snippet",
+                "to_addresses": [],  # missing recipient!
+                "subject": "Different Subject",
                 "direction": "outbound",
                 "status": "bounced",
             },
         },
     }
+
     response = asyncio.run(adapter._on_mail_delivery_failure(envelope))
     assert response.status == 200
     assert len(adapter._enqueued) == 1
     event = adapter._enqueued[0]
-    assert event.source.chat_id == "contact-789"
-    assert "email:thread-2" in event.source.thread_id
-    assert "Email body snippet" in event.text
-    assert "Proposed Subject" in event.text
-    assert "Full Email Snippet" not in event.text
+    assert event.source.chat_id == "contact-123"
+    assert event.source.thread_id == "email:inkbox-thread-uuid-1"  # routes to original thread_id
+    assert "Production path Email content" in event.text
+
+    # Verify thread-specific routing state was updated correctly
+    assert adapter._last_inbound_email["contact-123"]["rfc_message_id"] == "rfc-msg-id-1"
+    assert adapter._last_inbound_email["contact-123"]["subject"] == "(no subject)"
+
+    # Verify terminal cleanup
+    assert msg_id not in adapter._outbound_context
+
+
 

--- a/tests/test_delivery_failure_retry.py
+++ b/tests/test_delivery_failure_retry.py
@@ -135,6 +135,7 @@ def _adapter(identity, *, contact=None):
     adapter._last_inbound_sms = {}
     adapter._last_inbound_imessage = {}
     adapter._last_inbound_email = {}
+    adapter._outbound_context = {}
     adapter._stop_imessage_typing = lambda *_a, **_k: None
     adapter._resolve_channel_overrides = lambda *_a, **_k: (None, None)
 
@@ -568,3 +569,124 @@ def test_budget_expires_after_ttl():
 
     assert len(adapter._enqueued) == 2
     assert f"attempt=1/{MAX}" in adapter._enqueued[1].text
+
+
+def test_outbound_context_correlation_first_sms():
+    adapter = _adapter(FakeIdentity(), contact={"id": "contact-456", "name": "Alice"})
+    # Seed context
+    adapter._outbound_context["txt-out-2"] = {
+        "channel": "sms",
+        "chat_id": "contact-789",  # Different from the contact-456 resolved via fallback
+        "recipient": "+15555550202",
+        "body_snippet": "Hello Alice!",
+        "conversation_id": "conv-456",
+        "email_thread_id": None,
+        "email_subject": None,
+        "at": time.time(),
+    }
+
+    envelope = _delivery_failed_envelope(text_id="txt-out-2", conversation_id="conv-456")
+    envelope["data"]["text_message"]["remote_phone_number"] = "+15555550202"
+    envelope["data"]["text_message"]["text"] = "Hello Alice! Extra text"
+
+    response = asyncio.run(adapter._on_text_lifecycle(envelope))
+    assert response.status == 200
+    assert len(adapter._enqueued) == 1
+    event = adapter._enqueued[0]
+    # Wakes the chat_id from context (contact-789) not the fallback one (contact-456)
+    assert event.source.chat_id == "contact-789"
+    assert "Hello Alice!" in event.text
+    assert "Hello Alice! Extra text" not in event.text  # uses the body_snippet from context
+
+
+def test_outbound_context_correlation_unresolved_no_wake():
+    adapter = _adapter(FakeIdentity(), contact=None)
+    # The webhook fails to resolve to any contact (contact=None), and no context exists.
+    # Therefore, no usable thread/session can be resolved.
+    envelope = _delivery_failed_envelope(text_id="txt-unknown", conversation_id="")
+    envelope["data"]["text_message"]["remote_phone_number"] = ""
+    envelope["data"]["text_message"]["recipients"] = []
+
+    response = asyncio.run(adapter._on_text_lifecycle(envelope))
+    assert response.status == 200
+    assert adapter._enqueued == []  # Not woken
+
+
+def test_outbound_context_correlation_first_imessage():
+    adapter = _adapter(FakeIdentity(), contact={"id": "contact-456", "name": "Alice"})
+    adapter._outbound_context["imsg-out-2"] = {
+        "channel": "imessage",
+        "chat_id": "contact-789",
+        "recipient": "+15555550202",
+        "body_snippet": "iMessage snippet",
+        "conversation_id": "imsg-conv-2",
+        "email_thread_id": None,
+        "email_subject": None,
+        "at": time.time(),
+    }
+
+    response = asyncio.run(adapter._on_imessage_lifecycle({
+        "id": "evt-imsg-2",
+        "event_type": "imessage.delivery_failed",
+        "data": {
+            "message": {
+                "id": "imsg-out-2",
+                "direction": "outbound",
+                "remote_number": "+15555550202",
+                "conversation_id": "imsg-conv-2",
+                "content": "Full iMessage body",
+                "status": "delivery_failed",
+                "error_code": "OPTED_OUT",
+                "error_detail": "Recipient has opted out.",
+            },
+        },
+    }))
+    assert response.status == 200
+    assert len(adapter._enqueued) == 1
+    event = adapter._enqueued[0]
+    assert event.source.chat_id == "contact-789"
+    assert "iMessage snippet" in event.text
+    assert "Full iMessage body" not in event.text
+
+
+def test_outbound_context_correlation_first_email():
+    adapter = _adapter(FakeIdentity(), contact={"id": "contact-456", "name": "Alice"})
+    adapter._outbound_context["mail-out-2"] = {
+        "channel": "email",
+        "chat_id": "contact-789",
+        "recipient": "alice@example.com",
+        "body_snippet": "Email body snippet",
+        "conversation_id": None,
+        "email_thread_id": "thread-2",
+        "email_subject": "Proposed Subject",
+        "at": time.time(),
+    }
+
+    envelope = {
+        "id": "evt-mail-2",
+        "event_type": "message.bounced",
+        "data": {
+            "message": {
+                "id": "mail-out-2",
+                "mailbox_id": "mb-1",
+                "thread_id": "thread-fallback",
+                "message_id": "<out-2@inkboxmail.com>",
+                "from_address": "agent@inkboxmail.com",
+                "to_addresses": ["alice@example.com"],
+                "subject": "Fallback Subject",
+                "snippet": "Full Email Snippet",
+                "direction": "outbound",
+                "status": "bounced",
+            },
+        },
+    }
+    response = asyncio.run(adapter._on_mail_delivery_failure(envelope))
+    assert response.status == 200
+    assert len(adapter._enqueued) == 1
+    event = adapter._enqueued[0]
+    assert event.source.chat_id == "contact-789"
+    assert "email:thread-2" in event.source.thread_id
+    assert "Email body snippet" in event.text
+    assert "Proposed Subject" in event.text
+    assert "Full Email Snippet" not in event.text
+

--- a/tools.py
+++ b/tools.py
@@ -450,9 +450,39 @@ def inkbox_send_email(args: dict, **kwargs) -> str:
             )
 
         msg = _send()
+        msg_id = str(getattr(msg, "id", "")).strip()
+        if msg_id:
+            try:
+                from .adapter import save_outbound_context
+            except ImportError:
+                from adapter import save_outbound_context
+
+            # Resolve chat_id
+            recipient = to[0] if to else ""
+            chat_id = None
+            if recipient:
+                try:
+                    contact = _client.contacts.lookup(recipient)
+                    if contact and getattr(contact, "id", None):
+                        chat_id = str(contact.id)
+                except Exception:
+                    pass
+            if not chat_id:
+                chat_id = recipient
+
+            save_outbound_context(
+                msg_id=msg_id,
+                channel="email",
+                chat_id=chat_id,
+                recipient=recipient,
+                body=body_text or "",
+                email_rfc_message_id=in_reply_to or None,
+                email_subject=subject,
+            )
+
         return _json({
             "ok": True,
-            "message_id": str(getattr(msg, "id", "")),
+            "message_id": msg_id,
             "to": to,
             "subject": subject,
         })
@@ -499,9 +529,38 @@ def inkbox_send_sms(args: dict, **kwargs) -> str:
             payload,
             camel_payload,
         )
+        msg_id = str(getattr(msg, "id", "")).strip()
+        if msg_id:
+            try:
+                from .adapter import save_outbound_context
+            except ImportError:
+                from adapter import save_outbound_context
+
+            # Resolve chat_id
+            recipient = to_list[0] if to_list else ""
+            chat_id = None
+            if recipient:
+                try:
+                    contact = _client.contacts.lookup(recipient)
+                    if contact and getattr(contact, "id", None):
+                        chat_id = str(contact.id)
+                except Exception:
+                    pass
+            if not chat_id:
+                chat_id = conversation_id or recipient
+
+            save_outbound_context(
+                msg_id=msg_id,
+                channel="sms",
+                chat_id=chat_id,
+                recipient=recipient,
+                body=text,
+                conversation_id=conversation_id or "",
+            )
+
         return _json({
             "ok": True,
-            "message_id": str(getattr(msg, "id", "")),
+            "message_id": msg_id,
             "conversation_id": conversation_id or object_summary(
                 getattr(msg, "conversation_id", None) or getattr(msg, "conversationId", None)
             ),
@@ -694,9 +753,38 @@ def inkbox_send_imessage(args: dict, **kwargs) -> str:
             payload,
             camel_payload,
         )
+        msg_id = str(getattr(msg, "id", "")).strip()
+        if msg_id:
+            try:
+                from .adapter import save_outbound_context
+            except ImportError:
+                from adapter import save_outbound_context
+
+            # Resolve chat_id
+            recipient = to
+            chat_id = None
+            if recipient:
+                try:
+                    contact = _client.contacts.lookup(recipient)
+                    if contact and getattr(contact, "id", None):
+                        chat_id = str(contact.id)
+                except Exception:
+                    pass
+            if not chat_id:
+                chat_id = conversation_id or recipient
+
+            save_outbound_context(
+                msg_id=msg_id,
+                channel="imessage",
+                chat_id=chat_id,
+                recipient=recipient,
+                body=text or "[media attachment]",
+                conversation_id=conversation_id or "",
+            )
+
         return _json({
             "ok": True,
-            "message_id": str(getattr(msg, "id", "")),
+            "message_id": msg_id,
             "conversation_id": _json_safe(
                 getattr(msg, "conversation_id", None) or getattr(msg, "conversationId", None)
             ),

--- a/tools.py
+++ b/tools.py
@@ -450,39 +450,9 @@ def inkbox_send_email(args: dict, **kwargs) -> str:
             )
 
         msg = _send()
-        msg_id = str(getattr(msg, "id", "")).strip()
-        if msg_id:
-            try:
-                from .adapter import save_outbound_context
-            except ImportError:
-                from adapter import save_outbound_context
-
-            # Resolve chat_id
-            recipient = to[0] if to else ""
-            chat_id = None
-            if recipient:
-                try:
-                    contact = _client.contacts.lookup(recipient)
-                    if contact and getattr(contact, "id", None):
-                        chat_id = str(contact.id)
-                except Exception:
-                    pass
-            if not chat_id:
-                chat_id = recipient
-
-            save_outbound_context(
-                msg_id=msg_id,
-                channel="email",
-                chat_id=chat_id,
-                recipient=recipient,
-                body=body_text or "",
-                email_rfc_message_id=in_reply_to or None,
-                email_subject=subject,
-            )
-
         return _json({
             "ok": True,
-            "message_id": msg_id,
+            "message_id": str(getattr(msg, "id", "")),
             "to": to,
             "subject": subject,
         })
@@ -529,38 +499,9 @@ def inkbox_send_sms(args: dict, **kwargs) -> str:
             payload,
             camel_payload,
         )
-        msg_id = str(getattr(msg, "id", "")).strip()
-        if msg_id:
-            try:
-                from .adapter import save_outbound_context
-            except ImportError:
-                from adapter import save_outbound_context
-
-            # Resolve chat_id
-            recipient = to_list[0] if to_list else ""
-            chat_id = None
-            if recipient:
-                try:
-                    contact = _client.contacts.lookup(recipient)
-                    if contact and getattr(contact, "id", None):
-                        chat_id = str(contact.id)
-                except Exception:
-                    pass
-            if not chat_id:
-                chat_id = conversation_id or recipient
-
-            save_outbound_context(
-                msg_id=msg_id,
-                channel="sms",
-                chat_id=chat_id,
-                recipient=recipient,
-                body=text,
-                conversation_id=conversation_id or "",
-            )
-
         return _json({
             "ok": True,
-            "message_id": msg_id,
+            "message_id": str(getattr(msg, "id", "")),
             "conversation_id": conversation_id or object_summary(
                 getattr(msg, "conversation_id", None) or getattr(msg, "conversationId", None)
             ),
@@ -753,38 +694,9 @@ def inkbox_send_imessage(args: dict, **kwargs) -> str:
             payload,
             camel_payload,
         )
-        msg_id = str(getattr(msg, "id", "")).strip()
-        if msg_id:
-            try:
-                from .adapter import save_outbound_context
-            except ImportError:
-                from adapter import save_outbound_context
-
-            # Resolve chat_id
-            recipient = to
-            chat_id = None
-            if recipient:
-                try:
-                    contact = _client.contacts.lookup(recipient)
-                    if contact and getattr(contact, "id", None):
-                        chat_id = str(contact.id)
-                except Exception:
-                    pass
-            if not chat_id:
-                chat_id = conversation_id or recipient
-
-            save_outbound_context(
-                msg_id=msg_id,
-                channel="imessage",
-                chat_id=chat_id,
-                recipient=recipient,
-                body=text or "[media attachment]",
-                conversation_id=conversation_id or "",
-            )
-
         return _json({
             "ok": True,
-            "message_id": msg_id,
+            "message_id": str(getattr(msg, "id", "")),
             "conversation_id": _json_safe(
                 getattr(msg, "conversation_id", None) or getattr(msg, "conversationId", None)
             ),


### PR DESCRIPTION
Problem
Outbound SMS, iMessage, and email sends can queue successfully but fail downstream. Previously, async delivery webhooks had to reconstruct the contact and conversation session using only the details present in the webhook payload itself. In cases where contact or conversation details were missing or ambiguous in the payload, the webhook could fail to correlate back to the original session, or would not preserve the original outbound message content.

Solution
Implemented outbound delivery context tracking to standardize failed outbound recovery, adhering to the plugin fleet standard for Issue #27:

Outbound Context Store: Added self._outbound_context in InkboxAdapter to track queued outbound messages.
Context Logging on Send: Stored channel, session key chat_id, recipient, original body snippet, SMS/iMessage conversation ID, and email thread/subject metadata on successful sends in send().
Periodic Pruning: Added a prune helper (_prune_outbound_context()) to clean entries older than 2 hours to avoid memory leaks.
Correlation: Updated _on_text_lifecycle, _on_imessage_lifecycle, and _on_mail_delivery_failure to look up context first by message/text ID. When found, it correlates the webhook to the correct original thread/session and restores the original body snippet.
Fallback & Graceful Ignorance: If no context is found, it falls back to payload-based correlation. If no session/thread can be resolved, it logs a warning and acknowledges without waking the agent.
Unit Tests: Added 4 unit tests to 
tests/test_delivery_failure_retry.py
 verifying context-first correlation, no-wake behavior on unresolved sessions, and correlation on SMS, iMessage, and email.
