### PR TITLE
fix: suppress replies to automated email senders

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -884,6 +884,101 @@ def _identity_email_addresses(identity: Any) -> set[str]:
     }
 
 
+_AUTOMATED_EMAIL_LOCAL_PARTS: frozenset[str] = frozenset({
+    "bounce",
+    "do-not-reply",
+    "donotreply",
+    "mailer-daemon",
+    "no-reply",
+    "noreply",
+    "notifications",
+    "postmaster",
+})
+_AUTOMATED_EMAIL_PRECEDENCE_VALUES: frozenset[str] = frozenset({
+    "auto-reply",
+    "auto_reply",
+    "bulk",
+    "junk",
+    "list",
+})
+
+
+def _header_value(container: Any, header_name: str) -> str:
+    target = header_name.strip().lower()
+    if not target:
+        return ""
+    if isinstance(container, dict):
+        for key, value in container.items():
+            if str(key).strip().lower() == target:
+                return str(value or "").strip()
+        return ""
+    if isinstance(container, (list, tuple)):
+        for entry in container:
+            if isinstance(entry, dict):
+                name = str(entry.get("name") or entry.get("key") or "").strip().lower()
+                if name == target:
+                    return str(entry.get("value") or "").strip()
+            elif isinstance(entry, (list, tuple)) and len(entry) >= 2:
+                name = str(entry[0] or "").strip().lower()
+                if name == target:
+                    return str(entry[1] or "").strip()
+    return ""
+
+
+def _mail_header_value(message: Dict[str, Any], envelope: Dict[str, Any], header_name: str) -> str:
+    data = envelope.get("data") if isinstance(envelope.get("data"), dict) else {}
+    for container in (
+        message.get("headers"),
+        message.get("raw_headers"),
+        message.get("internet_message_headers"),
+        message.get("internetMessageHeaders"),
+        message.get("message_headers"),
+        message.get("messageHeaders"),
+        data.get("headers") if isinstance(data, dict) else None,
+        envelope.get("headers"),
+    ):
+        value = _header_value(container, header_name)
+        if value:
+            return value
+    return ""
+
+
+def _looks_automated_email_address(value: Any) -> bool:
+    address = _normalize_email_address(value)
+    if not address:
+        return False
+    local_part, _, domain = address.partition("@")
+    if local_part in _AUTOMATED_EMAIL_LOCAL_PARTS:
+        return True
+    if any(local_part.startswith(f"{prefix}+") for prefix in _AUTOMATED_EMAIL_LOCAL_PARTS):
+        return True
+    if domain == "reply.github.com" and local_part.startswith("reply+"):
+        return True
+    if domain == "github.com" and local_part == "notifications":
+        return True
+    return False
+
+
+def _mail_sender_is_automated(
+    envelope: Dict[str, Any],
+    message: Dict[str, Any],
+    from_address: str,
+) -> bool:
+    if _looks_automated_email_address(from_address):
+        return True
+    auto_submitted = _mail_header_value(message, envelope, "Auto-Submitted").strip().lower()
+    if auto_submitted and auto_submitted != "no":
+        return True
+    precedence = _mail_header_value(message, envelope, "Precedence").strip().lower()
+    if precedence in _AUTOMATED_EMAIL_PRECEDENCE_VALUES:
+        return True
+    if _mail_header_value(message, envelope, "List-Unsubscribe"):
+        return True
+    if _mail_header_value(message, envelope, "Auto-Response-Suppress"):
+        return True
+    return False
+
+
 def _mail_agent_identity_matches(
     envelope: Dict[str, Any],
     from_address: str,
@@ -1398,7 +1493,7 @@ class InkboxAdapter(BasePlatformAdapter):
         # Used by send()'s email branch to populate Re: <subject> and the
         # In-Reply-To header so replies thread into the original conversation
         # in the recipient's mail client.
-        self._last_inbound_email: Dict[str, Dict[str, str]] = {}
+        self._last_inbound_email: Dict[str, Dict[str, Any]] = {}
         # chat_id → metadata of the most-recent inbound SMS for that chat.
         # Used by send()'s SMS branch to reply by Inkbox conversation id
         # instead of reconstructing a phone-number send. This is required for
@@ -2121,6 +2216,15 @@ class InkboxAdapter(BasePlatformAdapter):
                     error=f"No email address on contact {chat_id}",
                 )
 
+            if stash.get("sender_is_automated") or _looks_automated_email_address(to_addr):
+                logger.warning(
+                    "[Inkbox] Suppressed outbound email to automated recipient %s for chat %s",
+                    to_addr,
+                    chat_id,
+                )
+                self._stop_imessage_typing_for_chat(chat_id)
+                return SendResult(success=True, message_id="suppressed-automated-email-recipient")
+
             # Threading: prefer the inbound RFC 5322 Message-ID we stashed in
             # _on_mail_received, fall back to whatever the gateway passed in
             # as ``reply_to``.  Subject defaults to ``Re: <inbound subject>``
@@ -2529,6 +2633,7 @@ class InkboxAdapter(BasePlatformAdapter):
         contact_name = contact["name"] if contact and contact.get("name") else None
         rfc_message_id = message.get("message_id")  # RFC 5322 Message-ID for threading
         subject = message.get("subject") or ""
+        sender_is_automated = _mail_sender_is_automated(envelope, message, from_address)
 
         # Stash the subject + RFC 5322 Message-ID so send() can populate
         # Re: <subject> and the In-Reply-To header on replies.  Keyed by
@@ -2538,6 +2643,7 @@ class InkboxAdapter(BasePlatformAdapter):
             "subject": subject,
             "rfc_message_id": rfc_message_id or "",
             "from_address": from_address,
+            "sender_is_automated": sender_is_automated,
         }
         self._last_inbound_modality[str(chat_id)] = "email"
 

--- a/tests/test_email_self_guard.py
+++ b/tests/test_email_self_guard.py
@@ -13,7 +13,7 @@ from inkbox_plugin import adapter as adapter_mod
 from inkbox_plugin.adapter import InkboxAdapter
 
 
-def _mail_envelope(from_address, *, agent_identities=None):
+def _mail_envelope(from_address, *, agent_identities=None, headers=None):
     return {
         "event_type": "message.received",
         "timestamp": "2026-05-21T00:00:00Z",
@@ -29,6 +29,7 @@ def _mail_envelope(from_address, *, agent_identities=None):
                 "bcc_addresses": None,
                 "subject": "Loop test",
                 "snippet": "Please reply to yourself.",
+                "headers": headers,
                 "direction": "inbound",
                 "status": "received",
                 "has_attachments": False,
@@ -42,6 +43,7 @@ def _mail_envelope(from_address, *, agent_identities=None):
 
 def _adapter_for_self_mail_check():
     adapter = object.__new__(InkboxAdapter)
+    adapter.platform = "inkbox"
     adapter._identity_handle = "agent"
     adapter._identity_id = None
     adapter._identity_email_addresses = {"agent@inkboxmail.com"}
@@ -172,6 +174,42 @@ def test_unknown_inbound_email_uses_thread_session_key(monkeypatch):
     assert events[0].source.thread_id == "email:thread-1"
     assert adapter._last_inbound_modality["email:thread-1"] == "email"
     assert adapter._last_inbound_email["email:thread-1"]["from_address"] == "person@example.com"
+    assert adapter._last_inbound_email["email:thread-1"]["sender_is_automated"] is False
+
+
+def test_automated_inbound_email_marks_thread_non_replyable(monkeypatch):
+    monkeypatch.setattr(
+        adapter_mod,
+        "web",
+        types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
+    )
+    events = []
+
+    async def _resolve_contact_full(**_kwargs):
+        return None
+
+    async def _enqueue(event):
+        events.append(event)
+
+    adapter = _adapter_for_self_mail_check()
+    adapter._resolve_contact_full = _resolve_contact_full
+    adapter._enqueue = _enqueue
+    adapter._last_inbound_email = {}
+    adapter._last_inbound_modality = {}
+    adapter._resolve_channel_overrides = lambda *_args, **_kwargs: (None, None)
+
+    response = asyncio.run(
+        adapter._on_mail_received(
+            _mail_envelope(
+                "updates@example.com",
+                headers=[{"name": "Auto-Submitted", "value": "auto-generated"}],
+            )
+        )
+    )
+
+    assert response.status == 200
+    assert len(events) == 1
+    assert adapter._last_inbound_email["email:thread-1"]["sender_is_automated"] is True
 
 
 def test_email_thread_session_reply_uses_stashed_sender(monkeypatch):
@@ -197,6 +235,7 @@ def test_email_thread_session_reply_uses_stashed_sender(monkeypatch):
     monkeypatch.setattr(adapter_mod.asyncio, "to_thread", _inline_to_thread)
 
     adapter = object.__new__(InkboxAdapter)
+    adapter.platform = "inkbox"
     adapter._identity_handle = "agent"
     adapter._inkbox = FakeInkbox(identity)
     adapter._active_call_ws = {}
@@ -219,3 +258,94 @@ def test_email_thread_session_reply_uses_stashed_sender(monkeypatch):
         "body_text": "Reply body",
         "in_reply_to_message_id": "<mail-in-1@example.com>",
     }]
+
+
+def test_email_thread_reply_to_automated_sender_is_suppressed(monkeypatch):
+    async def _inline_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    class FakeIdentity:
+        def __init__(self):
+            self.sent = []
+
+        def send_email(self, **kwargs):
+            self.sent.append(kwargs)
+            return types.SimpleNamespace(id="msg-out")
+
+    class FakeInkbox:
+        def __init__(self, identity):
+            self.identity = identity
+
+        def get_identity(self, _handle):
+            return self.identity
+
+    identity = FakeIdentity()
+    monkeypatch.setattr(adapter_mod.asyncio, "to_thread", _inline_to_thread)
+
+    adapter = object.__new__(InkboxAdapter)
+    adapter.platform = "inkbox"
+    adapter._identity_handle = "agent"
+    adapter._inkbox = FakeInkbox(identity)
+    adapter._active_call_ws = {}
+    adapter._voice_recently_closed = {}
+    adapter._last_inbound_modality = {"email:thread-1": "email"}
+    adapter._last_inbound_email = {
+        "email:thread-1": {
+            "subject": "Loop test",
+            "rfc_message_id": "<mail-in-1@example.com>",
+            "from_address": "notifications@github.com",
+            "sender_is_automated": True,
+        },
+    }
+    adapter._stop_imessage_typing_for_chat = lambda *_args, **_kwargs: None
+
+    result = asyncio.run(adapter.send("email:thread-1", "Reply body"))
+
+    assert result.success is True
+    assert result.message_id == "suppressed-automated-email-recipient"
+    assert identity.sent == []
+
+
+def test_explicit_automated_email_recipient_is_suppressed(monkeypatch):
+    async def _inline_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    class FakeIdentity:
+        def __init__(self):
+            self.sent = []
+
+        def send_email(self, **kwargs):
+            self.sent.append(kwargs)
+            return types.SimpleNamespace(id="msg-out")
+
+    class FakeInkbox:
+        def __init__(self, identity):
+            self.identity = identity
+
+        def get_identity(self, _handle):
+            return self.identity
+
+    identity = FakeIdentity()
+    monkeypatch.setattr(adapter_mod.asyncio, "to_thread", _inline_to_thread)
+
+    adapter = object.__new__(InkboxAdapter)
+    adapter.platform = "inkbox"
+    adapter._identity_handle = "agent"
+    adapter._inkbox = FakeInkbox(identity)
+    adapter._active_call_ws = {}
+    adapter._voice_recently_closed = {}
+    adapter._last_inbound_modality = {}
+    adapter._last_inbound_email = {}
+    adapter._stop_imessage_typing_for_chat = lambda *_args, **_kwargs: None
+
+    result = asyncio.run(
+        adapter.send(
+            "contact-123",
+            "Reply body",
+            metadata={"mode": "email", "to_email": "no-reply@mail.haft.sh"},
+        )
+    )
+
+    assert result.success is True
+    assert result.message_id == "suppressed-automated-email-recipient"
+    assert identity.sent == []


### PR DESCRIPTION
## Summary
- suppress outbound email replies to obviously automated senders before `identity.send_email(...)`
- mark inbound email threads as non-replyable when the sender or headers indicate an automated source
- add regression tests covering both the inbound classification and outbound suppression paths

## Pain point
When Hermes is reachable by email, automated messages like login codes, GitHub notifications, and delivery-failure mail can wake the agent and then receive an ordinary assistant reply back. That creates bad UX and can turn an operational inbox into an accidental support or bounce loop.

This patch adds a small fail-closed guard in the Inkbox email adapter so the plugin will not send replies back to obvious automated recipients. It relies on generic heuristics only (address patterns and common automation headers) and does not add new config surface.

## Testing
- `python3 -m pytest tests/test_email_self_guard.py -q`

## Follow-ups for maintainer review
- add optional operator-configurable read-only / blocked-recipient lists if maintainers want explicit policy control
- consider a separate change to suppress or reroute automated inbound email before it wakes the agent at all
