### PR TITLE
ci: use gpt-5.4-mini and hang up live calls

### DIFF
--- a/.github/workflows/live-channels.yml
+++ b/.github/workflows/live-channels.yml
@@ -102,7 +102,7 @@ jobs:
             # OPENAI_API_KEY — no known-model alias, no OpenRouter aggregator.
             hermes config set model.provider custom || true
             hermes config set model.base_url https://api.openai.com/v1 || true
-            hermes config set model.default gpt-5.5 || true
+            hermes config set model.default gpt-5.4-mini || true
           else
             {
               echo "OPENAI_API_KEY=sk-mock-not-used"

--- a/.github/workflows/live-external-events.yml
+++ b/.github/workflows/live-external-events.yml
@@ -97,7 +97,7 @@ jobs:
           } >> "$HERMES_HOME/.env"
           hermes config set model.provider custom || true
           hermes config set model.base_url https://api.openai.com/v1 || true
-          hermes config set model.default gpt-5.5 || true
+          hermes config set model.default gpt-5.4-mini || true
 
       - name: Start gateway and wait for readiness
         run: |

--- a/.github/workflows/live-stack.yml
+++ b/.github/workflows/live-stack.yml
@@ -49,7 +49,7 @@ jobs:
       orchestrated: true
       # The inbound PSTN carrier currently rejects the call before it reaches
       # the AUT. Keep that leg manually runnable; gate PRs on plugin-owned voice.
-      include_inbound: false
+      include_inbound: true
     secrets: inherit
 
   external-events:

--- a/.github/workflows/live-stack.yml
+++ b/.github/workflows/live-stack.yml
@@ -47,6 +47,9 @@ jobs:
     uses: ./.github/workflows/live-voice.yml
     with:
       orchestrated: true
+      # The inbound PSTN carrier currently rejects the call before it reaches
+      # the AUT. Keep that leg manually runnable; gate PRs on plugin-owned voice.
+      include_inbound: false
     secrets: inherit
 
   external-events:

--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -97,7 +97,7 @@ jobs:
           # the chat model; send it straight to OpenAI as-is.
           hermes config set model.provider custom || true
           hermes config set model.base_url https://api.openai.com/v1 || true
-          hermes config set model.default gpt-5.5 || true
+          hermes config set model.default gpt-5.4-mini || true
           if [ "${{ matrix.scenario }}" = "inbound_inkbox" ]; then
             echo "INKBOX_REALTIME_ENABLED=false" >> "$HERMES_HOME/.env"
           else

--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -23,11 +23,20 @@ on:
         required: false
         type: boolean
         default: false
+      include_inbound:
+        description: "Run the carrier-dependent inbound PSTN diagnostic"
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       timeout_s:
         description: "Seconds to wait for the call/transcript"
         default: "220"
+      include_inbound:
+        description: "Run the carrier-dependent inbound PSTN diagnostic"
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -45,7 +54,7 @@ jobs:
       fail-fast: false
       max-parallel: 1          # legs share the AUT identity → one at a time
       matrix:
-        scenario: [inbound_inkbox, outbound_realtime, outbound_realtime_contact]
+        scenario: ${{ fromJSON(inputs.include_inbound && '["inbound_inkbox","outbound_realtime","outbound_realtime_contact"]' || '["outbound_realtime","outbound_realtime_contact"]') }}
 
     steps:
       - uses: actions/checkout@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ description = "Inkbox platform plugin for Hermes Agent"
 requires-python = ">=3.11"
 dependencies = [
   "aiohttp>=3.9",
-  "inkbox>=0.4.20,<1.0.0",
+  "inkbox>=0.4.24,<1.0.0",
   "segno>=1.5",
 ]
 

--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -33,6 +33,8 @@ from __future__ import annotations
 
 import os
 import re
+import threading
+import time
 import uuid
 
 import pytest
@@ -60,6 +62,120 @@ def _client(key: str):
     from inkbox import Inkbox
 
     return Inkbox(api_key=key, base_url=BASE_URL)
+
+
+_ENDED_CALL_STATUSES = {"completed", "failed", "canceled"}
+
+
+def _owned_calls(client, local_phone: str):
+    """Newest calls owned by this live identity, keyed by call id."""
+    return {
+        str(call.id): call
+        for call in client.calls.list(limit=100)
+        if getattr(call, "local_phone_number", None) == local_phone
+    }
+
+
+def _call_status(call) -> str:
+    return str(getattr(call, "status", "") or "").lower()
+
+
+def _hang_up_owned_call(client, call) -> str | None:
+    """Send the authoritative hangup command, tolerating an ended-call race."""
+    call_id = str(call.id)
+    if _call_status(call) in _ENDED_CALL_STATUSES:
+        return None
+    try:
+        client.calls.hangup(call_id)
+        return None
+    except Exception as exc:
+        try:
+            current = client.calls.get(call_id)
+        except Exception as get_exc:
+            return f"hangup={exc!r}; get={get_exc!r}"
+        if _call_status(current) in _ENDED_CALL_STATUSES:
+            return None
+        return f"hangup={exc!r}; status={_call_status(current)!r}"
+
+
+def _finish_new_calls(client, local_phone: str, baseline: set[str]) -> None:
+    """Hang up and verify every call created by this pytest session."""
+    deadline = time.monotonic() + 12
+    last_errors: dict[str, str] = {}
+    while True:
+        current = _owned_calls(client, local_phone)
+        live = {
+            call_id: call
+            for call_id, call in current.items()
+            if call_id not in baseline and _call_status(call) not in _ENDED_CALL_STATUSES
+        }
+        if not live:
+            return
+        for call_id, call in live.items():
+            error = _hang_up_owned_call(client, call)
+            if error:
+                last_errors[call_id] = error
+        if time.monotonic() >= deadline:
+            states = {call_id: _call_status(call) for call_id, call in live.items()}
+            raise RuntimeError(
+                f"live-test calls remained active after API cleanup: "
+                f"states={states!r} errors={last_errors!r}"
+            )
+        time.sleep(0.5)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _clean_up_calls_created_by_live_session():
+    """Own all calls created by this live process and never leak a carrier leg.
+
+    Non-voice suites run a watchdog because a model can unexpectedly choose the
+    phone tool while answering an SMS/email test. Voice tests own their expected
+    call ids directly and use this fixture as a final safety net.
+    """
+    if not AUT_KEY:
+        yield
+        return
+
+    client = _client(AUT_KEY)
+    numbers = client.phone_numbers.list()
+    if not numbers:
+        raise RuntimeError("live-test identity has no phone number for call cleanup")
+    local_phone = numbers[0].number
+    baseline = set(_owned_calls(client, local_phone))
+    watch_client = _client(AUT_KEY)
+    voice_session = bool(os.environ.get("VOICE_SCENARIO"))
+    stop = threading.Event()
+
+    def watchdog() -> None:
+        attempted: set[str] = set()
+        while not stop.wait(1):
+            try:
+                current = _owned_calls(watch_client, local_phone)
+            except Exception:
+                continue
+            for call_id, call in current.items():
+                if (
+                    call_id in baseline
+                    or call_id in attempted
+                    or _call_status(call) in _ENDED_CALL_STATUSES
+                ):
+                    continue
+                attempted.add(call_id)
+                _hang_up_owned_call(watch_client, call)
+
+    watcher = None
+    if not voice_session:
+        watcher = threading.Thread(target=watchdog, name="live-call-cleanup", daemon=True)
+        watcher.start()
+    try:
+        yield
+    finally:
+        stop.set()
+        if watcher is not None:
+            watcher.join(timeout=3)
+        # Catch a call created during the last model turn / watcher shutdown.
+        time.sleep(1)
+        _finish_new_calls(client, local_phone, baseline)
 
 
 def _digits(s: str) -> str:

--- a/tests/live/test_sms.py
+++ b/tests/live/test_sms.py
@@ -6,7 +6,7 @@ subject to carrier + spam filtering — so prompts ask for SHORT replies and avo
 spammy content.
 
   * mock leg → reachability (deterministic ``REPLY_OK`` from the mock model).
-  * real leg → intelligence (gpt-5.5): basic, own identity, sender, tools.
+  * real leg → intelligence (gpt-5.4-mini): basic, own identity, sender, tools.
 
 Skipped unless both keys are set. Replies are matched by *new* inbound message id
 from the AUT's number (robust to clock skew).

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -80,6 +80,25 @@ def _aut_phone(aut) -> str:
     return nums[0].number
 
 
+def _ensure_driver_allowed(aut, driver_number: str) -> None:
+    """Allow the live driver through identity-level phone contact rules."""
+    handle = aut.mailboxes.list()[0].email_address.split("@", 1)[0]
+    rules = aut.phone_identity_contact_rules.list(handle)
+    for rule in rules:
+        if (
+            getattr(rule, "match_target", "") == driver_number
+            and str(getattr(rule, "action", "")).lower().endswith("allow")
+            and str(getattr(rule, "status", "active")).lower().endswith("active")
+        ):
+            return
+    aut.phone_identity_contact_rules.create(
+        handle,
+        action="allow",
+        match_type="exact_number",
+        match_target=driver_number,
+    )
+
+
 def _segments(remote, number_id, call_id):
     """Transcript segments for a call, split by who spoke."""
     # Identity-centered transcript read (SDK 0.4.15+); number_id is vestigial.
@@ -128,6 +147,11 @@ def test_inbound_call_inkbox_tts_stt():
     st = _driver_state()
     remote, aut = _client(REMOTE_KEY), _client(AUT_KEY)
     aut_phone = _aut_phone(aut)
+
+    # Server-side contact rules run before the plugin or its local allow-all
+    # setting. Whitelisted smoke identities therefore need the driver allowed
+    # explicitly or the call is rejected before either media WS connects.
+    _ensure_driver_allowed(aut, st["number"])
 
     # Place the call to the agent, handing Inkbox the driver's own media WS.
     call = remote.calls.place(

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -141,6 +141,29 @@ def _aut_speech_mode(aut, direction, driver_number):
     return c.use_inkbox_tts, c.use_inkbox_stt
 
 
+def _hangup_call(client, call_id) -> None:
+    """End a live test call through the control API, tolerating an ended race."""
+    if not call_id:
+        return
+    try:
+        client.calls.hangup(call_id)
+        return
+    except Exception as hangup_error:
+        deadline = time.monotonic() + 10
+        status = "unknown"
+        while time.monotonic() < deadline:
+            try:
+                status = (getattr(client.calls.get(call_id), "status", "") or "").lower()
+            except Exception:
+                status = "unknown"
+            if status in {"completed", "canceled", "failed"}:
+                return
+            time.sleep(0.5)
+        raise RuntimeError(
+            f"failed to hang up live test call {call_id}; status={status!r}"
+        ) from hangup_error
+
+
 @pytest.mark.skipif(SCENARIO != "inbound_inkbox", reason="inbound Inkbox STT/TTS leg only")
 def test_inbound_call_inkbox_tts_stt():
     """Driver calls the agent; the agent answers via Inkbox STT/TTS and replies."""
@@ -157,11 +180,14 @@ def test_inbound_call_inkbox_tts_stt():
     call = remote.calls.place(
         from_number=st["number"], to_number=aut_phone, client_websocket_url=st["ws_url"],
     )
-    agent_said = _wait_for_two_way_call(remote, st["number_id"], call.id)
-    assert agent_said, "agent produced no speech on the inbound call"
+    try:
+        agent_said = _wait_for_two_way_call(remote, st["number_id"], call.id)
+        assert agent_said, "agent produced no speech on the inbound call"
 
-    tts, stt = _aut_speech_mode(aut, "inbound", st["number"])
-    assert tts and stt, f"inbound call should run Inkbox STT/TTS, got tts={tts} stt={stt}"
+        tts, stt = _aut_speech_mode(aut, "inbound", st["number"])
+        assert tts and stt, f"inbound call should run Inkbox STT/TTS, got tts={tts} stt={stt}"
+    finally:
+        _hangup_call(remote, call.id)
 
 
 # Fixed identifiers for the mid-call contact-lookup leg. Fixed (not uuid) so the
@@ -313,14 +339,9 @@ def test_outbound_call_realtime_direct_contact_lookup():
                 break
 
         # Ensure every call actually ends. Realtime sends a `stop` frame, but the
-        # PSTN leg can linger at "answered" — force it closed via the SDK hangup so
-        # it finalizes (and doesn't burn a call slot). Best-effort; already-ended
-        # legs just error out harmlessly.
+        # PSTN leg can linger at "answered" — force it closed via the control API.
         for client, cid in end_ids:
-            try:
-                client.calls.hangup(cid)
-            except Exception:
-                pass
+            _hangup_call(client, cid)
 
         # After teardown the transcript is final — give the recite a last chance
         # to land (in case it persisted on the very last turn).
@@ -383,20 +404,23 @@ def test_outbound_call_realtime():
     before = {c.id for c in _inbound_from_aut()}
     remote.texts.send(st["number_id"], to=aut_phone, text=_call_me_text())
 
-    # Wait for the agent to dial back, then verify the call transcript.
-    deadline = time.monotonic() + TIMEOUT_S
     call_id = None
-    while time.monotonic() < deadline:
-        fresh = [c for c in _inbound_from_aut() if c.id not in before]
-        if fresh:
-            call_id = fresh[0].id
-            break
-        time.sleep(POLL_EVERY_S)
-    assert call_id, f"agent never placed a call back within {TIMEOUT_S:.0f}s"
+    try:
+        # Wait for the agent to dial back, then verify the call transcript.
+        deadline = time.monotonic() + TIMEOUT_S
+        while time.monotonic() < deadline:
+            fresh = [c for c in _inbound_from_aut() if c.id not in before]
+            if fresh:
+                call_id = fresh[0].id
+                break
+            time.sleep(POLL_EVERY_S)
+        assert call_id, f"agent never placed a call back within {TIMEOUT_S:.0f}s"
 
-    agent_said = _wait_for_two_way_call(remote, st["number_id"], call_id)
-    assert agent_said, "agent produced no speech on the outbound call"
+        agent_said = _wait_for_two_way_call(remote, st["number_id"], call_id)
+        assert agent_said, "agent produced no speech on the outbound call"
 
-    tts, stt = _aut_speech_mode(aut, "outbound", st["number"])
-    assert tts is False and stt is False, \
-        f"outbound call must be powered by the realtime API (Inkbox speech off), got tts={tts} stt={stt}"
+        tts, stt = _aut_speech_mode(aut, "outbound", st["number"])
+        assert tts is False and stt is False, \
+            f"outbound call must be powered by the realtime API (Inkbox speech off), got tts={tts} stt={stt}"
+    finally:
+        _hangup_call(remote, call_id)


### PR DESCRIPTION
## Summary

- use gpt-5.4-mini for non-Realtime live intelligence while leaving Realtime media unchanged
- hang up every expected inbound, callback, and contact-aware voice call through `calls.hangup(call_id)`
- snapshot calls owned by each live pytest process, watchdog accidental calls in non-voice suites, and verify every new call is terminal during teardown
- require Inkbox SDK 0.4.24 for the external call-control API
- restore the inbound PSTN leg to required full-stack CI

## Root cause fixed

The voice test finished before the driver's delayed media `stop` frame, and teardown killed the driver. The carrier leg then remained alive until the ten-minute cap. Call records also proved that general channel jobs can unexpectedly choose the phone tool, so cleanup limited to `test_voice.py` was insufficient.

Every live pytest process now owns a baseline of calls. Non-voice suites stop any newly created call within the watchdog interval; voice tests retain direct per-call cleanup and use the session guard as a fallback.

## Validation

- live voice tests compile and all three scenarios collect successfully
- simulated cleanup preserved baseline/other-identity calls and terminated the newly owned call
- workflow YAML and `git diff --check` passed
- the local full suite's unrelated host-version fixture failures remain unchanged
