### PR TITLE
ci: repair Hermes main canary fixtures

### DIFF
--- a/tests/test_email_self_guard.py
+++ b/tests/test_email_self_guard.py
@@ -13,6 +13,12 @@ from inkbox_plugin import adapter as adapter_mod
 from inkbox_plugin.adapter import InkboxAdapter
 
 
+def _new_test_adapter():
+    adapter = object.__new__(InkboxAdapter)
+    adapter.platform = types.SimpleNamespace(value="inkbox")
+    return adapter
+
+
 def _mail_envelope(from_address, *, agent_identities=None):
     return {
         "event_type": "message.received",
@@ -41,7 +47,7 @@ def _mail_envelope(from_address, *, agent_identities=None):
 
 
 def _adapter_for_self_mail_check():
-    adapter = object.__new__(InkboxAdapter)
+    adapter = _new_test_adapter()
     adapter._identity_handle = "agent"
     adapter._identity_id = None
     adapter._identity_email_addresses = {"agent@inkboxmail.com"}
@@ -89,7 +95,7 @@ def test_self_mail_check_caches_identity_with_no_mailbox_address(monkeypatch):
             return types.SimpleNamespace(id="identity-1", mailbox=None, email_address=None)
 
     monkeypatch.setattr(adapter_mod.asyncio, "to_thread", _inline_to_thread)
-    adapter = object.__new__(InkboxAdapter)
+    adapter = _new_test_adapter()
     adapter._identity_handle = "agent"
     adapter._identity_id = None
     adapter._identity_email_addresses = set()
@@ -196,7 +202,7 @@ def test_email_thread_session_reply_uses_stashed_sender(monkeypatch):
     identity = FakeIdentity()
     monkeypatch.setattr(adapter_mod.asyncio, "to_thread", _inline_to_thread)
 
-    adapter = object.__new__(InkboxAdapter)
+    adapter = _new_test_adapter()
     adapter._identity_handle = "agent"
     adapter._inkbox = FakeInkbox(identity)
     adapter._active_call_ws = {}

--- a/tests/test_imessage.py
+++ b/tests/test_imessage.py
@@ -19,6 +19,12 @@ from inkbox_plugin.adapter import (
 )
 
 
+def _new_test_adapter():
+    adapter = object.__new__(InkboxAdapter)
+    adapter.platform = types.SimpleNamespace(value="inkbox")
+    return adapter
+
+
 class FakeIMessage:
     id = "im-1"
     conversation_id = "imconv-123"
@@ -232,7 +238,7 @@ def test_adapter_imessage_reply_uses_last_inbound_conversation_id(monkeypatch):
         return func(*args, **kwargs)
 
     monkeypatch.setattr(adapter_mod.asyncio, "to_thread", _inline_to_thread)
-    adapter = object.__new__(InkboxAdapter)
+    adapter = _new_test_adapter()
     adapter._active_call_ws = {}
     adapter._voice_recently_closed = {}
     adapter._last_inbound_modality = {"contact-123": "imessage"}
@@ -262,7 +268,7 @@ def test_adapter_imessage_channel_uploads_media_file(monkeypatch, tmp_path):
         return func(*args, **kwargs)
 
     monkeypatch.setattr(adapter_mod.asyncio, "to_thread", _inline_to_thread)
-    adapter = object.__new__(InkboxAdapter)
+    adapter = _new_test_adapter()
     adapter._active_call_ws = {}
     adapter._last_inbound_modality = {"contact-123": "imessage"}
     adapter._last_inbound_imessage = {
@@ -303,7 +309,7 @@ def test_adapter_imessage_channel_sends_hosted_media_url(monkeypatch):
         return func(*args, **kwargs)
 
     monkeypatch.setattr(adapter_mod.asyncio, "to_thread", _inline_to_thread)
-    adapter = object.__new__(InkboxAdapter)
+    adapter = _new_test_adapter()
     adapter._active_call_ws = {}
     adapter._last_inbound_modality = {"contact-123": "imessage"}
     adapter._last_inbound_imessage = {
@@ -332,7 +338,7 @@ def test_adapter_imessage_channel_sends_hosted_media_url(monkeypatch):
 
 def test_adapter_imessage_channel_rejects_unsafe_media_path(monkeypatch):
     identity = FakeIdentity()
-    adapter = object.__new__(InkboxAdapter)
+    adapter = _new_test_adapter()
     adapter._active_call_ws = {}
     adapter._last_inbound_modality = {"contact-123": "imessage"}
     adapter._last_inbound_imessage = {}
@@ -353,7 +359,7 @@ def test_adapter_imessage_channel_rejects_unsafe_media_path(monkeypatch):
 
 def test_adapter_imessage_reply_rejects_text_over_limit():
     identity = FakeIdentity()
-    adapter = object.__new__(InkboxAdapter)
+    adapter = _new_test_adapter()
     adapter._active_call_ws = {}
     adapter._voice_recently_closed = {}
     adapter._last_inbound_modality = {"contact-123": "imessage"}
@@ -382,7 +388,7 @@ def test_adapter_imessage_reply_uses_thread_conversation_id(monkeypatch):
         return func(*args, **kwargs)
 
     monkeypatch.setattr(adapter_mod.asyncio, "to_thread", _inline_to_thread)
-    adapter = object.__new__(InkboxAdapter)
+    adapter = _new_test_adapter()
     adapter._active_call_ws = {}
     adapter._voice_recently_closed = {}
     adapter._last_inbound_modality = {"contact-123": "imessage"}
@@ -426,7 +432,7 @@ def test_inbound_imessage_builds_marker_and_stashes_state(monkeypatch):
         "web",
         types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
     )
-    adapter = object.__new__(InkboxAdapter)
+    adapter = _new_test_adapter()
     adapter._inkbox = FakeInkboxClient(identity)
     adapter._identity_handle = "agent"
     adapter._seen_request_ids = {}
@@ -478,7 +484,7 @@ def test_unknown_inbound_imessage_uses_conversation_session_key(monkeypatch):
         "web",
         types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
     )
-    adapter = object.__new__(InkboxAdapter)
+    adapter = _new_test_adapter()
     adapter._inkbox = FakeInkboxClient(identity)
     adapter._identity_handle = "agent"
     adapter._seen_request_ids = {}
@@ -530,7 +536,7 @@ def test_duplicate_inbound_imessage_event_id_does_not_enqueue_twice(monkeypatch)
         "web",
         types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
     )
-    adapter = object.__new__(InkboxAdapter)
+    adapter = _new_test_adapter()
     adapter._inkbox = FakeInkboxClient(identity)
     adapter._identity_handle = "agent"
     adapter._seen_request_ids = {}
@@ -570,7 +576,7 @@ def test_inbound_imessage_ignores_outbound_echo(monkeypatch):
         "web",
         types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
     )
-    adapter = object.__new__(InkboxAdapter)
+    adapter = _new_test_adapter()
     adapter._seen_request_ids = {}
     adapter._enqueue_sms_text_event = _enqueue_sms_text_event
 
@@ -642,7 +648,7 @@ def test_imessage_lifecycle_event_logs_without_agent_turn(monkeypatch):
         "web",
         types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
     )
-    adapter = object.__new__(InkboxAdapter)
+    adapter = _new_test_adapter()
     adapter._enqueue = _enqueue
 
     response = asyncio.run(adapter._on_imessage_lifecycle({
@@ -684,7 +690,7 @@ def test_inbound_imessage_starts_typing_pulse(monkeypatch):
     )
 
     async def _run():
-        adapter = object.__new__(InkboxAdapter)
+        adapter = _new_test_adapter()
         adapter._inkbox = FakeInkboxClient(identity)
         adapter._identity_handle = "agent"
         adapter._seen_request_ids = {}
@@ -736,7 +742,7 @@ def test_inbound_reaction_enqueues_turn_with_silent_policy(monkeypatch):
         "web",
         types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
     )
-    adapter = object.__new__(InkboxAdapter)
+    adapter = _new_test_adapter()
     adapter._inkbox = FakeInkboxClient(identity)
     adapter._identity_handle = "agent"
     adapter._seen_request_ids = {}
@@ -797,7 +803,7 @@ def test_unknown_imessage_reaction_uses_conversation_session_key(monkeypatch):
         "web",
         types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
     )
-    adapter = object.__new__(InkboxAdapter)
+    adapter = _new_test_adapter()
     adapter._inkbox = FakeInkboxClient(identity)
     adapter._identity_handle = "agent"
     adapter._seen_request_ids = {}
@@ -846,7 +852,7 @@ def test_duplicate_imessage_reaction_event_id_does_not_enqueue_twice(monkeypatch
         "web",
         types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
     )
-    adapter = object.__new__(InkboxAdapter)
+    adapter = _new_test_adapter()
     adapter._inkbox = FakeInkboxClient(identity)
     adapter._identity_handle = "agent"
     adapter._seen_request_ids = {}
@@ -892,7 +898,7 @@ def test_inbound_non_question_reaction_does_not_type(monkeypatch):
         "web",
         types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
     )
-    adapter = object.__new__(InkboxAdapter)
+    adapter = _new_test_adapter()
     adapter._inkbox = FakeInkboxClient(identity)
     adapter._identity_handle = "agent"
     adapter._seen_request_ids = {}
@@ -933,7 +939,7 @@ def test_inbound_reaction_ignores_outbound_echo(monkeypatch):
         "web",
         types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
     )
-    adapter = object.__new__(InkboxAdapter)
+    adapter = _new_test_adapter()
     adapter._seen_request_ids = {}
     adapter._enqueue = _enqueue
 

--- a/tests/test_place_call_origination.py
+++ b/tests/test_place_call_origination.py
@@ -7,9 +7,17 @@ to "call me" and the call went out over the dedicated number instead of the
 shared iMessage line.
 """
 
+import sys
 import types
+from pathlib import Path
 
-import tools
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("inkbox_plugin")
+pkg.__path__ = [str(ROOT)]
+sys.modules.setdefault("inkbox_plugin", pkg)
+
+from inkbox_plugin import tools
 
 
 def _identity(has_number: bool, imessage: bool):

--- a/tests/test_realtime_bridge_parity.py
+++ b/tests/test_realtime_bridge_parity.py
@@ -34,6 +34,12 @@ from inkbox_plugin.realtime import (
 )
 
 
+def _new_test_adapter():
+    adapter = adapter_mod.InkboxAdapter.__new__(adapter_mod.InkboxAdapter)
+    adapter.platform = types.SimpleNamespace(value="inkbox")
+    return adapter
+
+
 if realtime_mod.aiohttp is None:
     realtime_mod.aiohttp = types.SimpleNamespace(
         WSMsgType=types.SimpleNamespace(
@@ -712,7 +718,7 @@ def test_agent_consult_allows_explicit_repeat_sms_request():
 
 
 def test_adapter_realtime_call_ended_enqueues_reflection():
-    adapter = adapter_mod.InkboxAdapter.__new__(adapter_mod.InkboxAdapter)
+    adapter = _new_test_adapter()
     events = []
 
     async def _enqueue(event):
@@ -734,7 +740,7 @@ def test_adapter_realtime_call_ended_enqueues_reflection():
 
 
 def test_adapter_realtime_post_call_actions_enqueues_without_auto_skill():
-    adapter = adapter_mod.InkboxAdapter.__new__(adapter_mod.InkboxAdapter)
+    adapter = _new_test_adapter()
     events = []
 
     async def _enqueue(event):

--- a/tests/test_sms_conversations.py
+++ b/tests/test_sms_conversations.py
@@ -15,6 +15,12 @@ from inkbox_plugin import tools
 from inkbox_plugin.adapter import InkboxAdapter, send_inkbox_direct
 
 
+def _new_test_adapter():
+    adapter = object.__new__(InkboxAdapter)
+    adapter.platform = types.SimpleNamespace(value="inkbox")
+    return adapter
+
+
 class FakeText:
     id = "txt-1"
     delivery_status = "queued"
@@ -110,7 +116,7 @@ def test_adapter_sms_reply_uses_last_inbound_conversation_id(monkeypatch):
         return func(*args, **kwargs)
 
     monkeypatch.setattr(adapter_mod.asyncio, "to_thread", _inline_to_thread)
-    adapter = object.__new__(InkboxAdapter)
+    adapter = _new_test_adapter()
     adapter._active_call_ws = {}
     adapter._voice_recently_closed = {}
     adapter._last_inbound_modality = {"contact-123": "sms"}
@@ -132,7 +138,7 @@ def test_adapter_sms_reply_uses_last_inbound_conversation_id(monkeypatch):
 
 def test_adapter_sms_reply_rejects_text_over_limit():
     identity = FakeIdentity()
-    adapter = object.__new__(InkboxAdapter)
+    adapter = _new_test_adapter()
     adapter._active_call_ws = {}
     adapter._voice_recently_closed = {}
     adapter._last_inbound_modality = {"contact-123": "sms"}
@@ -161,7 +167,7 @@ def test_adapter_sms_reply_uses_thread_conversation_id(monkeypatch):
         return func(*args, **kwargs)
 
     monkeypatch.setattr(adapter_mod.asyncio, "to_thread", _inline_to_thread)
-    adapter = object.__new__(InkboxAdapter)
+    adapter = _new_test_adapter()
     adapter._active_call_ws = {}
     adapter._voice_recently_closed = {}
     adapter._last_inbound_modality = {"contact-123": "sms"}
@@ -205,7 +211,7 @@ def test_inbound_group_sms_injects_silence_policy(monkeypatch):
         "web",
         types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
     )
-    adapter = object.__new__(InkboxAdapter)
+    adapter = _new_test_adapter()
     adapter._inkbox = FakeInkboxClient(identity)
     adapter._identity_handle = "agent"
     adapter._seen_request_ids = {}
@@ -260,7 +266,7 @@ def test_unknown_inbound_sms_uses_conversation_session_key(monkeypatch):
         "web",
         types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
     )
-    adapter = object.__new__(InkboxAdapter)
+    adapter = _new_test_adapter()
     adapter._inkbox = FakeInkboxClient(identity)
     adapter._identity_handle = "agent"
     adapter._seen_request_ids = {}
@@ -309,7 +315,7 @@ def test_duplicate_inbound_sms_event_id_does_not_enqueue_twice(monkeypatch):
         "web",
         types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
     )
-    adapter = object.__new__(InkboxAdapter)
+    adapter = _new_test_adapter()
     adapter._inkbox = FakeInkboxClient(identity)
     adapter._identity_handle = "agent"
     adapter._seen_request_ids = {}

--- a/uv.lock
+++ b/uv.lock
@@ -501,7 +501,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9" },
-    { name = "inkbox", specifier = ">=0.4.20,<1.0.0" },
+    { name = "inkbox", specifier = ">=0.4.24,<1.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
     { name = "ruff", marker = "extra == 'test'", specifier = ">=0.11.0" },
     { name = "segno", specifier = ">=1.5" },


### PR DESCRIPTION
## Summary

- initialize constructor-bypassing adapter fixtures with the platform state required by current Hermes
- import the plugin's `tools` module explicitly so Hermes' host module cannot shadow it
- sync the Inkbox requirement recorded in `uv.lock` with `pyproject.toml`

## Root cause

Hermes `main` now reads `adapter.platform` while building every `SessionSource`. Several tests created adapters with `object.__new__`, bypassing both `InkboxAdapter.__init__` and `BasePlatformAdapter.__init__`, so the fixture no longer represented a valid adapter.

Separately, `test_place_call_origination.py` used bare `import tools`. When the real Hermes host was installed, its top-level `tools` module already occupied `sys.modules["tools"]`, so the tests called the wrong module.

## Validation

- `uv run ruff check .`
- offline suite: 241 passed, 24 skipped
- exact canary against Hermes `main` at `b27d8b6`: 253 passed, 23 skipped
- `git diff --check`
