### PR TITLE
Isolate canary imports from flat plugin modules

### DIFF
--- a/.github/workflows/live-channels.yml
+++ b/.github/workflows/live-channels.yml
@@ -154,11 +154,12 @@ jobs:
           LIVE_EMAIL_TIMEOUT: ${{ inputs.timeout_s || '150' }}
         run: |
           PY="$HERMES_HOME/hermes-agent/venv/bin/python3"
+          PYTEST="$HERMES_HOME/hermes-agent/venv/bin/pytest"
           "$HERMES_HOME/bin/uv" pip install --python "$PY" pytest pyyaml
           if [ "${{ matrix.mode }}" = "real" ]; then
-            LIVE_REAL_MODEL=1 "$PY" -m pytest tests/live -v
+            LIVE_REAL_MODEL=1 "$PYTEST" tests/live -v
           else
-            "$PY" -m pytest tests/live -v
+            "$PYTEST" tests/live -v
           fi
 
       # Failure-only: these logs carry live phone/email/message content and this repo

--- a/.github/workflows/live-external-events.yml
+++ b/.github/workflows/live-external-events.yml
@@ -120,10 +120,11 @@ jobs:
           LIVE_EXTERNAL_TIMEOUT: ${{ inputs.timeout_s || '45' }}
         run: |
           PY="$HERMES_HOME/hermes-agent/venv/bin/python3"
+          PYTEST="$HERMES_HOME/hermes-agent/venv/bin/pytest"
           "$HERMES_HOME/bin/uv" pip install --python "$PY" pytest
           # Inkbox-signed escalation + GitHub-signed (valid & forged) escalation.
           LIVE_REAL_MODEL=1 AUT_WEBHOOK_URL=http://127.0.0.1:8765/webhook \
-            "$PY" -m pytest \
+            "$PYTEST" \
               tests/live/test_external_event_intelligence.py \
               tests/live/test_external_event_github.py -v
 

--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -156,9 +156,10 @@ jobs:
           LIVE_VOICE_TIMEOUT: ${{ inputs.timeout_s || '220' }}
         run: |
           PY="$HERMES_HOME/hermes-agent/venv/bin/python3"
+          PYTEST="$HERMES_HOME/hermes-agent/venv/bin/pytest"
           "$HERMES_HOME/bin/uv" pip install --python "$PY" pytest
           LIVE_REAL_MODEL=1 VOICE_DRIVER_STATE="$DRIVER_STATE" \
-            "$PY" -m pytest tests/live/test_voice.py -v
+            "$PYTEST" tests/live/test_voice.py -v
 
       # Failure-only: these logs carry live call content and this repo is public.
       - name: Dump logs (on failure only)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,4 +31,4 @@ line-length = 125
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-pythonpath = ["."]
+addopts = ["--import-mode=importlib"]

--- a/tests/test_ci_import_isolation.py
+++ b/tests/test_ci_import_isolation.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize(
+    "workflow_name",
+    ["live-channels.yml", "live-voice.yml", "live-external-events.yml"],
+)
+def test_live_workflow_uses_isolated_pytest_entrypoint(workflow_name):
+    workflow = (ROOT / ".github" / "workflows" / workflow_name).read_text()
+
+    assert 'PYTEST="$HERMES_HOME/hermes-agent/venv/bin/pytest"' in workflow
+    assert '"$PY" -m pytest' not in workflow


### PR DESCRIPTION
## Decisions

- **Import isolation:** Chose pytest importlib mode instead of renaming runtime plugin modules or pinning the host because the canary should continue validating the current host without allowing the flat plugin layout to shadow host packages.
- **Live runner:** Invoke the installed pytest entrypoint directly because `python -m pytest` adds the repository root before host packages and recreates the same collision in every live suite.

## Changes

- Run the test suite in importlib mode.
- Remove the repository-root path injection that allowed plugin modules to override host imports.
- Use the isolated pytest entrypoint in channel, voice, and external-event workflows.
- Add a regression test covering all live workflow entrypoints.

## Verification

- Reproduced 15 collection errors with the previous canary configuration against the current host.
- Reproduced the same collision in the full-stack live runner and verified direct pytest entrypoint collection succeeds.
- `uv run pytest -q` — 261 passed, 23 skipped against the current host.
- `uv run ruff check .` — passed.
- All workflow YAML parsed successfully.
- `git diff --check`.
- Canary run 29713665019 passed against the latest Hermes main.
- Full-stack run 29712928416 passed: mock channels, real channels, inbound voice, both outbound voice variants, external events, and the aggregate gate.
- PR unit checks passed on Python 3.11 and 3.12; the current-host contract check passed.