### PR TITLE
Remove paused contact-rule guidance

### DIFF
--- a/skills/inkbox-contact-rules/SKILL.md
+++ b/skills/inkbox-contact-rules/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inkbox-contact-rules
-description: Use when the user wants to block, allow, pause, delete, or list Inkbox contact-rule filters for the agent's mailbox or phone number. Hermes does not expose contact-rule edit tools; guide the user to Inkbox Console or explain the limitation.
+description: Use when the user wants to block, allow, delete, or list Inkbox contact-rule filters for the agent's mailbox or phone number. Hermes does not expose contact-rule edit tools; guide the user to Inkbox Console or explain the limitation.
 user-invocable: false
 ---
 
@@ -26,8 +26,7 @@ Use this skill when discussing who can reach the agent's Inkbox mailbox or phone
 3. For phone rules, explain the intended settings:
    - `matchType: "exact_number"` for E.164 numbers.
    - Rules apply to SMS and voice calls for that phone number.
-4. Mention that `status: "paused"` can temporarily disable a rule without deleting it if Console exposes that option.
-5. Explain that blocked inbound messages/calls may be rejected before the agent sees an event.
+4. Explain that blocked inbound messages/calls may be rejected before the agent sees an event.
 
 ## Safety
 


### PR DESCRIPTION
## Decisions

- Stop directing users toward paused contact-rule lifecycle controls.
- Continue directing contact-rule mutations to the supported console workflow.
- Align with the public SDK contract in https://github.com/inkbox-ai/inkbox/pull/120.

## Changes

- Removes pause from the contact-rule skill trigger description.
- Removes guidance suggesting a paused status setting.

## Verification

- Ruff passed.
- Full pytest result: 250 passed, 24 skipped.
- Confirmed the contact-rule skill contains no paused write guidance.
- git diff --check passed.