### PR TITLE
Fix Hermes main installation in CI

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Install test deps + real Hermes host (main)
         run: |
           uv sync --extra test --python 3.12
-          uv pip install "hermes-agent @ git+https://github.com/NousResearch/hermes-agent.git@main"
+          git clone --depth 1 https://github.com/NousResearch/hermes-agent.git "$RUNNER_TEMP/hermes-agent"
+          uv pip install --editable "$RUNNER_TEMP/hermes-agent"
 
       - name: Complete offline suite vs real Hermes main
         run: uv run pytest -q

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,7 +69,8 @@ jobs:
           uv pip install \
             "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@199bbd27c8dab2f70e379de52ca9cc910b0e141d#subdirectory=sdk/python" \
             'aiohttp>=3.9' 'segno>=1.5' 'pytest>=8' 'ruff>=0.11.0'
-          uv pip install "hermes-agent @ git+https://github.com/NousResearch/hermes-agent.git@main"
+          git clone --depth 1 https://github.com/NousResearch/hermes-agent.git "$RUNNER_TEMP/hermes-agent"
+          uv pip install --editable "$RUNNER_TEMP/hermes-agent"
 
       - name: Contract tests vs real Hermes main
         run: .venv/bin/pytest --override-ini pythonpath= --import-mode=importlib tests/contract -v


### PR DESCRIPTION
## Decisions

- **Hermes installation:** Keep testing upstream `main`, but use its supported editable-install path now that wheel and sdist builds are intentionally disabled.

## Changes

- Clone Hermes `main` into the runner temporary directory.
- Install the checkout editable in both the scheduled canary and per-PR contract job.

## Verification

- Fresh editable install from current Hermes `main`.
- Full plugin suite: `262 passed, 23 skipped`.
- Host contract suite: `12 passed`.
- `git diff --check`.