### PR TITLE
Hermes: serve Inkbox A2A tasks

### DIFF
--- a/.github/workflows/live-channels.yml
+++ b/.github/workflows/live-channels.yml
@@ -68,7 +68,7 @@ jobs:
           ln -sfn "$GITHUB_WORKSPACE" "$HERMES_HOME/plugins/inkbox"
           hermes plugins enable inkbox
           "$HERMES_HOME/bin/uv" pip install --python "$HERMES_HOME/hermes-agent/venv/bin/python3" \
-            'inkbox>=0.5.1,<1.0.0' 'aiohttp>=3.9' 'segno>=1.5'
+            'inkbox>=0.5.6,<1.0.0' 'aiohttp>=3.9' 'segno>=1.5'
 
       - name: Configure AUT identity + model (${{ matrix.mode }})
         env:

--- a/.github/workflows/live-channels.yml
+++ b/.github/workflows/live-channels.yml
@@ -68,7 +68,8 @@ jobs:
           ln -sfn "$GITHUB_WORKSPACE" "$HERMES_HOME/plugins/inkbox"
           hermes plugins enable inkbox
           "$HERMES_HOME/bin/uv" pip install --python "$HERMES_HOME/hermes-agent/venv/bin/python3" \
-            'inkbox>=0.5.6,<1.0.0' 'aiohttp>=3.9' 'segno>=1.5'
+            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@fdea6e55ac117f246624852aedeef0feabe08b9a#subdirectory=sdk/python" \
+            'aiohttp>=3.9' 'segno>=1.5'
 
       - name: Configure AUT identity + model (${{ matrix.mode }})
         env:

--- a/.github/workflows/live-channels.yml
+++ b/.github/workflows/live-channels.yml
@@ -68,7 +68,7 @@ jobs:
           ln -sfn "$GITHUB_WORKSPACE" "$HERMES_HOME/plugins/inkbox"
           hermes plugins enable inkbox
           "$HERMES_HOME/bin/uv" pip install --python "$HERMES_HOME/hermes-agent/venv/bin/python3" \
-            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@fdea6e55ac117f246624852aedeef0feabe08b9a#subdirectory=sdk/python" \
+            'inkbox>=0.5.6,<1.0.0' \
             'aiohttp>=3.9' 'segno>=1.5'
 
       - name: Configure AUT identity + model (${{ matrix.mode }})

--- a/.github/workflows/live-external-events.yml
+++ b/.github/workflows/live-external-events.yml
@@ -58,7 +58,7 @@ jobs:
           ln -sfn "$GITHUB_WORKSPACE" "$HERMES_HOME/plugins/inkbox"
           hermes plugins enable inkbox
           "$HERMES_HOME/bin/uv" pip install --python "$HERMES_HOME/hermes-agent/venv/bin/python3" \
-            'inkbox>=0.5.1,<1.0.0' 'aiohttp>=3.9' 'segno>=1.5'
+            'inkbox>=0.5.6,<1.0.0' 'aiohttp>=3.9' 'segno>=1.5'
 
       - name: Configure AUT identity + model
         env:

--- a/.github/workflows/live-external-events.yml
+++ b/.github/workflows/live-external-events.yml
@@ -58,7 +58,8 @@ jobs:
           ln -sfn "$GITHUB_WORKSPACE" "$HERMES_HOME/plugins/inkbox"
           hermes plugins enable inkbox
           "$HERMES_HOME/bin/uv" pip install --python "$HERMES_HOME/hermes-agent/venv/bin/python3" \
-            'inkbox>=0.5.6,<1.0.0' 'aiohttp>=3.9' 'segno>=1.5'
+            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@fdea6e55ac117f246624852aedeef0feabe08b9a#subdirectory=sdk/python" \
+            'aiohttp>=3.9' 'segno>=1.5'
 
       - name: Configure AUT identity + model
         env:

--- a/.github/workflows/live-external-events.yml
+++ b/.github/workflows/live-external-events.yml
@@ -58,7 +58,7 @@ jobs:
           ln -sfn "$GITHUB_WORKSPACE" "$HERMES_HOME/plugins/inkbox"
           hermes plugins enable inkbox
           "$HERMES_HOME/bin/uv" pip install --python "$HERMES_HOME/hermes-agent/venv/bin/python3" \
-            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@fdea6e55ac117f246624852aedeef0feabe08b9a#subdirectory=sdk/python" \
+            'inkbox>=0.5.6,<1.0.0' \
             'aiohttp>=3.9' 'segno>=1.5'
 
       - name: Configure AUT identity + model

--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -77,7 +77,8 @@ jobs:
           ln -sfn "$GITHUB_WORKSPACE" "$HERMES_HOME/plugins/inkbox"
           hermes plugins enable inkbox
           "$HERMES_HOME/bin/uv" pip install --python "$HERMES_HOME/hermes-agent/venv/bin/python3" \
-            'inkbox>=0.5.6,<1.0.0' 'aiohttp>=3.9' 'segno>=1.5' fastapi uvicorn
+            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@fdea6e55ac117f246624852aedeef0feabe08b9a#subdirectory=sdk/python" \
+            'aiohttp>=3.9' 'segno>=1.5' fastapi uvicorn
 
       - name: Configure AUT identity + model + speech path (${{ matrix.scenario }})
         env:

--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -77,7 +77,7 @@ jobs:
           ln -sfn "$GITHUB_WORKSPACE" "$HERMES_HOME/plugins/inkbox"
           hermes plugins enable inkbox
           "$HERMES_HOME/bin/uv" pip install --python "$HERMES_HOME/hermes-agent/venv/bin/python3" \
-            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@fdea6e55ac117f246624852aedeef0feabe08b9a#subdirectory=sdk/python" \
+            'inkbox>=0.5.6,<1.0.0' \
             'aiohttp>=3.9' 'segno>=1.5' fastapi uvicorn
 
       - name: Configure AUT identity + model + speech path (${{ matrix.scenario }})

--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -77,7 +77,7 @@ jobs:
           ln -sfn "$GITHUB_WORKSPACE" "$HERMES_HOME/plugins/inkbox"
           hermes plugins enable inkbox
           "$HERMES_HOME/bin/uv" pip install --python "$HERMES_HOME/hermes-agent/venv/bin/python3" \
-            'inkbox>=0.5.1,<1.0.0' 'aiohttp>=3.9' 'segno>=1.5' fastapi uvicorn
+            'inkbox>=0.5.6,<1.0.0' 'aiohttp>=3.9' 'segno>=1.5' fastapi uvicorn
 
       - name: Configure AUT identity + model + speech path (${{ matrix.scenario }})
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
           uv venv --python ${{ matrix.python-version }}
           uv pip install \
             "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@199bbd27c8dab2f70e379de52ca9cc910b0e141d#subdirectory=sdk/python" \
-            'aiohttp>=3.9' 'segno>=1.5' 'pytest>=8' 'ruff>=0.11.0'
+            'aiohttp>=3.9' 'segno>=1.5' 'pytest>=8' 'ruff>=0.11.0,<0.16'
 
       - name: Lint
         run: .venv/bin/ruff check .
@@ -68,7 +68,7 @@ jobs:
           uv venv --python 3.12
           uv pip install \
             "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@199bbd27c8dab2f70e379de52ca9cc910b0e141d#subdirectory=sdk/python" \
-            'aiohttp>=3.9' 'segno>=1.5' 'pytest>=8' 'ruff>=0.11.0'
+            'aiohttp>=3.9' 'segno>=1.5' 'pytest>=8' 'ruff>=0.11.0,<0.16'
           git clone --depth 1 https://github.com/NousResearch/hermes-agent.git "$RUNNER_TEMP/hermes-agent"
           uv pip install --editable "$RUNNER_TEMP/hermes-agent"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           uv venv --python ${{ matrix.python-version }}
           uv pip install \
-            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@199bbd27c8dab2f70e379de52ca9cc910b0e141d#subdirectory=sdk/python" \
+            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@fdea6e55ac117f246624852aedeef0feabe08b9a#subdirectory=sdk/python" \
             'aiohttp>=3.9' 'segno>=1.5' 'pytest>=8' 'ruff>=0.11.0,<0.16'
 
       - name: Lint
@@ -67,7 +67,7 @@ jobs:
         run: |
           uv venv --python 3.12
           uv pip install \
-            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@199bbd27c8dab2f70e379de52ca9cc910b0e141d#subdirectory=sdk/python" \
+            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@fdea6e55ac117f246624852aedeef0feabe08b9a#subdirectory=sdk/python" \
             'aiohttp>=3.9' 'segno>=1.5' 'pytest>=8' 'ruff>=0.11.0,<0.16'
           git clone --depth 1 https://github.com/NousResearch/hermes-agent.git "$RUNNER_TEMP/hermes-agent"
           uv pip install --editable "$RUNNER_TEMP/hermes-agent"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           uv venv --python ${{ matrix.python-version }}
           uv pip install \
-            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@fdea6e55ac117f246624852aedeef0feabe08b9a#subdirectory=sdk/python" \
+            'inkbox>=0.5.6,<1.0.0' \
             'aiohttp>=3.9' 'segno>=1.5' 'pytest>=8' 'ruff>=0.11.0,<0.16'
 
       - name: Lint
@@ -67,10 +67,16 @@ jobs:
         run: |
           uv venv --python 3.12
           uv pip install \
-            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@fdea6e55ac117f246624852aedeef0feabe08b9a#subdirectory=sdk/python" \
+            'inkbox>=0.5.6,<1.0.0' \
             'aiohttp>=3.9' 'segno>=1.5' 'pytest>=8' 'ruff>=0.11.0,<0.16'
           git clone --depth 1 https://github.com/NousResearch/hermes-agent.git "$RUNNER_TEMP/hermes-agent"
           uv pip install --editable "$RUNNER_TEMP/hermes-agent"
 
       - name: Contract tests vs real Hermes main
-        run: .venv/bin/pytest --override-ini pythonpath= --import-mode=importlib tests/contract -v
+        working-directory: ${{ runner.temp }}
+        run: |
+          "$GITHUB_WORKSPACE/.venv/bin/python" -m pytest \
+            --rootdir="$GITHUB_WORKSPACE" \
+            --override-ini pythonpath= \
+            --import-mode=importlib \
+            "$GITHUB_WORKSPACE/tests/contract" -v

--- a/README.md
+++ b/README.md
@@ -301,12 +301,20 @@ Hermes direct tools:
 - `inkbox_send_imessage_reaction`
 - `inkbox_mark_imessage_conversation_read`
 - `inkbox_place_call`
+- `inkbox_a2a_complete`
+- `inkbox_a2a_ask_caller`
+- `inkbox_a2a_fail`
 - `inkbox_lookup_contact`
 - `inkbox_list_contacts`
 - `inkbox_get_contact`
 - `inkbox_create_contact`
 - `inkbox_update_contact`
 - `inkbox_delete_contact`
+
+Inbound A2A tasks use isolated context sessions and a durable task registry.
+The three A2A outcome tools are accepted only during a verified inbound A2A
+turn. A2A serving requires Inkbox SDK 0.5.5 or newer; the rest of the plugin
+continues to support the base SDK range shown above.
 
 Realtime-only call tools:
 

--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ Hermes direct tools:
 - `inkbox_a2a_complete`
 - `inkbox_a2a_ask_caller`
 - `inkbox_a2a_fail`
+- `inkbox_list_a2a_sent_tasks`
+- `inkbox_get_a2a_sent_task`
 - `inkbox_lookup_contact`
 - `inkbox_list_contacts`
 - `inkbox_get_contact`

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ hermes gateway restart
 
 `hermes inkbox setup` walks the active Hermes install through Inkbox configuration:
 
-1. Installs or upgrades `inkbox>=0.5.1,<1.0.0` and `aiohttp>=3.9` in the Hermes Python environment when needed.
+1. Installs or upgrades `inkbox>=0.5.6,<1.0.0` and `aiohttp>=3.9` in the Hermes Python environment when needed.
 2. Authenticates to Inkbox, or starts self-signup if you do not have an API key yet.
 3. Resolves or creates the Inkbox agent identity for this Hermes gateway.
 4. Optionally provisions a local US phone number so SMS and voice are available.
@@ -96,13 +96,13 @@ The setup wizard installs dependencies into the Python environment that runs Her
 If the wizard prints a missing-SDK warning, use the exact command it prints. It will look like this:
 
 ```bash
-/path/to/hermes/venv/bin/python3 -m pip install 'inkbox>=0.5.1,<1.0.0' 'aiohttp>=3.9'
+/path/to/hermes/venv/bin/python3 -m pip install 'inkbox>=0.5.6,<1.0.0' 'aiohttp>=3.9'
 ```
 
 When `uv` is available, the wizard prefers:
 
 ```bash
-uv pip install --python /path/to/hermes/venv/bin/python3 'inkbox>=0.5.1,<1.0.0' 'aiohttp>=3.9'
+uv pip install --python /path/to/hermes/venv/bin/python3 'inkbox>=0.5.6,<1.0.0' 'aiohttp>=3.9'
 ```
 
 Do not use plain `pip install inkbox aiohttp` unless the wizard tells you to; plain `pip` may point at pyenv, Homebrew, system Python, or another virtualenv.
@@ -304,6 +304,8 @@ Hermes direct tools:
 - `inkbox_a2a_complete`
 - `inkbox_a2a_ask_caller`
 - `inkbox_a2a_fail`
+- `inkbox_list_a2a_tasks`
+- `inkbox_list_a2a_messages`
 - `inkbox_list_a2a_sent_tasks`
 - `inkbox_get_a2a_sent_task`
 - `inkbox_lookup_contact`
@@ -315,8 +317,9 @@ Hermes direct tools:
 
 Inbound A2A tasks use isolated context sessions and a durable task registry.
 The three A2A outcome tools are accepted only during a verified inbound A2A
-turn. A2A serving requires Inkbox SDK 0.5.5 or newer; the rest of the plugin
-continues to support the base SDK range shown above.
+turn. The history tools support direction, participant, lifecycle, context,
+keyword, timestamp, and cursor filters. The sent-task tools remain available as
+outbound-only compatibility aliases. The plugin requires Inkbox SDK 0.5.6 or newer.
 
 Realtime-only call tools:
 

--- a/__init__.py
+++ b/__init__.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 try:
+    from .a2a_context import activate_next_a2a_turn_context
     from .adapter import InkboxAdapter, check_inkbox_requirements, send_inkbox_direct
     from .cli import setup_argparse, handle_cli, slash_handler
     from .config import read_config
@@ -42,6 +43,9 @@ except ImportError:  # pragma: no cover - direct local import/test fallback
     SETUP_HINT = _diagnostics.SETUP_HINT
     interactive_setup = _setup_wizard.interactive_setup
     register_tools = _tools.register_tools
+    activate_next_a2a_turn_context = importlib.import_module(
+        f"{_LOCAL_PACKAGE}.a2a_context"
+    ).activate_next_a2a_turn_context
 
 logger = logging.getLogger(__name__)
 _unconfigured_warning_emitted = False
@@ -194,6 +198,12 @@ def register(ctx) -> None:
         ),
     )
     register_tools(ctx)
+    ctx.register_hook(
+        "pre_llm_call",
+        lambda session_id="", **_kwargs: activate_next_a2a_turn_context(
+            str(session_id)
+        ),
+    )
     ctx.register_cli_command(
         name="inkbox",
         help="Inkbox plugin commands",

--- a/a2a_context.py
+++ b/a2a_context.py
@@ -1,0 +1,58 @@
+"""Trusted turn context for inbound Inkbox A2A tasks."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+def _context_root() -> Path:
+    try:
+        from hermes_cli.config import get_hermes_home
+
+        home = Path(get_hermes_home())
+    except ImportError:  # pragma: no cover - local import/test fallback
+        configured = os.getenv("HERMES_HOME")
+        home = Path(configured).expanduser() if configured else Path.home() / ".hermes"
+    root = home / "inkbox_a2a_turn_contexts"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _context_path(session_id: str) -> Path:
+    digest = hashlib.sha256(session_id.encode("utf-8")).hexdigest()
+    return _context_root() / f"{digest}.json"
+
+
+def write_a2a_turn_context(session_id: str, context: Dict[str, Any]) -> None:
+    """Atomically bind a verified A2A task to one Hermes session."""
+    path = _context_path(session_id)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(context, sort_keys=True) + "\n")
+    tmp.chmod(0o600)
+    os.replace(tmp, path)
+    path.chmod(0o600)
+
+
+def read_a2a_turn_context(session_id: str) -> Optional[Dict[str, Any]]:
+    """Return the verified A2A context for a Hermes session, when present."""
+    if not session_id:
+        return None
+    path = _context_path(session_id)
+    try:
+        value = json.loads(path.read_text())
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def mark_a2a_reply_committed(session_id: str) -> None:
+    """Record that an explicit A2A intent tool already replied."""
+    context = read_a2a_turn_context(session_id)
+    if context is None:
+        return
+    context["reply_intent_committed"] = True
+    write_a2a_turn_context(session_id, context)

--- a/a2a_context.py
+++ b/a2a_context.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import threading
 from pathlib import Path
 from typing import Any, Dict, Optional
+
+_LOCK = threading.Lock()
 
 
 def _context_root() -> Path:
@@ -27,14 +30,93 @@ def _context_path(session_id: str) -> Path:
     return _context_root() / f"{digest}.json"
 
 
-def write_a2a_turn_context(session_id: str, context: Dict[str, Any]) -> None:
-    """Atomically bind a verified A2A task to one Hermes session."""
-    path = _context_path(session_id)
-    tmp = path.with_suffix(".tmp")
-    tmp.write_text(json.dumps(context, sort_keys=True) + "\n")
+def _queue_path(session_id: str) -> Path:
+    return _context_path(session_id).with_suffix(".queue.json")
+
+
+def _atomic_write(path: Path, value: Any) -> None:
+    tmp = path.with_suffix(f"{path.suffix}.tmp")
+    tmp.write_text(json.dumps(value, sort_keys=True) + "\n")
     tmp.chmod(0o600)
     os.replace(tmp, path)
     path.chmod(0o600)
+
+
+def write_a2a_turn_context(session_id: str, context: Dict[str, Any]) -> None:
+    """Atomically bind a verified A2A task to one Hermes session."""
+    with _LOCK:
+        _atomic_write(_context_path(session_id), context)
+
+
+def enqueue_a2a_turn_context(session_id: str, context: Dict[str, Any]) -> None:
+    """Queue verified context until Hermes starts the corresponding turn."""
+    path = _queue_path(session_id)
+    with _LOCK:
+        try:
+            loaded = json.loads(path.read_text())
+            queue = loaded if isinstance(loaded, list) else []
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            queue = []
+        identity = (
+            str(context.get("task_id") or ""),
+            str(context.get("message_id") or ""),
+        )
+        if any(
+            (
+                str(item.get("task_id") or ""),
+                str(item.get("message_id") or ""),
+            ) == identity
+            for item in queue
+            if isinstance(item, dict)
+        ):
+            return
+        queue.append(context)
+        _atomic_write(path, queue)
+
+
+def activate_next_a2a_turn_context(session_id: str) -> Optional[Dict[str, Any]]:
+    """Activate the next verified context at Hermes' real turn boundary."""
+    path = _queue_path(session_id)
+    with _LOCK:
+        try:
+            loaded = json.loads(path.read_text())
+            queue = loaded if isinstance(loaded, list) else []
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            return None
+        if not queue:
+            return None
+        context = queue.pop(0)
+        if not isinstance(context, dict):
+            return None
+        if queue:
+            _atomic_write(path, queue)
+        else:
+            path.unlink(missing_ok=True)
+        _atomic_write(_context_path(session_id), context)
+        return context
+
+
+def remove_queued_a2a_turn_context(session_id: str, task_id: str) -> None:
+    """Remove canceled work that has not reached the Hermes turn boundary."""
+    path = _queue_path(session_id)
+    with _LOCK:
+        try:
+            loaded = json.loads(path.read_text())
+            queue = loaded if isinstance(loaded, list) else []
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            return
+        remaining = [
+            item
+            for item in queue
+            if not (
+                isinstance(item, dict)
+                and str(item.get("task_id") or "") == task_id
+            )
+        ]
+        if remaining:
+            _atomic_write(path, remaining)
+        else:
+            path.unlink(missing_ok=True)
 
 
 def read_a2a_turn_context(session_id: str) -> Optional[Dict[str, Any]]:
@@ -51,8 +133,13 @@ def read_a2a_turn_context(session_id: str) -> Optional[Dict[str, Any]]:
 
 def mark_a2a_reply_committed(session_id: str) -> None:
     """Record that an explicit A2A intent tool already replied."""
-    context = read_a2a_turn_context(session_id)
-    if context is None:
-        return
-    context["reply_intent_committed"] = True
-    write_a2a_turn_context(session_id, context)
+    with _LOCK:
+        path = _context_path(session_id)
+        try:
+            context = json.loads(path.read_text())
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            return
+        if not isinstance(context, dict):
+            return
+        context["reply_intent_committed"] = True
+        _atomic_write(path, context)

--- a/adapter.py
+++ b/adapter.py
@@ -134,6 +134,7 @@ from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
 from gateway.platforms.helpers import redact_phone
 try:
+    from .a2a_context import read_a2a_turn_context, write_a2a_turn_context
     from .config import INKBOX_BASE_URL_DEFAULT, inkbox_client_kwargs
     from .diagnostics import inkbox_api_error_message, missing_config_message, is_inkbox_auth_error, is_inkbox_identity_error
     from .webhook_providers import match_provider
@@ -148,6 +149,7 @@ try:
         open_inkbox_realtime_bridge,
     )
 except ImportError:  # pragma: no cover - direct local import/test fallback
+    from a2a_context import read_a2a_turn_context, write_a2a_turn_context
     from config import INKBOX_BASE_URL_DEFAULT, inkbox_client_kwargs
     from diagnostics import inkbox_api_error_message, missing_config_message, is_inkbox_auth_error, is_inkbox_identity_error
     from webhook_providers import match_provider
@@ -1699,6 +1701,9 @@ class InkboxAdapter(BasePlatformAdapter):
         # voice-intended text into the user's inbox.
         self._voice_recently_closed: Dict[str, float] = {}
         self._a2a_tasks_by_chat: Dict[str, List[str]] = {}
+        self._a2a_session_by_chat: Dict[str, str] = {}
+        self._a2a_session_key_by_chat: Dict[str, str] = {}
+        self._a2a_suppress_next_reply_by_chat: set[str] = set()
         self._a2a_registry_path = _inkbox_state_path().with_name(
             "inkbox_a2a_tasks.json"
         )
@@ -3200,46 +3205,121 @@ class InkboxAdapter(BasePlatformAdapter):
         loaded = json.loads(self._a2a_registry_path.read_text())
         return loaded if isinstance(loaded, dict) else {}
 
-    def _write_a2a_registry(self, event_id: str, data: Dict[str, Any], state: str) -> None:
+    def _write_a2a_registry(self, key: str, data: Dict[str, Any], state: str) -> None:
         """Durably record an A2A delivery before acknowledging its webhook."""
         try:
             current = self._read_a2a_registry()
-            current[event_id] = {
+            current[key] = {
                 "task_id": str(data.get("task_id") or ""),
                 "context_id": str(data.get("context_id") or ""),
                 "message_id": str(data.get("message_id") or ""),
                 "state": state,
+                "data": data,
                 "updated_at": time.time(),
             }
             tmp = self._a2a_registry_path.with_suffix(".tmp")
             tmp.write_text(json.dumps(current, indent=2, sort_keys=True) + "\n")
+            tmp.chmod(0o600)
             os.replace(tmp, self._a2a_registry_path)
+            self._a2a_registry_path.chmod(0o600)
         except Exception:
             logger.exception("[Inkbox] Could not persist A2A task registry")
             raise
 
+    def _finalize_a2a_task_registry(self, task_id: str) -> None:
+        for key, entry in self._read_a2a_registry().items():
+            if (
+                str(entry.get("task_id") or "") == task_id
+                and entry.get("state") != "finalized"
+            ):
+                data = entry.get("data")
+                if not isinstance(data, dict):
+                    data = {
+                        "task_id": task_id,
+                        "context_id": entry.get("context_id"),
+                        "message_id": entry.get("message_id"),
+                    }
+                self._write_a2a_registry(key, data, "finalized")
+
+    def _bind_a2a_turn_context(
+        self,
+        source: Any,
+        *,
+        task_id: str,
+        context_id: str,
+        message_id: str,
+    ) -> None:
+        """Bind verified webhook data to the host session used by tool calls."""
+        handler_owner = getattr(
+            getattr(self, "_message_handler", None),
+            "__self__",
+            None,
+        )
+        session_store = getattr(handler_owner, "session_store", None)
+        if session_store is None:
+            return
+        try:
+            entry = session_store.get_or_create_session(source)
+            session_id = str(entry.session_id)
+            chat_id = str(source.chat_id)
+            self._a2a_session_by_chat[chat_id] = session_id
+            self._a2a_session_key_by_chat[chat_id] = str(entry.session_key)
+            write_a2a_turn_context(
+                session_id,
+                {
+                    "task_id": task_id,
+                    "context_id": context_id,
+                    "message_id": message_id,
+                    "reply_intent_committed": False,
+                },
+            )
+        except Exception:
+            logger.exception("[Inkbox] Could not bind the A2A turn context")
+
     async def _on_a2a_event(self, envelope: Dict[str, Any]) -> "web.Response":
-        event_id = str(envelope.get("id") or "")
         event_type = str(envelope.get("event_type") or "")
         data = envelope.get("data") if isinstance(envelope.get("data"), dict) else {}
         task_id = str(data.get("task_id") or "")
         context_id = str(data.get("context_id") or "")
         message_id = str(data.get("message_id") or envelope.get("id") or "")
-        if not event_id or not task_id or not context_id:
+        if not task_id or not context_id or not message_id:
             return web.Response(status=200, text="ignored")
-        if event_id in self._read_a2a_registry():
-            return web.Response(status=200, text="duplicate")
         chat_id = f"a2a:{self._identity_id}:{context_id}"
         if event_type == "a2a.task.canceled":
+            queue = self._a2a_tasks_by_chat.get(chat_id, [])
+            was_active = bool(queue and queue[0] == task_id)
+            session_key = self._a2a_session_key_by_chat.get(chat_id)
+            if was_active and session_key:
+                await self.cancel_session_processing(
+                    session_key,
+                    discard_pending=False,
+                )
+            elif was_active:
+                # Older hosts may not expose their session binding. Suppress
+                # one late delivery so it cannot complete the next task.
+                self._a2a_suppress_next_reply_by_chat.add(chat_id)
             self._a2a_tasks_by_chat[chat_id] = [
-                value for value in self._a2a_tasks_by_chat.get(chat_id, [])
+                value for value in queue
                 if value != task_id
             ]
-            self._write_a2a_registry(event_id, data, "finalized")
+            self._finalize_a2a_task_registry(task_id)
+            return web.Response(status=200, text="ok")
+        if event_type == "a2a.sent_task.updated":
+            logger.info("[Inkbox] Outbound A2A task updated: %s", task_id)
             return web.Response(status=200, text="ok")
 
-        self._write_a2a_registry(event_id, data, "queued")
-        self._a2a_tasks_by_chat.setdefault(chat_id, []).append(task_id)
+        key = f"{task_id}:{message_id}"
+        existing = self._read_a2a_registry().get(key)
+        is_resume = str(envelope.get("id") or "").startswith("resume:")
+        if existing and not (
+            is_resume and existing.get("state") != "finalized"
+        ):
+            return web.Response(status=200, text="duplicate")
+        if not existing:
+            self._write_a2a_registry(key, data, "queued")
+        queue = self._a2a_tasks_by_chat.setdefault(chat_id, [])
+        if task_id not in queue:
+            queue.append(task_id)
         caller = data.get("caller") if isinstance(data.get("caller"), dict) else {}
         parts = data.get("parts") if isinstance(data.get("parts"), list) else []
         body = "\n".join(
@@ -3256,18 +3336,30 @@ class InkboxAdapter(BasePlatformAdapter):
             thread_id=None,
             message_id=message_id,
         )
+        self._bind_a2a_turn_context(
+            source,
+            task_id=task_id,
+            context_id=context_id,
+            message_id=message_id,
+        )
         marker = (
             f"[inkbox:a2a_task caller=@{str(caller.get('handle') or 'unknown').lstrip('@')} "
             f"caller_org={caller.get('organization_id') or 'unknown'}]"
         )
         await self._enqueue(MessageEvent(
-            text=f"{marker}\n{body}".rstrip(),
+            text=(
+                f"{marker}\n"
+                "Use inkbox_a2a_complete, inkbox_a2a_ask_caller, or "
+                "inkbox_a2a_fail when an explicit outcome is appropriate.\n"
+                f"{body}"
+            ).rstrip(),
             message_type=MessageType.TEXT,
             source=source,
             raw_message=envelope,
             message_id=message_id,
             internal=True,
         ))
+        self._write_a2a_registry(key, data, "running")
         return web.Response(status=200, text="ok")
 
     async def _catch_up_a2a_tasks(self) -> None:
@@ -3278,6 +3370,51 @@ class InkboxAdapter(BasePlatformAdapter):
             identity = await asyncio.to_thread(
                 self._inkbox.get_identity, self._identity_handle
             )
+            for key, entry in self._read_a2a_registry().items():
+                if entry.get("state") == "finalized":
+                    continue
+                task_id = str(entry.get("task_id") or "")
+                if not task_id:
+                    continue
+                full = await asyncio.to_thread(identity.a2a_task, task_id)
+                state = str(getattr(full.state, "value", full.state))
+                if state in {"completed", "failed", "canceled", "rejected"}:
+                    data = entry.get("data")
+                    self._write_a2a_registry(
+                        key,
+                        data if isinstance(data, dict) else {
+                            "task_id": task_id,
+                            "context_id": entry.get("context_id"),
+                            "message_id": entry.get("message_id"),
+                        },
+                        "finalized",
+                    )
+                    continue
+                context_id = str(full.context_id)
+                chat_id = f"a2a:{self._identity_id}:{context_id}"
+                if task_id in self._a2a_tasks_by_chat.get(chat_id, []):
+                    continue
+                message = full.messages[-1] if full.messages else None
+                await self._on_a2a_event({
+                    "id": f"resume:{task_id}",
+                    "event_type": "a2a.task.created",
+                    "data": {
+                        "task_id": task_id,
+                        "context_id": context_id,
+                        "state": state,
+                        "caller": {
+                            "identity_id": str(full.caller.identity_id),
+                            "organization_id": full.caller.organization_id,
+                            "handle": full.caller.handle,
+                        },
+                        "message_id": (
+                            str(message.message_id)
+                            if message
+                            else str(entry.get("message_id") or f"task:{task_id}")
+                        ),
+                        "parts": message.parts if message else [],
+                    },
+                })
             tasks = await asyncio.to_thread(
                 lambda: list(identity.iter_a2a_tasks(state="submitted"))
             )
@@ -3304,10 +3441,27 @@ class InkboxAdapter(BasePlatformAdapter):
             logger.exception("[Inkbox] A2A catch-up failed")
 
     async def _send_a2a_reply(self, chat_id: str, content: str) -> SendResult:
+        if chat_id in self._a2a_suppress_next_reply_by_chat:
+            self._a2a_suppress_next_reply_by_chat.discard(chat_id)
+            return SendResult(success=True, message_id="a2a-canceled")
         queue = self._a2a_tasks_by_chat.get(chat_id) or []
         if not queue or not content.strip() or content.strip().upper() == "[SILENT]":
             return SendResult(success=True, message_id="a2a-no-reply")
         task_id = queue[0]
+        session_id = self._a2a_session_by_chat.get(chat_id)
+        turn_context = (
+            read_a2a_turn_context(session_id)
+            if session_id
+            else None
+        )
+        if (
+            turn_context
+            and str(turn_context.get("task_id") or "") == task_id
+            and turn_context.get("reply_intent_committed") is True
+        ):
+            queue.pop(0)
+            self._finalize_a2a_task_registry(task_id)
+            return SendResult(success=True, message_id=f"a2a:{task_id}")
         try:
             identity = await asyncio.to_thread(
                 self._inkbox.get_identity, self._identity_handle
@@ -3319,11 +3473,13 @@ class InkboxAdapter(BasePlatformAdapter):
                 text=content,
             )
             queue.pop(0)
+            self._finalize_a2a_task_registry(task_id)
             return SendResult(success=True, message_id=f"a2a:{task_id}")
         except Exception as exc:
             detail = str(exc).lower()
             if "terminal" in detail:
                 queue.pop(0)
+                self._finalize_a2a_task_registry(task_id)
                 return SendResult(success=True, message_id=f"a2a:{task_id}")
             return SendResult(success=False, error=str(exc), retryable=True)
 

--- a/adapter.py
+++ b/adapter.py
@@ -134,7 +134,11 @@ from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
 from gateway.platforms.helpers import redact_phone
 try:
-    from .a2a_context import read_a2a_turn_context, write_a2a_turn_context
+    from .a2a_context import (
+        enqueue_a2a_turn_context,
+        read_a2a_turn_context,
+        remove_queued_a2a_turn_context,
+    )
     from .config import INKBOX_BASE_URL_DEFAULT, inkbox_client_kwargs
     from .diagnostics import inkbox_api_error_message, missing_config_message, is_inkbox_auth_error, is_inkbox_identity_error
     from .webhook_providers import match_provider
@@ -149,7 +153,11 @@ try:
         open_inkbox_realtime_bridge,
     )
 except ImportError:  # pragma: no cover - direct local import/test fallback
-    from a2a_context import read_a2a_turn_context, write_a2a_turn_context
+    from a2a_context import (
+        enqueue_a2a_turn_context,
+        read_a2a_turn_context,
+        remove_queued_a2a_turn_context,
+    )
     from config import INKBOX_BASE_URL_DEFAULT, inkbox_client_kwargs
     from diagnostics import inkbox_api_error_message, missing_config_message, is_inkbox_auth_error, is_inkbox_identity_error
     from webhook_providers import match_provider
@@ -1701,6 +1709,9 @@ class InkboxAdapter(BasePlatformAdapter):
         # voice-intended text into the user's inbox.
         self._voice_recently_closed: Dict[str, float] = {}
         self._a2a_tasks_by_chat: Dict[str, List[str]] = {}
+        self._a2a_events_by_chat: Dict[str, List[MessageEvent]] = {}
+        self._a2a_active_chats: set[str] = set()
+        self._a2a_default_reply_allowed: Dict[str, bool] = {}
         self._a2a_session_by_chat: Dict[str, str] = {}
         self._a2a_session_key_by_chat: Dict[str, str] = {}
         self._a2a_suppress_next_reply_by_chat: set[str] = set()
@@ -3264,7 +3275,7 @@ class InkboxAdapter(BasePlatformAdapter):
             chat_id = str(source.chat_id)
             self._a2a_session_by_chat[chat_id] = session_id
             self._a2a_session_key_by_chat[chat_id] = str(entry.session_key)
-            write_a2a_turn_context(
+            enqueue_a2a_turn_context(
                 session_id,
                 {
                     "task_id": task_id,
@@ -3289,6 +3300,9 @@ class InkboxAdapter(BasePlatformAdapter):
             queue = self._a2a_tasks_by_chat.get(chat_id, [])
             was_active = bool(queue and queue[0] == task_id)
             session_key = self._a2a_session_key_by_chat.get(chat_id)
+            session_id = self._a2a_session_by_chat.get(chat_id)
+            if session_id:
+                remove_queued_a2a_turn_context(session_id, task_id)
             if was_active and session_key:
                 await self.cancel_session_processing(
                     session_key,
@@ -3301,6 +3315,17 @@ class InkboxAdapter(BasePlatformAdapter):
             self._a2a_tasks_by_chat[chat_id] = [
                 value for value in queue
                 if value != task_id
+            ]
+            self._a2a_events_by_chat[chat_id] = [
+                event
+                for event in self._a2a_events_by_chat.get(chat_id, [])
+                if str(
+                    (
+                        event.raw_message.get("data", {})
+                        if isinstance(event.raw_message, dict)
+                        else {}
+                    ).get("task_id") or ""
+                ) != task_id
             ]
             self._finalize_a2a_task_registry(task_id)
             return web.Response(status=200, text="ok")
@@ -3346,7 +3371,7 @@ class InkboxAdapter(BasePlatformAdapter):
             f"[inkbox:a2a_task caller=@{str(caller.get('handle') or 'unknown').lstrip('@')} "
             f"caller_org={caller.get('organization_id') or 'unknown'}]"
         )
-        await self._enqueue(MessageEvent(
+        message_event = MessageEvent(
             text=(
                 f"{marker}\n"
                 "Use inkbox_a2a_complete, inkbox_a2a_ask_caller, or "
@@ -3358,9 +3383,54 @@ class InkboxAdapter(BasePlatformAdapter):
             raw_message=envelope,
             message_id=message_id,
             internal=True,
-        ))
-        self._write_a2a_registry(key, data, "running")
+        )
+        event_queue = self._a2a_events_by_chat.setdefault(chat_id, [])
+        event_queue.append(message_event)
+        if chat_id not in self._a2a_active_chats:
+            self._a2a_active_chats.add(chat_id)
+            await self._enqueue(message_event)
         return web.Response(status=200, text="ok")
+
+    async def on_processing_start(self, event: MessageEvent) -> None:
+        if not str(event.source.chat_id).startswith("a2a:"):
+            return
+        self._a2a_default_reply_allowed[str(event.source.chat_id)] = True
+        raw = event.raw_message if isinstance(event.raw_message, dict) else {}
+        data = raw.get("data") if isinstance(raw.get("data"), dict) else {}
+        task_id = str(data.get("task_id") or "")
+        message_id = str(data.get("message_id") or event.message_id or "")
+        if task_id and message_id:
+            self._write_a2a_registry(
+                f"{task_id}:{message_id}",
+                data,
+                "running",
+            )
+
+    async def on_processing_complete(
+        self,
+        event: MessageEvent,
+        outcome: Any,
+    ) -> None:
+        chat_id = str(event.source.chat_id)
+        if not chat_id.startswith("a2a:"):
+            return
+        self._a2a_default_reply_allowed[chat_id] = (
+            str(getattr(outcome, "value", outcome)) == "success"
+        )
+        queue = self._a2a_events_by_chat.get(chat_id, [])
+        if queue:
+            if queue[0] is event:
+                queue.pop(0)
+            else:
+                with suppress(ValueError):
+                    queue.remove(event)
+        if queue:
+            # Feed exactly one next event into the host's per-session pending
+            # lane. The host drains it after this completion hook returns.
+            await self.handle_message(queue[0])
+        else:
+            self._a2a_events_by_chat.pop(chat_id, None)
+            self._a2a_active_chats.discard(chat_id)
 
     async def _catch_up_a2a_tasks(self) -> None:
         """Drain every submitted task through the same durable ingestion path."""
@@ -3441,45 +3511,64 @@ class InkboxAdapter(BasePlatformAdapter):
             logger.exception("[Inkbox] A2A catch-up failed")
 
     async def _send_a2a_reply(self, chat_id: str, content: str) -> SendResult:
+        if not self._a2a_default_reply_allowed.get(chat_id, True):
+            return SendResult(success=True, message_id="a2a-no-reply")
         if chat_id in self._a2a_suppress_next_reply_by_chat:
             self._a2a_suppress_next_reply_by_chat.discard(chat_id)
             return SendResult(success=True, message_id="a2a-canceled")
         queue = self._a2a_tasks_by_chat.get(chat_id) or []
         if not queue or not content.strip() or content.strip().upper() == "[SILENT]":
             return SendResult(success=True, message_id="a2a-no-reply")
-        task_id = queue[0]
         session_id = self._a2a_session_by_chat.get(chat_id)
         turn_context = (
             read_a2a_turn_context(session_id)
             if session_id
             else None
         )
+        task_id = (
+            str(turn_context.get("task_id") or "")
+            if turn_context
+            else ""
+        ) or queue[0]
+
+        def finish_task() -> None:
+            with suppress(ValueError):
+                queue.remove(task_id)
+            self._finalize_a2a_task_registry(task_id)
+
         if (
             turn_context
             and str(turn_context.get("task_id") or "") == task_id
             and turn_context.get("reply_intent_committed") is True
         ):
-            queue.pop(0)
-            self._finalize_a2a_task_registry(task_id)
+            finish_task()
             return SendResult(success=True, message_id=f"a2a:{task_id}")
         try:
             identity = await asyncio.to_thread(
                 self._inkbox.get_identity, self._identity_handle
             )
+            authoritative = await asyncio.to_thread(
+                identity.a2a_task,
+                task_id,
+            )
+            state = str(
+                getattr(authoritative.state, "value", authoritative.state)
+            )
+            if state in {"completed", "failed", "canceled", "rejected"}:
+                finish_task()
+                return SendResult(success=True, message_id=f"a2a:{task_id}")
             await asyncio.to_thread(
                 identity.a2a_reply,
                 task_id,
                 intent="complete",
                 text=content,
             )
-            queue.pop(0)
-            self._finalize_a2a_task_registry(task_id)
+            finish_task()
             return SendResult(success=True, message_id=f"a2a:{task_id}")
         except Exception as exc:
             detail = str(exc).lower()
             if "terminal" in detail:
-                queue.pop(0)
-                self._finalize_a2a_task_registry(task_id)
+                finish_task()
                 return SendResult(success=True, message_id=f"a2a:{task_id}")
             return SendResult(success=False, error=str(exc), retryable=True)
 
@@ -4057,6 +4146,8 @@ class InkboxAdapter(BasePlatformAdapter):
         if event.message_type != MessageType.TEXT:
             return None
         text = (event.text or "").lstrip()
+        if text.startswith("[inkbox:a2a_"):
+            return {"mode": "queue"}
         if (
             text.startswith("[inkbox:sms ")
             or text.startswith("[inkbox:sms_burst ")
@@ -4064,7 +4155,6 @@ class InkboxAdapter(BasePlatformAdapter):
             or text.startswith("[inkbox:group_sms_burst ")
             or text.startswith("[inkbox:imessage ")
             or text.startswith("[inkbox:imessage_burst ")
-            or text.startswith("[inkbox:a2a_")
         ):
             return {"mode": "queue", "merge_text": True}
         return None

--- a/adapter.py
+++ b/adapter.py
@@ -425,6 +425,14 @@ _DESIRED_A2A_EVENTS: tuple[str, ...] = (
 )
 
 
+def _is_unsupported_a2a_event_types(exc: Exception) -> bool:
+    detail = str(getattr(exc, "detail", exc))
+    return (
+        getattr(exc, "status_code", None) == 422
+        and any(event_type in detail for event_type in _DESIRED_A2A_EVENTS)
+    )
+
+
 def _inkbox_state_path():
     """Return the on-disk path used for the Inkbox identity state file.
 
@@ -2072,13 +2080,29 @@ class InkboxAdapter(BasePlatformAdapter):
             identity_events = list(_DESIRED_A2A_EVENTS)
             if getattr(identity, "imessage_enabled", False):
                 identity_events = [*_DESIRED_IMESSAGE_EVENTS, *identity_events]
-            _reconcile_imessage_subscription(
-                self._inkbox,
-                self._identity_id,
-                desired_url=webhook_url,
-                previous_webhook_url=previous_webhook_url,
-                desired_events=tuple(identity_events),
-            )
+            try:
+                _reconcile_imessage_subscription(
+                    self._inkbox,
+                    self._identity_id,
+                    desired_url=webhook_url,
+                    previous_webhook_url=previous_webhook_url,
+                    desired_events=tuple(identity_events),
+                )
+            except InkboxAPIError as exc:
+                if not _is_unsupported_a2a_event_types(exc):
+                    raise
+                logger.warning(
+                    "[Inkbox] API does not support A2A webhook events yet; "
+                    "continuing without A2A delivery until the backend is upgraded",
+                )
+                if getattr(identity, "imessage_enabled", False):
+                    _reconcile_imessage_subscription(
+                        self._inkbox,
+                        self._identity_id,
+                        desired_url=webhook_url,
+                        previous_webhook_url=previous_webhook_url,
+                        desired_events=_DESIRED_IMESSAGE_EVENTS,
+                    )
             logger.info(
                 "[Inkbox] Patched identity events for %s → %s",
                 self._identity_handle, webhook_url,

--- a/adapter.py
+++ b/adapter.py
@@ -408,6 +408,11 @@ _DESIRED_IMESSAGE_EVENTS: tuple[str, ...] = (
     "imessage.delivery_failed",
     "imessage.reaction_received",
 )
+_DESIRED_A2A_EVENTS: tuple[str, ...] = (
+    "a2a.task.created",
+    "a2a.task.message",
+    "a2a.task.canceled",
+)
 
 
 def _inkbox_state_path():
@@ -1693,6 +1698,10 @@ class InkboxAdapter(BasePlatformAdapter):
         # otherwise fall through to the email/SMS default and leak the
         # voice-intended text into the user's inbox.
         self._voice_recently_closed: Dict[str, float] = {}
+        self._a2a_tasks_by_chat: Dict[str, List[str]] = {}
+        self._a2a_registry_path = _inkbox_state_path().with_name(
+            "inkbox_a2a_tasks.json"
+        )
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -1797,6 +1806,7 @@ class InkboxAdapter(BasePlatformAdapter):
             return False
 
         self._mark_connected()
+        await self._catch_up_a2a_tasks()
         logger.info(
             "[Inkbox] Connected: identity=%s public=%s listen=%s:%d",
             self._identity_handle, self._public_url, self._host, self._port,
@@ -2042,16 +2052,19 @@ class InkboxAdapter(BasePlatformAdapter):
 
         # iMessage: identity-owned subscription, only while the identity is
         # enabled (the server rejects imessage.* subscriptions otherwise).
-        if getattr(identity, "imessage_enabled", False) and self._identity_id:
+        if self._identity_id:
+            identity_events = list(_DESIRED_A2A_EVENTS)
+            if getattr(identity, "imessage_enabled", False):
+                identity_events = [*_DESIRED_IMESSAGE_EVENTS, *identity_events]
             _reconcile_imessage_subscription(
                 self._inkbox,
                 self._identity_id,
                 desired_url=webhook_url,
                 previous_webhook_url=previous_webhook_url,
-                desired_events=_DESIRED_IMESSAGE_EVENTS,
+                desired_events=tuple(identity_events),
             )
             logger.info(
-                "[Inkbox] Patched iMessage for identity %s → %s",
+                "[Inkbox] Patched identity events for %s → %s",
                 self._identity_handle, webhook_url,
             )
 
@@ -2434,6 +2447,9 @@ class InkboxAdapter(BasePlatformAdapter):
         these are CLI chatter that never belongs in a real user's email or
         SMS thread.  See ``_is_hermes_admin_notice`` for the prefix list.
         """
+        if str(chat_id).startswith("a2a:"):
+            return await self._send_a2a_reply(chat_id, content)
+
         if _is_hermes_admin_notice(content, metadata):
             logger.debug(
                 "[Inkbox] Suppressed admin notice for chat %s: %s…",
@@ -3033,6 +3049,8 @@ class InkboxAdapter(BasePlatformAdapter):
                     response = await self._on_text_received(envelope)
                 elif event_type and event_type.startswith("text."):
                     response = await self._on_text_lifecycle(envelope)
+                elif event_type and event_type.startswith("a2a."):
+                    response = await self._on_a2a_event(envelope)
                 elif event_type == "imessage.received":
                     response = await self._on_imessage_received(envelope)
                 elif event_type == "imessage.reaction_received":
@@ -3085,7 +3103,9 @@ class InkboxAdapter(BasePlatformAdapter):
         Returns:
             bool: True for a recognised Inkbox event shape.
         """
-        if event_type and event_type.startswith(("message.", "text.", "imessage.")):
+        if event_type and event_type.startswith(
+            ("message.", "text.", "imessage.", "a2a.")
+        ):
             return True
         return "phone_number_id" in envelope and "remote_phone_number" in envelope
 
@@ -3173,6 +3193,139 @@ class InkboxAdapter(BasePlatformAdapter):
         ):
             return True
         return from_address in self._identity_email_addresses
+
+    def _read_a2a_registry(self) -> Dict[str, Any]:
+        if not self._a2a_registry_path.exists():
+            return {}
+        loaded = json.loads(self._a2a_registry_path.read_text())
+        return loaded if isinstance(loaded, dict) else {}
+
+    def _write_a2a_registry(self, event_id: str, data: Dict[str, Any], state: str) -> None:
+        """Durably record an A2A delivery before acknowledging its webhook."""
+        try:
+            current = self._read_a2a_registry()
+            current[event_id] = {
+                "task_id": str(data.get("task_id") or ""),
+                "context_id": str(data.get("context_id") or ""),
+                "message_id": str(data.get("message_id") or ""),
+                "state": state,
+                "updated_at": time.time(),
+            }
+            tmp = self._a2a_registry_path.with_suffix(".tmp")
+            tmp.write_text(json.dumps(current, indent=2, sort_keys=True) + "\n")
+            os.replace(tmp, self._a2a_registry_path)
+        except Exception:
+            logger.exception("[Inkbox] Could not persist A2A task registry")
+            raise
+
+    async def _on_a2a_event(self, envelope: Dict[str, Any]) -> "web.Response":
+        event_id = str(envelope.get("id") or "")
+        event_type = str(envelope.get("event_type") or "")
+        data = envelope.get("data") if isinstance(envelope.get("data"), dict) else {}
+        task_id = str(data.get("task_id") or "")
+        context_id = str(data.get("context_id") or "")
+        message_id = str(data.get("message_id") or envelope.get("id") or "")
+        if not event_id or not task_id or not context_id:
+            return web.Response(status=200, text="ignored")
+        if event_id in self._read_a2a_registry():
+            return web.Response(status=200, text="duplicate")
+        chat_id = f"a2a:{self._identity_id}:{context_id}"
+        if event_type == "a2a.task.canceled":
+            self._a2a_tasks_by_chat[chat_id] = [
+                value for value in self._a2a_tasks_by_chat.get(chat_id, [])
+                if value != task_id
+            ]
+            self._write_a2a_registry(event_id, data, "finalized")
+            return web.Response(status=200, text="ok")
+
+        self._write_a2a_registry(event_id, data, "queued")
+        self._a2a_tasks_by_chat.setdefault(chat_id, []).append(task_id)
+        caller = data.get("caller") if isinstance(data.get("caller"), dict) else {}
+        parts = data.get("parts") if isinstance(data.get("parts"), list) else []
+        body = "\n".join(
+            str(part.get("text"))
+            for part in parts
+            if isinstance(part, dict) and part.get("text")
+        )
+        source = self.build_source(
+            chat_id=chat_id,
+            chat_name=f"A2A context {context_id}",
+            chat_type="dm",
+            user_id=str(caller.get("identity_id") or "a2a-caller"),
+            user_name=str(caller.get("handle") or "A2A caller"),
+            thread_id=None,
+            message_id=message_id,
+        )
+        marker = (
+            f"[inkbox:a2a_task caller=@{str(caller.get('handle') or 'unknown').lstrip('@')} "
+            f"caller_org={caller.get('organization_id') or 'unknown'}]"
+        )
+        await self._enqueue(MessageEvent(
+            text=f"{marker}\n{body}".rstrip(),
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message=envelope,
+            message_id=message_id,
+            internal=True,
+        ))
+        return web.Response(status=200, text="ok")
+
+    async def _catch_up_a2a_tasks(self) -> None:
+        """Drain every submitted task through the same durable ingestion path."""
+        if self._inkbox is None:
+            return
+        try:
+            identity = await asyncio.to_thread(
+                self._inkbox.get_identity, self._identity_handle
+            )
+            tasks = await asyncio.to_thread(
+                lambda: list(identity.iter_a2a_tasks(state="submitted"))
+            )
+            for task in tasks:
+                full = await asyncio.to_thread(identity.a2a_task, task.id)
+                message = full.messages[-1] if full.messages else None
+                await self._on_a2a_event({
+                    "id": f"catchup:{task.id}",
+                    "event_type": "a2a.task.created",
+                    "data": {
+                        "task_id": str(task.id),
+                        "context_id": str(task.context_id),
+                        "state": str(getattr(task.state, "value", task.state)),
+                        "caller": {
+                            "identity_id": str(task.caller.identity_id),
+                            "organization_id": task.caller.organization_id,
+                            "handle": task.caller.handle,
+                        },
+                        "message_id": str(message.message_id) if message else f"task:{task.id}",
+                        "parts": message.parts if message else [],
+                    },
+                })
+        except Exception:
+            logger.exception("[Inkbox] A2A catch-up failed")
+
+    async def _send_a2a_reply(self, chat_id: str, content: str) -> SendResult:
+        queue = self._a2a_tasks_by_chat.get(chat_id) or []
+        if not queue or not content.strip() or content.strip().upper() == "[SILENT]":
+            return SendResult(success=True, message_id="a2a-no-reply")
+        task_id = queue[0]
+        try:
+            identity = await asyncio.to_thread(
+                self._inkbox.get_identity, self._identity_handle
+            )
+            await asyncio.to_thread(
+                identity.a2a_reply,
+                task_id,
+                intent="complete",
+                text=content,
+            )
+            queue.pop(0)
+            return SendResult(success=True, message_id=f"a2a:{task_id}")
+        except Exception as exc:
+            detail = str(exc).lower()
+            if "terminal" in detail:
+                queue.pop(0)
+                return SendResult(success=True, message_id=f"a2a:{task_id}")
+            return SendResult(success=False, error=str(exc), retryable=True)
 
     async def _on_mail_received(self, envelope: Dict[str, Any]) -> "web.Response":
         message = (envelope.get("data") or {}).get("message") or {}
@@ -3755,6 +3908,7 @@ class InkboxAdapter(BasePlatformAdapter):
             or text.startswith("[inkbox:group_sms_burst ")
             or text.startswith("[inkbox:imessage ")
             or text.startswith("[inkbox:imessage_burst ")
+            or text.startswith("[inkbox:a2a_")
         ):
             return {"mode": "queue", "merge_text": True}
         return None

--- a/adapter.py
+++ b/adapter.py
@@ -428,8 +428,11 @@ _DESIRED_A2A_EVENTS: tuple[str, ...] = (
 def _is_unsupported_a2a_event_types(exc: Exception) -> bool:
     detail = str(getattr(exc, "detail", exc))
     return (
-        getattr(exc, "status_code", None) == 422
-        and any(event_type in detail for event_type in _DESIRED_A2A_EVENTS)
+        any(event_type in detail for event_type in _DESIRED_A2A_EVENTS)
+        and (
+            getattr(exc, "status_code", None) == 422
+            or "does not belong to any known channel" in detail
+        )
     )
 
 
@@ -2088,7 +2091,7 @@ class InkboxAdapter(BasePlatformAdapter):
                     previous_webhook_url=previous_webhook_url,
                     desired_events=tuple(identity_events),
                 )
-            except InkboxAPIError as exc:
+            except Exception as exc:
                 if not _is_unsupported_a2a_event_types(exc):
                     raise
                 logger.warning(

--- a/adapter.py
+++ b/adapter.py
@@ -696,8 +696,7 @@ def _reconcile_subscription(
 ):
     """Reconcile a single owner's webhook subscription against desired state.
 
-    ``owner_kwarg`` is ``"mailbox_id"`` or ``"phone_number_id"``. Returns the
-    active subscription's id for DEBUG logging at the call site.
+    Returns the active subscription's id for DEBUG logging at the call site.
     """
     desired_set = set(desired_events)
     list_kwargs = {owner_kwarg: owner_id}
@@ -730,10 +729,19 @@ def _reconcile_subscription(
     # Previous-URL cleanup runs after the new row is in place so a failure
     # mid-reconcile can never leave the owner with zero receivers.
     if previous_webhook_url and previous_webhook_url != desired_url:
+        previous_urls = {previous_webhook_url}
+        if "?channel=a2a" in desired_url:
+            previous_urls.add(f"{previous_webhook_url}?channel=a2a")
+        desired_families = {
+            event_type.split(".", 1)[0] for event_type in desired_events
+        }
         # Re-list rather than reusing ``existing`` because a create/update
         # may have shifted the visible rows.
         for row in client.webhooks.subscriptions.list(**list_kwargs):
-            if row.url == previous_webhook_url:
+            row_families = {
+                event_type.split(".", 1)[0] for event_type in row.event_types
+            }
+            if row.url in previous_urls and desired_families & row_families:
                 try:
                     client.webhooks.subscriptions.delete(row.id)
                 except InkboxAPIError as exc:
@@ -741,7 +749,6 @@ def _reconcile_subscription(
                         pass  # already gone; fine
                     else:
                         raise
-                break
 
     return active_id
 
@@ -2077,19 +2084,16 @@ class InkboxAdapter(BasePlatformAdapter):
                 self._identity_handle, webhook_url, ws_url,
             )
 
-        # iMessage: identity-owned subscription, only while the identity is
-        # enabled (the server rejects imessage.* subscriptions otherwise).
+        # A2A and iMessage are separate event channels. They need distinct
+        # owner URLs because active subscriptions are unique by owner + URL.
         if self._identity_id:
-            identity_events = list(_DESIRED_A2A_EVENTS)
-            if getattr(identity, "imessage_enabled", False):
-                identity_events = [*_DESIRED_IMESSAGE_EVENTS, *identity_events]
             try:
                 _reconcile_imessage_subscription(
                     self._inkbox,
                     self._identity_id,
-                    desired_url=webhook_url,
+                    desired_url=f"{webhook_url}?channel=a2a",
                     previous_webhook_url=previous_webhook_url,
-                    desired_events=tuple(identity_events),
+                    desired_events=_DESIRED_A2A_EVENTS,
                 )
             except Exception as exc:
                 if not _is_unsupported_a2a_event_types(exc):
@@ -2098,14 +2102,14 @@ class InkboxAdapter(BasePlatformAdapter):
                     "[Inkbox] API does not support A2A webhook events yet; "
                     "continuing without A2A delivery until the backend is upgraded",
                 )
-                if getattr(identity, "imessage_enabled", False):
-                    _reconcile_imessage_subscription(
-                        self._inkbox,
-                        self._identity_id,
-                        desired_url=webhook_url,
-                        previous_webhook_url=previous_webhook_url,
-                        desired_events=_DESIRED_IMESSAGE_EVENTS,
-                    )
+            if getattr(identity, "imessage_enabled", False):
+                _reconcile_imessage_subscription(
+                    self._inkbox,
+                    self._identity_id,
+                    desired_url=webhook_url,
+                    previous_webhook_url=previous_webhook_url,
+                    desired_events=_DESIRED_IMESSAGE_EVENTS,
+                )
             logger.info(
                 "[Inkbox] Patched identity events for %s → %s",
                 self._identity_handle, webhook_url,

--- a/adapter.py
+++ b/adapter.py
@@ -2490,9 +2490,6 @@ class InkboxAdapter(BasePlatformAdapter):
         these are CLI chatter that never belongs in a real user's email or
         SMS thread.  See ``_is_hermes_admin_notice`` for the prefix list.
         """
-        if str(chat_id).startswith("a2a:"):
-            return await self._send_a2a_reply(chat_id, content)
-
         if _is_hermes_admin_notice(content, metadata):
             logger.debug(
                 "[Inkbox] Suppressed admin notice for chat %s: %s…",
@@ -2500,6 +2497,9 @@ class InkboxAdapter(BasePlatformAdapter):
             )
             self._stop_imessage_typing_for_chat(chat_id)
             return SendResult(success=True, message_id="suppressed-admin-notice")
+
+        if str(chat_id).startswith("a2a:"):
+            return await self._send_a2a_reply(chat_id, content)
 
         # The [SILENT] marker is the cron scheduler's "I have nothing to
         # say" sentinel and is also instructed to the agent in the

--- a/adapter.py
+++ b/adapter.py
@@ -3467,6 +3467,12 @@ class InkboxAdapter(BasePlatformAdapter):
             identity = await asyncio.to_thread(
                 self._inkbox.get_identity, self._identity_handle
             )
+            if not callable(getattr(identity, "iter_a2a_tasks", None)):
+                logger.debug(
+                    "[Inkbox] Installed SDK has no A2A task inbox; "
+                    "skipping catch-up"
+                )
+                return
             for key, entry in self._read_a2a_registry().items():
                 if entry.get("state") == "finalized":
                     continue

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -94,3 +94,6 @@ provides_tools:
   - inkbox_send_imessage_reaction
   - inkbox_mark_imessage_conversation_read
   - inkbox_place_call
+  - inkbox_a2a_complete
+  - inkbox_a2a_ask_caller
+  - inkbox_a2a_fail

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: inkbox
 label: Inkbox
 kind: platform
-version: 0.2.3
+version: 0.2.4
 description: Inkbox email, SMS/MMS, iMessage, and voice platform plugin for Hermes Agent.
 author: Inkbox
 requires_env: []

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -97,5 +97,7 @@ provides_tools:
   - inkbox_a2a_complete
   - inkbox_a2a_ask_caller
   - inkbox_a2a_fail
+  - inkbox_list_a2a_tasks
+  - inkbox_list_a2a_messages
   - inkbox_list_a2a_sent_tasks
   - inkbox_get_a2a_sent_task

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -97,3 +97,5 @@ provides_tools:
   - inkbox_a2a_complete
   - inkbox_a2a_ask_caller
   - inkbox_a2a_fail
+  - inkbox_list_a2a_sent_tasks
+  - inkbox_get_a2a_sent_task

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 [project.optional-dependencies]
 test = [
   "pytest>=8",
-  "ruff>=0.11.0",
+  "ruff>=0.11.0,<0.16",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hermes-agent-plugin"
-version = "0.2.3"
+version = "0.2.4"
 description = "Inkbox platform plugin for Hermes Agent"
 # inkbox>=0.4.7 requires Python 3.11+, so we can't claim 3.10 support.
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ description = "Inkbox platform plugin for Hermes Agent"
 requires-python = ">=3.11"
 dependencies = [
   "aiohttp>=3.9",
-  "inkbox>=0.5.1,<1.0.0",
+  "inkbox>=0.5.6,<1.0.0",
   "segno>=1.5",
 ]
 
@@ -20,6 +20,9 @@ test = [
 # Flat-layout Hermes plugin loaded by the gateway, not a pip-installable
 # package — keep uv from trying to build/install the project itself.
 package = false
+
+[tool.uv.sources]
+inkbox = { git = "https://github.com/inkbox-ai/inkbox.git", rev = "fdea6e55ac117f246624852aedeef0feabe08b9a", subdirectory = "sdk/python" }
 
 [tool.ruff]
 line-length = 125

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,6 @@ test = [
 # package — keep uv from trying to build/install the project itself.
 package = false
 
-[tool.uv.sources]
-inkbox = { git = "https://github.com/inkbox-ai/inkbox.git", rev = "fdea6e55ac117f246624852aedeef0feabe08b9a", subdirectory = "sdk/python" }
-
 [tool.ruff]
 line-length = 125
 

--- a/realtime.py
+++ b/realtime.py
@@ -178,6 +178,15 @@ MAIN_AGENT_CAPABILITIES: Tuple[Tuple[str, str, Tuple[str, ...]], ...] = (
     ("calls", "place a separate outbound phone call", ("inkbox_place_call",)),
     ("identity", "check its own Inkbox identity and numbers", ("inkbox_whoami",)),
     (
+        "a2a",
+        "complete, clarify, or fail an active agent-to-agent task",
+        (
+            "inkbox_a2a_complete",
+            "inkbox_a2a_ask_caller",
+            "inkbox_a2a_fail",
+        ),
+    ),
+    (
         "general",
         "search session history and notes, check the calendar, do research or "
         "computation, call external APIs, and draft long-form replies",

--- a/realtime.py
+++ b/realtime.py
@@ -185,6 +185,8 @@ MAIN_AGENT_CAPABILITIES: Tuple[Tuple[str, str, Tuple[str, ...]], ...] = (
             "inkbox_a2a_complete",
             "inkbox_a2a_ask_caller",
             "inkbox_a2a_fail",
+            "inkbox_list_a2a_tasks",
+            "inkbox_list_a2a_messages",
             "inkbox_list_a2a_sent_tasks",
             "inkbox_get_a2a_sent_task",
         ),

--- a/realtime.py
+++ b/realtime.py
@@ -179,11 +179,14 @@ MAIN_AGENT_CAPABILITIES: Tuple[Tuple[str, str, Tuple[str, ...]], ...] = (
     ("identity", "check its own Inkbox identity and numbers", ("inkbox_whoami",)),
     (
         "a2a",
-        "complete, clarify, or fail an active agent-to-agent task",
+        "complete, clarify, or fail an active agent-to-agent task and read "
+        "tasks it previously sent",
         (
             "inkbox_a2a_complete",
             "inkbox_a2a_ask_caller",
             "inkbox_a2a_fail",
+            "inkbox_list_a2a_sent_tasks",
+            "inkbox_get_a2a_sent_task",
         ),
     ),
     (

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -58,7 +58,7 @@ except Exception:  # pragma: no cover - local tests without Hermes
     masked_secret_prompt = None
 
 
-INKBOX_MIN_VERSION = "0.5.1"
+INKBOX_MIN_VERSION = "0.5.6"
 INKBOX_REQUIREMENTS = (f"inkbox>={INKBOX_MIN_VERSION},<1.0.0", "aiohttp>=3.9", "segno>=1.5")
 _BRACKETED_PASTE_PATTERN = re.compile(r"\x1b\[\s*200~|\x1b\[\s*201~")
 _AVATAR_PATH = Path(__file__).resolve().parent / "assets" / "hermes_with_iphone.png"

--- a/skills/inkbox-contact-rules/SKILL.md
+++ b/skills/inkbox-contact-rules/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inkbox-contact-rules
-description: Use when the user wants to block, allow, pause, delete, or list Inkbox contact-rule filters for the agent's mailbox or phone number. Hermes does not expose contact-rule edit tools; guide the user to Inkbox Console or explain the limitation.
+description: Use when the user wants to block, allow, delete, or list Inkbox contact-rule filters for the agent's mailbox or phone number. Hermes does not expose contact-rule edit tools; guide the user to Inkbox Console or explain the limitation.
 user-invocable: false
 ---
 
@@ -26,8 +26,7 @@ Use this skill when discussing who can reach the agent's Inkbox mailbox or phone
 3. For phone rules, explain the intended settings:
    - `matchType: "exact_number"` for E.164 numbers.
    - Rules apply to SMS and voice calls for that phone number.
-4. Mention that `status: "paused"` can temporarily disable a rule without deleting it if Console exposes that option.
-5. Explain that blocked inbound messages/calls may be rejected before the agent sees an event.
+4. Explain that blocked inbound messages/calls may be rejected before the agent sees an event.
 
 ## Safety
 

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -77,8 +77,12 @@ def test_detects_only_unsupported_a2a_event_validation_errors():
         detail="a2a.task.created is not a valid event type",
     )
     unrelated = types.SimpleNamespace(status_code=422, detail="invalid webhook URL")
+    local_validation = ValueError(
+        "event_type 'a2a.task.created' does not belong to any known channel"
+    )
 
     assert adapter_mod._is_unsupported_a2a_event_types(unsupported)
+    assert adapter_mod._is_unsupported_a2a_event_types(local_validation)
     assert not adapter_mod._is_unsupported_a2a_event_types(unrelated)
 
 

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import sys
 import types
 from pathlib import Path
@@ -11,6 +12,11 @@ pkg.__path__ = [str(ROOT)]
 sys.modules.setdefault("inkbox_plugin", pkg)
 
 from inkbox_plugin import adapter as adapter_mod
+from inkbox_plugin import tools as tools_mod
+from inkbox_plugin.a2a_context import (
+    read_a2a_turn_context,
+    write_a2a_turn_context,
+)
 from inkbox_plugin.adapter import InkboxAdapter
 
 
@@ -29,6 +35,9 @@ def _adapter(tmp_path):
     adapter._identity_handle = "agent"
     adapter._a2a_registry_path = tmp_path / "a2a.json"
     adapter._a2a_tasks_by_chat = {}
+    adapter._a2a_session_by_chat = {}
+    adapter._a2a_session_key_by_chat = {}
+    adapter._a2a_suppress_next_reply_by_chat = set()
     adapter._enqueued = []
 
     async def enqueue(event):
@@ -68,6 +77,8 @@ def test_a2a_event_is_persisted_before_enqueue_and_deduplicated(tmp_path):
     assert len(adapter._enqueued) == 1
     assert adapter._enqueued[0].source.chat_id == "a2a:identity-1:context-1"
     assert adapter._a2a_registry_path.exists()
+    registry = json.loads(adapter._a2a_registry_path.read_text())
+    assert registry["task-1:message-1"]["state"] == "running"
 
 
 def test_a2a_cancel_removes_only_the_addressed_task(tmp_path):
@@ -82,6 +93,21 @@ def test_a2a_cancel_removes_only_the_addressed_task(tmp_path):
     assert response.text == "ok"
     assert adapter._a2a_tasks_by_chat[chat_id] == ["task-2"]
     assert adapter._enqueued == []
+
+
+def test_canceled_task_late_output_cannot_complete_the_next_task(tmp_path):
+    adapter = _adapter(tmp_path)
+    chat_id = "a2a:identity-1:context-1"
+    adapter._a2a_tasks_by_chat[chat_id] = ["task-1", "task-2"]
+
+    asyncio.run(
+        adapter._on_a2a_event(_event("evt-cancel", "a2a.task.canceled"))
+    )
+    result = asyncio.run(adapter._send_a2a_reply(chat_id, "Late result."))
+
+    assert result.success is True
+    assert result.message_id == "a2a-canceled"
+    assert adapter._a2a_tasks_by_chat[chat_id] == ["task-2"]
 
 
 def test_default_a2a_reply_completes_oldest_task(monkeypatch, tmp_path):
@@ -107,3 +133,93 @@ def test_default_a2a_reply_completes_oldest_task(monkeypatch, tmp_path):
     assert result.success is True
     assert replies == [("task-1", {"intent": "complete", "text": "Done."})]
     assert adapter._a2a_tasks_by_chat[chat_id] == ["task-2"]
+
+
+def test_a2a_intent_tools_require_verified_turn_context(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    outside = json.loads(
+        tools_mod.inkbox_a2a_complete({"text": "Done."}, task_id="ordinary")
+    )
+    assert "only available" in outside["error"]
+
+    replies = []
+    identity = types.SimpleNamespace(
+        a2a_reply=lambda task_id, **kwargs: replies.append((task_id, kwargs))
+    )
+    monkeypatch.setattr(
+        tools_mod,
+        "_client_and_identity",
+        lambda: (None, None, identity),
+    )
+    write_a2a_turn_context(
+        "session-1",
+        {
+            "task_id": "task-1",
+            "context_id": "context-1",
+            "message_id": "message-1",
+            "reply_intent_committed": False,
+        },
+    )
+
+    inside = json.loads(
+        tools_mod.inkbox_a2a_ask_caller(
+            {"text": "Which region?"},
+            task_id="session-1",
+        )
+    )
+
+    assert inside["ok"] is True
+    assert replies == [
+        ("task-1", {"intent": "ask_caller", "text": "Which region?"})
+    ]
+    assert read_a2a_turn_context("session-1")["reply_intent_committed"] is True
+
+
+def test_a2a_catch_up_resumes_nonfinal_registry_entries(
+    monkeypatch,
+    tmp_path,
+):
+    adapter = _adapter(tmp_path)
+    adapter._write_a2a_registry(
+        "task-1:message-1",
+        _event()["data"],
+        "running",
+    )
+    task = types.SimpleNamespace(
+        id="task-1",
+        context_id="context-1",
+        state="working",
+        caller=types.SimpleNamespace(
+            identity_id="caller-1",
+            organization_id="org-1",
+            handle="caller",
+        ),
+        messages=[
+            types.SimpleNamespace(
+                message_id="message-1",
+                parts=[{"text": "Resume this."}],
+            )
+        ],
+    )
+    identity = types.SimpleNamespace(
+        a2a_task=lambda _task_id: task,
+        iter_a2a_tasks=lambda **_kwargs: iter(()),
+    )
+    adapter._inkbox = types.SimpleNamespace(
+        get_identity=lambda _handle: identity,
+    )
+
+    async def inline(function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(adapter_mod.asyncio, "to_thread", inline)
+    asyncio.run(adapter._catch_up_a2a_tasks())
+
+    assert len(adapter._enqueued) == 1
+    assert adapter._enqueued[0].text.endswith("Resume this.")
+    assert adapter._a2a_tasks_by_chat[
+        "a2a:identity-1:context-1"
+    ] == ["task-1"]

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -1,0 +1,109 @@
+import asyncio
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("inkbox_plugin")
+pkg.__path__ = [str(ROOT)]
+sys.modules.setdefault("inkbox_plugin", pkg)
+
+from inkbox_plugin import adapter as adapter_mod
+from inkbox_plugin.adapter import InkboxAdapter
+
+
+@pytest.fixture(autouse=True)
+def fake_web(monkeypatch):
+    monkeypatch.setattr(
+        adapter_mod,
+        "web",
+        types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
+    )
+
+
+def _adapter(tmp_path):
+    adapter = object.__new__(InkboxAdapter)
+    adapter._identity_id = "identity-1"
+    adapter._identity_handle = "agent"
+    adapter._a2a_registry_path = tmp_path / "a2a.json"
+    adapter._a2a_tasks_by_chat = {}
+    adapter._enqueued = []
+
+    async def enqueue(event):
+        adapter._enqueued.append(event)
+
+    adapter._enqueue = enqueue
+    return adapter
+
+
+def _event(event_id="evt-1", event_type="a2a.task.created"):
+    return {
+        "id": event_id,
+        "event_type": event_type,
+        "data": {
+            "task_id": "task-1",
+            "context_id": "context-1",
+            "state": "submitted",
+            "caller": {
+                "identity_id": "caller-1",
+                "organization_id": "org-1",
+                "handle": "caller",
+            },
+            "message_id": "message-1",
+            "parts": [{"text": "Please investigate."}],
+        },
+    }
+
+
+def test_a2a_event_is_persisted_before_enqueue_and_deduplicated(tmp_path):
+    adapter = _adapter(tmp_path)
+
+    first = asyncio.run(adapter._on_a2a_event(_event()))
+    second = asyncio.run(adapter._on_a2a_event(_event()))
+
+    assert first.text == "ok"
+    assert second.text == "duplicate"
+    assert len(adapter._enqueued) == 1
+    assert adapter._enqueued[0].source.chat_id == "a2a:identity-1:context-1"
+    assert adapter._a2a_registry_path.exists()
+
+
+def test_a2a_cancel_removes_only_the_addressed_task(tmp_path):
+    adapter = _adapter(tmp_path)
+    chat_id = "a2a:identity-1:context-1"
+    adapter._a2a_tasks_by_chat[chat_id] = ["task-1", "task-2"]
+
+    response = asyncio.run(
+        adapter._on_a2a_event(_event("evt-cancel", "a2a.task.canceled"))
+    )
+
+    assert response.text == "ok"
+    assert adapter._a2a_tasks_by_chat[chat_id] == ["task-2"]
+    assert adapter._enqueued == []
+
+
+def test_default_a2a_reply_completes_oldest_task(monkeypatch, tmp_path):
+    adapter = _adapter(tmp_path)
+    chat_id = "a2a:identity-1:context-1"
+    adapter._a2a_tasks_by_chat[chat_id] = ["task-1", "task-2"]
+    replies = []
+
+    class Identity:
+        def a2a_reply(self, task_id, **kwargs):
+            replies.append((task_id, kwargs))
+
+    adapter._inkbox = types.SimpleNamespace(
+        get_identity=lambda _handle: Identity(),
+    )
+
+    async def inline(function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(adapter_mod.asyncio, "to_thread", inline)
+    result = asyncio.run(adapter._send_a2a_reply(chat_id, "Done."))
+
+    assert result.success is True
+    assert replies == [("task-1", {"intent": "complete", "text": "Done."})]
+    assert adapter._a2a_tasks_by_chat[chat_id] == ["task-2"]

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -14,6 +14,8 @@ sys.modules.setdefault("inkbox_plugin", pkg)
 from inkbox_plugin import adapter as adapter_mod
 from inkbox_plugin import tools as tools_mod
 from inkbox_plugin.a2a_context import (
+    activate_next_a2a_turn_context,
+    enqueue_a2a_turn_context,
     read_a2a_turn_context,
     write_a2a_turn_context,
 )
@@ -35,6 +37,9 @@ def _adapter(tmp_path):
     adapter._identity_handle = "agent"
     adapter._a2a_registry_path = tmp_path / "a2a.json"
     adapter._a2a_tasks_by_chat = {}
+    adapter._a2a_events_by_chat = {}
+    adapter._a2a_active_chats = set()
+    adapter._a2a_default_reply_allowed = {}
     adapter._a2a_session_by_chat = {}
     adapter._a2a_session_key_by_chat = {}
     adapter._a2a_suppress_next_reply_by_chat = set()
@@ -78,7 +83,7 @@ def test_a2a_event_is_persisted_before_enqueue_and_deduplicated(tmp_path):
     assert adapter._enqueued[0].source.chat_id == "a2a:identity-1:context-1"
     assert adapter._a2a_registry_path.exists()
     registry = json.loads(adapter._a2a_registry_path.read_text())
-    assert registry["task-1:message-1"]["state"] == "running"
+    assert registry["task-1:message-1"]["state"] == "queued"
 
 
 def test_a2a_cancel_removes_only_the_addressed_task(tmp_path):
@@ -110,6 +115,46 @@ def test_canceled_task_late_output_cannot_complete_the_next_task(tmp_path):
     assert adapter._a2a_tasks_by_chat[chat_id] == ["task-2"]
 
 
+def test_same_context_a2a_events_are_dispatched_one_at_a_time(tmp_path):
+    adapter = _adapter(tmp_path)
+
+    asyncio.run(adapter._on_a2a_event(_event()))
+    second = _event("evt-2")
+    second["data"]["task_id"] = "task-2"
+    second["data"]["message_id"] = "message-2"
+    asyncio.run(adapter._on_a2a_event(second))
+
+    assert len(adapter._enqueued) == 1
+    assert len(adapter._a2a_events_by_chat["a2a:identity-1:context-1"]) == 2
+
+    handed_off = []
+
+    async def handle_message(event):
+        handed_off.append(event)
+
+    adapter.handle_message = handle_message
+    asyncio.run(
+        adapter.on_processing_complete(
+            adapter._enqueued[0],
+            types.SimpleNamespace(value="success"),
+        )
+    )
+
+    assert [event.message_id for event in handed_off] == ["message-2"]
+
+
+def test_failed_a2a_turn_cannot_default_complete(tmp_path):
+    adapter = _adapter(tmp_path)
+    chat_id = "a2a:identity-1:context-1"
+    adapter._a2a_tasks_by_chat[chat_id] = ["task-1"]
+    adapter._a2a_default_reply_allowed[chat_id] = False
+
+    result = asyncio.run(adapter._send_a2a_reply(chat_id, "Error text."))
+
+    assert result.success is True
+    assert result.message_id == "a2a-no-reply"
+
+
 def test_default_a2a_reply_completes_oldest_task(monkeypatch, tmp_path):
     adapter = _adapter(tmp_path)
     chat_id = "a2a:identity-1:context-1"
@@ -117,6 +162,9 @@ def test_default_a2a_reply_completes_oldest_task(monkeypatch, tmp_path):
     replies = []
 
     class Identity:
+        def a2a_task(self, _task_id):
+            return types.SimpleNamespace(state="working")
+
         def a2a_reply(self, task_id, **kwargs):
             replies.append((task_id, kwargs))
 
@@ -176,6 +224,35 @@ def test_a2a_intent_tools_require_verified_turn_context(
         ("task-1", {"intent": "ask_caller", "text": "Which region?"})
     ]
     assert read_a2a_turn_context("session-1")["reply_intent_committed"] is True
+
+
+def test_a2a_context_activates_in_hermes_turn_order(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    enqueue_a2a_turn_context(
+        "session-1",
+        {
+            "task_id": "task-1",
+            "context_id": "context-1",
+            "message_id": "message-1",
+            "reply_intent_committed": False,
+        },
+    )
+    enqueue_a2a_turn_context(
+        "session-1",
+        {
+            "task_id": "task-2",
+            "context_id": "context-1",
+            "message_id": "message-2",
+            "reply_intent_committed": False,
+        },
+    )
+
+    first = activate_next_a2a_turn_context("session-1")
+    second = activate_next_a2a_turn_context("session-1")
+
+    assert first["task_id"] == "task-1"
+    assert second["task_id"] == "task-2"
+    assert read_a2a_turn_context("session-1")["task_id"] == "task-2"
 
 
 def test_a2a_catch_up_resumes_nonfinal_registry_entries(

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -71,6 +71,17 @@ def _event(event_id="evt-1", event_type="a2a.task.created"):
     }
 
 
+def test_detects_only_unsupported_a2a_event_validation_errors():
+    unsupported = types.SimpleNamespace(
+        status_code=422,
+        detail="a2a.task.created is not a valid event type",
+    )
+    unrelated = types.SimpleNamespace(status_code=422, detail="invalid webhook URL")
+
+    assert adapter_mod._is_unsupported_a2a_event_types(unsupported)
+    assert not adapter_mod._is_unsupported_a2a_event_types(unrelated)
+
+
 def test_a2a_event_is_persisted_before_enqueue_and_deduplicated(tmp_path):
     adapter = _adapter(tmp_path)
 

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -170,6 +170,24 @@ def test_failed_a2a_turn_cannot_default_complete(tmp_path):
     assert result.message_id == "a2a-no-reply"
 
 
+def test_a2a_home_channel_notice_does_not_complete_task(tmp_path):
+    adapter = _adapter(tmp_path)
+    chat_id = "a2a:identity-1:context-1"
+    adapter._a2a_tasks_by_chat[chat_id] = ["task-1"]
+    adapter._last_inbound_imessage = {}
+
+    result = asyncio.run(
+        adapter.send(
+            chat_id,
+            "📬 No home channel is set for Inkbox. Type /sethome to configure one.",
+        )
+    )
+
+    assert result.success is True
+    assert result.message_id == "suppressed-admin-notice"
+    assert adapter._a2a_tasks_by_chat[chat_id] == ["task-1"]
+
+
 def test_default_a2a_reply_completes_oldest_task(monkeypatch, tmp_path):
     adapter = _adapter(tmp_path)
     chat_id = "a2a:identity-1:context-1"

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -259,6 +259,91 @@ def test_a2a_intent_tools_require_verified_turn_context(
     assert read_a2a_turn_context("session-1")["reply_intent_committed"] is True
 
 
+def test_a2a_sent_history_tools_are_scoped_to_configured_identity(
+    monkeypatch,
+):
+    calls = []
+
+    class Identity:
+        def a2a_sent_tasks(self, **kwargs):
+            calls.append(("list", kwargs))
+            return {
+                "items": [
+                    {
+                        "id": "task-1",
+                        "state": "completed",
+                        "target": {"handle": "worker-agent"},
+                    }
+                ],
+                "next_cursor": "next-page",
+            }
+
+        def a2a_sent_task(self, task_id):
+            calls.append(("get", task_id))
+            return {
+                "id": task_id,
+                "messages": [
+                    {"role": "agent", "parts": [{"text": "Done."}]}
+                ],
+            }
+
+    monkeypatch.setattr(
+        tools_mod,
+        "_client_and_identity",
+        lambda: (None, None, Identity()),
+    )
+
+    page = json.loads(
+        tools_mod.inkbox_list_a2a_sent_tasks({
+            "state": "completed",
+            "contextId": "context-1",
+            "cursor": "cursor-1",
+            "limit": 3,
+        })
+    )
+    task = json.loads(
+        tools_mod.inkbox_get_a2a_sent_task({"taskId": "task-1"})
+    )
+
+    assert page["page"]["next_cursor"] == "next-page"
+    assert page["page"]["items"][0]["target"]["handle"] == "worker-agent"
+    assert task["task"]["messages"][0]["parts"][0]["text"] == "Done."
+    assert calls == [
+        (
+            "list",
+            {
+                "state": "completed",
+                "context_id": "context-1",
+                "cursor": "cursor-1",
+                "limit": 3,
+            },
+        ),
+        ("get", "task-1"),
+    ]
+
+
+def test_a2a_sent_history_rejects_unbounded_page_and_missing_task_id(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        tools_mod,
+        "_client_and_identity",
+        lambda: (
+            None,
+            None,
+            types.SimpleNamespace(a2a_sent_tasks=lambda **_kwargs: {}),
+        ),
+    )
+
+    page = json.loads(
+        tools_mod.inkbox_list_a2a_sent_tasks({"limit": 101})
+    )
+    task = json.loads(tools_mod.inkbox_get_a2a_sent_task({}))
+
+    assert page["error"] == "limit must be between 1 and 100"
+    assert task["error"] == "taskId is required"
+
+
 def test_a2a_context_activates_in_hermes_turn_order(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     enqueue_a2a_turn_context(

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -265,6 +265,14 @@ def test_a2a_sent_history_tools_are_scoped_to_configured_identity(
     calls = []
 
     class Identity:
+        def a2a_tasks(self, **kwargs):
+            calls.append(("history", kwargs))
+            return {"items": [], "next_cursor": None}
+
+        def a2a_messages(self, **kwargs):
+            calls.append(("messages", kwargs))
+            return {"items": [], "next_cursor": None}
+
         def a2a_sent_tasks(self, **kwargs):
             calls.append(("list", kwargs))
             return {
@@ -293,10 +301,41 @@ def test_a2a_sent_history_tools_are_scoped_to_configured_identity(
         lambda: (None, None, Identity()),
     )
 
-    page = json.loads(
-        tools_mod.inkbox_list_a2a_sent_tasks({
+    history = json.loads(
+        tools_mod.inkbox_list_a2a_tasks({
+            "direction": "both",
+            "requesterHandle": "requester",
+            "workerHandle": "worker",
             "state": "completed",
             "contextId": "context-1",
+            "query": "summary",
+            "since": "2026-07-01T00:00:00Z",
+            "cursor": "cursor-1",
+            "limit": 3,
+        })
+    )
+    messages = json.loads(
+        tools_mod.inkbox_list_a2a_messages({
+            "direction": "outbound",
+            "requesterHandle": "requester",
+            "workerHandle": "worker",
+            "taskId": "task-1",
+            "contextId": "context-1",
+            "role": "agent",
+            "query": "done",
+            "since": "2026-07-01T00:00:00Z",
+            "cursor": "cursor-2",
+            "limit": 4,
+        })
+    )
+    page = json.loads(
+        tools_mod.inkbox_list_a2a_sent_tasks({
+            "requesterHandle": "requester",
+            "workerHandle": "worker",
+            "state": "completed",
+            "contextId": "context-1",
+            "query": "summary",
+            "since": "2026-07-01T00:00:00Z",
             "cursor": "cursor-1",
             "limit": 3,
         })
@@ -305,15 +344,50 @@ def test_a2a_sent_history_tools_are_scoped_to_configured_identity(
         tools_mod.inkbox_get_a2a_sent_task({"taskId": "task-1"})
     )
 
+    assert history["page"]["items"] == []
+    assert messages["page"]["items"] == []
     assert page["page"]["next_cursor"] == "next-page"
     assert page["page"]["items"][0]["target"]["handle"] == "worker-agent"
     assert task["task"]["messages"][0]["parts"][0]["text"] == "Done."
     assert calls == [
         (
-            "list",
+            "history",
             {
+                "direction": "both",
+                "requester_handle": "requester",
+                "worker_handle": "worker",
                 "state": "completed",
                 "context_id": "context-1",
+                "q": "summary",
+                "since": "2026-07-01T00:00:00Z",
+                "cursor": "cursor-1",
+                "limit": 3,
+            },
+        ),
+        (
+            "messages",
+            {
+                "direction": "outbound",
+                "requester_handle": "requester",
+                "worker_handle": "worker",
+                "task_id": "task-1",
+                "context_id": "context-1",
+                "role": "agent",
+                "q": "done",
+                "since": "2026-07-01T00:00:00Z",
+                "cursor": "cursor-2",
+                "limit": 4,
+            },
+        ),
+        (
+            "list",
+            {
+                "requester_handle": "requester",
+                "worker_handle": "worker",
+                "state": "completed",
+                "context_id": "context-1",
+                "q": "summary",
+                "since": "2026-07-01T00:00:00Z",
                 "cursor": "cursor-1",
                 "limit": 3,
             },
@@ -338,9 +412,13 @@ def test_a2a_sent_history_rejects_unbounded_page_and_missing_task_id(
     page = json.loads(
         tools_mod.inkbox_list_a2a_sent_tasks({"limit": 101})
     )
+    history = json.loads(tools_mod.inkbox_list_a2a_tasks({"limit": 0}))
+    messages = json.loads(tools_mod.inkbox_list_a2a_messages({"limit": 101}))
     task = json.loads(tools_mod.inkbox_get_a2a_sent_task({}))
 
     assert page["error"] == "limit must be between 1 and 100"
+    assert history["error"] == "limit must be between 1 and 100"
+    assert messages["error"] == "limit must be between 1 and 100"
     assert task["error"] == "taskId is required"
 
 

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -333,3 +333,21 @@ def test_a2a_catch_up_resumes_nonfinal_registry_entries(
     assert adapter._a2a_tasks_by_chat[
         "a2a:identity-1:context-1"
     ] == ["task-1"]
+
+
+def test_a2a_catch_up_skips_sdk_without_task_inbox(
+    monkeypatch,
+    tmp_path,
+):
+    adapter = _adapter(tmp_path)
+    adapter._inkbox = types.SimpleNamespace(
+        get_identity=lambda _handle: types.SimpleNamespace(),
+    )
+
+    async def inline(function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(adapter_mod.asyncio, "to_thread", inline)
+    asyncio.run(adapter._catch_up_a2a_tasks())
+
+    assert adapter._enqueued == []

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -30,6 +30,7 @@ class DummyContext:
         self.cli_commands = []
         self.commands = []
         self.skills = []
+        self.hooks = []
 
     def register_platform(self, **kwargs):
         self.platforms.append(kwargs)
@@ -45,6 +46,9 @@ class DummyContext:
 
     def register_skill(self, *args, **kwargs):
         self.skills.append((args, kwargs))
+
+    def register_hook(self, *args, **kwargs):
+        self.hooks.append((args, kwargs))
 
 
 def _manifest_provides_tools() -> set[str]:
@@ -111,6 +115,7 @@ def test_registers_inkbox_platform_tools_commands_and_skills():
     assert ctx.cli_commands[0]["name"] == "inkbox"
     assert ctx.commands[0][0][0] == "inkbox"
     assert {args[0] for args, _kwargs in ctx.skills}
+    assert ctx.hooks[0][0][0] == "pre_llm_call"
 
 
 def test_env_enablement_warns_once_when_plugin_is_unconfigured(monkeypatch, caplog):

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -102,6 +102,9 @@ def test_registers_inkbox_platform_tools_commands_and_skills():
         "inkbox_send_imessage_reaction",
         "inkbox_mark_imessage_conversation_read",
         "inkbox_place_call",
+        "inkbox_a2a_complete",
+        "inkbox_a2a_ask_caller",
+        "inkbox_a2a_fail",
     }
     assert _manifest_provides_tools() == tool_names
 

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -109,6 +109,8 @@ def test_registers_inkbox_platform_tools_commands_and_skills():
         "inkbox_a2a_complete",
         "inkbox_a2a_ask_caller",
         "inkbox_a2a_fail",
+        "inkbox_list_a2a_tasks",
+        "inkbox_list_a2a_messages",
         "inkbox_list_a2a_sent_tasks",
         "inkbox_get_a2a_sent_task",
     }

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -109,6 +109,8 @@ def test_registers_inkbox_platform_tools_commands_and_skills():
         "inkbox_a2a_complete",
         "inkbox_a2a_ask_caller",
         "inkbox_a2a_fail",
+        "inkbox_list_a2a_sent_tasks",
+        "inkbox_get_a2a_sent_task",
     }
     assert _manifest_provides_tools() == tool_names
 

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -26,7 +26,7 @@ def test_install_command_prefers_uv_when_available(monkeypatch):
         "install",
         "--python",
         "/tmp/hermes/venv/bin/python",
-        "inkbox>=0.5.1,<1.0.0",
+        "inkbox>=0.5.6,<1.0.0",
         "aiohttp>=3.9",
         "segno>=1.5",
     ]]
@@ -37,10 +37,10 @@ def test_install_command_falls_back_to_pip_and_ensurepip(monkeypatch):
     monkeypatch.setattr(setup_wizard.shutil, "which", lambda _name: None)
 
     assert setup_wizard._install_commands() == [
-        [["/tmp/hermes/venv/bin/python", "-m", "pip", "install", "inkbox>=0.5.1,<1.0.0", "aiohttp>=3.9", "segno>=1.5"]],
+        [["/tmp/hermes/venv/bin/python", "-m", "pip", "install", "inkbox>=0.5.6,<1.0.0", "aiohttp>=3.9", "segno>=1.5"]],
         [
             ["/tmp/hermes/venv/bin/python", "-m", "ensurepip", "--upgrade"],
-            ["/tmp/hermes/venv/bin/python", "-m", "pip", "install", "inkbox>=0.5.1,<1.0.0", "aiohttp>=3.9", "segno>=1.5"],
+            ["/tmp/hermes/venv/bin/python", "-m", "pip", "install", "inkbox>=0.5.6,<1.0.0", "aiohttp>=3.9", "segno>=1.5"],
         ],
     ]
 
@@ -59,7 +59,7 @@ def test_missing_sdk_guidance_prints_hermes_python(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "/tmp/hermes/venv/bin/python" in out
     assert "uv pip install --python" in out
-    assert "inkbox>=0.5.1,<1.0.0" in out
+    assert "inkbox>=0.5.6,<1.0.0" in out
     assert "aiohttp>=3.9" in out
 
 

--- a/tests/test_subscription_channels.py
+++ b/tests/test_subscription_channels.py
@@ -1,0 +1,92 @@
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("inkbox_plugin")
+pkg.__path__ = [str(ROOT)]
+sys.modules.setdefault("inkbox_plugin", pkg)
+
+from inkbox_plugin import adapter
+
+
+class _Subscriptions:
+    def __init__(self, rows=()):
+        self.rows = list(rows)
+        self.deleted = []
+
+    def list(self, **_owner):
+        return list(self.rows)
+
+    def create(self, **kwargs):
+        assert all(row.url != kwargs["url"] for row in self.rows)
+        row = SimpleNamespace(
+            id=f"sub-{len(self.rows) + 1}",
+            url=kwargs["url"],
+            event_types=list(kwargs["event_types"]),
+        )
+        self.rows.append(row)
+        return row
+
+    def update(self, sub_id, **kwargs):
+        row = next(row for row in self.rows if row.id == sub_id)
+        row.event_types = list(kwargs["event_types"])
+        return row
+
+    def delete(self, sub_id):
+        self.deleted.append(sub_id)
+        self.rows = [row for row in self.rows if row.id != sub_id]
+
+
+def _client(rows=()):
+    subscriptions = _Subscriptions(rows)
+    return (
+        SimpleNamespace(
+            webhooks=SimpleNamespace(subscriptions=subscriptions),
+        ),
+        subscriptions,
+    )
+
+
+def _reconcile(client, url, events, previous=None):
+    return adapter._reconcile_imessage_subscription(
+        client,
+        "identity-1",
+        desired_url=url,
+        previous_webhook_url=previous,
+        desired_events=events,
+    )
+
+
+def test_a2a_and_imessage_use_separate_owner_urls():
+    client, subscriptions = _client()
+    base = "https://agent.example/webhook"
+
+    _reconcile(client, f"{base}?channel=a2a", adapter._DESIRED_A2A_EVENTS)
+    _reconcile(client, base, adapter._DESIRED_IMESSAGE_EVENTS)
+
+    assert [(row.url, tuple(row.event_types)) for row in subscriptions.rows] == [
+        (f"{base}?channel=a2a", adapter._DESIRED_A2A_EVENTS),
+        (base, adapter._DESIRED_IMESSAGE_EVENTS),
+    ]
+
+
+def test_a2a_migration_preserves_imessage_subscription_at_base_url():
+    base = "https://agent.example/webhook"
+    imessage = SimpleNamespace(
+        id="sub-imessage",
+        url=base,
+        event_types=list(adapter._DESIRED_IMESSAGE_EVENTS),
+    )
+    client, subscriptions = _client([imessage])
+
+    _reconcile(
+        client,
+        f"{base}?channel=a2a",
+        adapter._DESIRED_A2A_EVENTS,
+        previous=base,
+    )
+
+    assert "sub-imessage" not in subscriptions.deleted
+    assert any(row.id == "sub-imessage" for row in subscriptions.rows)

--- a/tools.py
+++ b/tools.py
@@ -13,8 +13,13 @@ from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlencode, urlparse, urlunparse, parse_qsl
 
 try:
+    from .a2a_context import (
+        mark_a2a_reply_committed,
+        read_a2a_turn_context,
+    )
     from .config import inkbox_client_kwargs, object_summary, public_call_ws_url, read_config
 except ImportError:  # pragma: no cover - direct local import/test fallback
+    from a2a_context import mark_a2a_reply_committed, read_a2a_turn_context
     from config import inkbox_client_kwargs, object_summary, public_call_ws_url, read_config
 
 SMS_MAX_LENGTH = 1600
@@ -24,6 +29,40 @@ IMESSAGE_MEDIA_MAX_BYTES = 10 * 1024 * 1024
 
 def _json(data: Dict[str, Any]) -> str:
     return json.dumps(data, ensure_ascii=False)
+
+
+def _a2a_intent(intent: str, text: str, session_id: str) -> str:
+    context = read_a2a_turn_context(session_id)
+    if context is None:
+        return _json({
+            "error": "This tool is only available during an inbound A2A task",
+        })
+    try:
+        _, _, identity = _client_and_identity()
+        result = identity.a2a_reply(
+            str(context["task_id"]),
+            intent=intent,
+            text=text,
+        )
+        mark_a2a_reply_committed(session_id)
+        return _json({"ok": True, "result": _json_safe(result)})
+    except Exception as exc:
+        return _json({"error": str(exc)})
+
+
+def inkbox_a2a_complete(args: dict, task_id: str = "", **kwargs) -> str:
+    del kwargs
+    return _a2a_intent("complete", str(args.get("text") or ""), task_id)
+
+
+def inkbox_a2a_ask_caller(args: dict, task_id: str = "", **kwargs) -> str:
+    del kwargs
+    return _a2a_intent("ask_caller", str(args.get("text") or ""), task_id)
+
+
+def inkbox_a2a_fail(args: dict, task_id: str = "", **kwargs) -> str:
+    del kwargs
+    return _a2a_intent("fail", str(args.get("reason") or ""), task_id)
 
 
 def _message_too_long_payload(channel: str, content: str, max_chars: int) -> Dict[str, Any]:
@@ -1330,6 +1369,36 @@ PLACE_CALL_SCHEMA = {
     },
 }
 
+A2A_COMPLETE_SCHEMA = {
+    "name": "inkbox_a2a_complete",
+    "description": "Complete the active inbound A2A task with a final answer.",
+    "parameters": {
+        "type": "object",
+        "properties": {"text": {"type": "string"}},
+        "required": ["text"],
+    },
+}
+
+A2A_ASK_CALLER_SCHEMA = {
+    "name": "inkbox_a2a_ask_caller",
+    "description": "Ask the caller for more input on the active inbound A2A task.",
+    "parameters": {
+        "type": "object",
+        "properties": {"text": {"type": "string"}},
+        "required": ["text"],
+    },
+}
+
+A2A_FAIL_SCHEMA = {
+    "name": "inkbox_a2a_fail",
+    "description": "Fail the active inbound A2A task with a reason.",
+    "parameters": {
+        "type": "object",
+        "properties": {"reason": {"type": "string"}},
+        "required": ["reason"],
+    },
+}
+
 
 def register_tools(ctx) -> None:
     ctx.register_tool("inkbox_whoami", "inkbox", WHOAMI_SCHEMA, inkbox_whoami, check_fn=_configured)
@@ -1355,3 +1424,6 @@ def register_tools(ctx) -> None:
     ctx.register_tool("inkbox_send_imessage_reaction", "inkbox", SEND_IMESSAGE_REACTION_SCHEMA, inkbox_send_imessage_reaction, check_fn=_configured)
     ctx.register_tool("inkbox_mark_imessage_conversation_read", "inkbox", MARK_IMESSAGE_CONVERSATION_READ_SCHEMA, inkbox_mark_imessage_conversation_read, check_fn=_configured)
     ctx.register_tool("inkbox_place_call", "inkbox", PLACE_CALL_SCHEMA, inkbox_place_call, check_fn=_configured)
+    ctx.register_tool("inkbox_a2a_complete", "inkbox", A2A_COMPLETE_SCHEMA, inkbox_a2a_complete, check_fn=_configured)
+    ctx.register_tool("inkbox_a2a_ask_caller", "inkbox", A2A_ASK_CALLER_SCHEMA, inkbox_a2a_ask_caller, check_fn=_configured)
+    ctx.register_tool("inkbox_a2a_fail", "inkbox", A2A_FAIL_SCHEMA, inkbox_a2a_fail, check_fn=_configured)

--- a/tools.py
+++ b/tools.py
@@ -39,11 +39,32 @@ def _a2a_intent(intent: str, text: str, session_id: str) -> str:
         })
     try:
         _, _, identity = _client_and_identity()
-        result = identity.a2a_reply(
-            str(context["task_id"]),
-            intent=intent,
-            text=text,
-        )
+        task_id = str(context["task_id"])
+        try:
+            result = identity.a2a_reply(
+                task_id,
+                intent=intent,
+                text=text,
+            )
+        except Exception:
+            authoritative = identity.a2a_task(task_id)
+            state = str(
+                getattr(authoritative.state, "value", authoritative.state)
+            )
+            expected = {
+                "complete": "completed",
+                "ask_caller": "input_required",
+                "fail": "failed",
+            }[intent]
+            if state not in {
+                expected,
+                "completed",
+                "failed",
+                "canceled",
+                "rejected",
+            }:
+                raise
+            result = authoritative
         mark_a2a_reply_committed(session_id)
         return _json({"ok": True, "result": _json_safe(result)})
     except Exception as exc:

--- a/tools.py
+++ b/tools.py
@@ -86,6 +86,65 @@ def inkbox_a2a_fail(args: dict, task_id: str = "", **kwargs) -> str:
     return _a2a_intent("fail", str(args.get("reason") or ""), task_id)
 
 
+def inkbox_list_a2a_sent_tasks(args: dict, **kwargs) -> str:
+    """List the configured identity's caller-side A2A task history."""
+    del kwargs
+    try:
+        _, _, identity = _client_and_identity()
+        method = _identity_method(
+            identity,
+            "a2a_sent_tasks",
+            "a2aSentTasks",
+        )
+        state = str(args.get("state") or "").strip() or None
+        context_id = str(
+            args.get("contextId") or args.get("context_id") or ""
+        ).strip() or None
+        cursor = str(args.get("cursor") or "").strip() or None
+        limit = int(args.get("limit", 50))
+        if not 1 <= limit <= 100:
+            raise ValueError("limit must be between 1 and 100")
+        result = _call_with_kwargs_or_payload(
+            method,
+            {
+                "state": state,
+                "context_id": context_id,
+                "cursor": cursor,
+                "limit": limit,
+            },
+            {
+                "state": state,
+                "contextId": context_id,
+                "cursor": cursor,
+                "limit": limit,
+            },
+        )
+        return _json({"ok": True, "page": _json_safe(result)})
+    except Exception as exc:
+        return _json({"error": str(exc)})
+
+
+def inkbox_get_a2a_sent_task(args: dict, **kwargs) -> str:
+    """Fetch one full caller-side A2A task from the configured identity."""
+    del kwargs
+    task_id = str(args.get("taskId") or args.get("task_id") or "").strip()
+    if not task_id:
+        return _json({"error": "taskId is required"})
+    try:
+        _, _, identity = _client_and_identity()
+        method = _identity_method(
+            identity,
+            "a2a_sent_task",
+            "a2aSentTask",
+        )
+        return _json({
+            "ok": True,
+            "task": _json_safe(method(task_id)),
+        })
+    except Exception as exc:
+        return _json({"error": str(exc)})
+
+
 def _message_too_long_payload(channel: str, content: str, max_chars: int) -> Dict[str, Any]:
     char_count = len(content or "")
     return {
@@ -1420,6 +1479,66 @@ A2A_FAIL_SCHEMA = {
     },
 }
 
+A2A_LIST_SENT_TASKS_SCHEMA = {
+    "name": "inkbox_list_a2a_sent_tasks",
+    "description": (
+        "List A2A tasks sent by this Inkbox identity, newest first. This is the "
+        "identity's durable caller-side history. Follow next_cursor until it is "
+        "null to read every page."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "state": {
+                "type": "string",
+                "enum": [
+                    "submitted",
+                    "working",
+                    "input_required",
+                    "auth_required",
+                    "completed",
+                    "failed",
+                    "canceled",
+                    "rejected",
+                ],
+                "description": "Optional task lifecycle-state filter.",
+            },
+            "contextId": {
+                "type": "string",
+                "description": "Optional A2A context UUID filter.",
+            },
+            "cursor": {
+                "type": "string",
+                "description": "Opaque next_cursor from the previous page.",
+            },
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 100,
+                "default": 50,
+            },
+        },
+    },
+}
+
+A2A_GET_SENT_TASK_SCHEMA = {
+    "name": "inkbox_get_a2a_sent_task",
+    "description": (
+        "Fetch one A2A task sent by this Inkbox identity, including its complete "
+        "message and state-transition history."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "taskId": {
+                "type": "string",
+                "description": "A2A task UUID from inkbox_list_a2a_sent_tasks.",
+            },
+        },
+        "required": ["taskId"],
+    },
+}
+
 
 def register_tools(ctx) -> None:
     ctx.register_tool("inkbox_whoami", "inkbox", WHOAMI_SCHEMA, inkbox_whoami, check_fn=_configured)
@@ -1448,3 +1567,5 @@ def register_tools(ctx) -> None:
     ctx.register_tool("inkbox_a2a_complete", "inkbox", A2A_COMPLETE_SCHEMA, inkbox_a2a_complete, check_fn=_configured)
     ctx.register_tool("inkbox_a2a_ask_caller", "inkbox", A2A_ASK_CALLER_SCHEMA, inkbox_a2a_ask_caller, check_fn=_configured)
     ctx.register_tool("inkbox_a2a_fail", "inkbox", A2A_FAIL_SCHEMA, inkbox_a2a_fail, check_fn=_configured)
+    ctx.register_tool("inkbox_list_a2a_sent_tasks", "inkbox", A2A_LIST_SENT_TASKS_SCHEMA, inkbox_list_a2a_sent_tasks, check_fn=_configured)
+    ctx.register_tool("inkbox_get_a2a_sent_task", "inkbox", A2A_GET_SENT_TASK_SCHEMA, inkbox_get_a2a_sent_task, check_fn=_configured)

--- a/tools.py
+++ b/tools.py
@@ -86,6 +86,104 @@ def inkbox_a2a_fail(args: dict, task_id: str = "", **kwargs) -> str:
     return _a2a_intent("fail", str(args.get("reason") or ""), task_id)
 
 
+def _a2a_optional(args: dict, camel: str, snake: str | None = None) -> str | None:
+    value = args.get(camel)
+    if value is None and snake is not None:
+        value = args.get(snake)
+    return str(value or "").strip() or None
+
+
+def _a2a_limit(args: dict) -> int:
+    limit = int(args.get("limit", 50))
+    if not 1 <= limit <= 100:
+        raise ValueError("limit must be between 1 and 100")
+    return limit
+
+
+def inkbox_list_a2a_tasks(args: dict, **kwargs) -> str:
+    """List the configured identity's A2A task history."""
+    del kwargs
+    try:
+        python_options = {
+            "direction": _a2a_optional(args, "direction"),
+            "requester_handle": _a2a_optional(
+                args, "requesterHandle", "requester_handle"
+            ),
+            "worker_handle": _a2a_optional(
+                args, "workerHandle", "worker_handle"
+            ),
+            "state": _a2a_optional(args, "state"),
+            "context_id": _a2a_optional(args, "contextId", "context_id"),
+            "q": _a2a_optional(args, "query", "q"),
+            "since": _a2a_optional(args, "since"),
+            "cursor": _a2a_optional(args, "cursor"),
+            "limit": _a2a_limit(args),
+        }
+        _, _, identity = _client_and_identity()
+        method = _identity_method(identity, "a2a_tasks", "a2aTasks")
+        result = _call_with_kwargs_or_payload(
+            method,
+            python_options,
+            {
+                "direction": python_options["direction"],
+                "requesterHandle": python_options["requester_handle"],
+                "workerHandle": python_options["worker_handle"],
+                "state": python_options["state"],
+                "contextId": python_options["context_id"],
+                "q": python_options["q"],
+                "since": python_options["since"],
+                "cursor": python_options["cursor"],
+                "limit": python_options["limit"],
+            },
+        )
+        return _json({"ok": True, "page": _json_safe(result)})
+    except Exception as exc:
+        return _json({"error": str(exc)})
+
+
+def inkbox_list_a2a_messages(args: dict, **kwargs) -> str:
+    """List the configured identity's A2A message history."""
+    del kwargs
+    try:
+        python_options = {
+            "direction": _a2a_optional(args, "direction"),
+            "requester_handle": _a2a_optional(
+                args, "requesterHandle", "requester_handle"
+            ),
+            "worker_handle": _a2a_optional(
+                args, "workerHandle", "worker_handle"
+            ),
+            "task_id": _a2a_optional(args, "taskId", "task_id"),
+            "context_id": _a2a_optional(args, "contextId", "context_id"),
+            "role": _a2a_optional(args, "role"),
+            "q": _a2a_optional(args, "query", "q"),
+            "since": _a2a_optional(args, "since"),
+            "cursor": _a2a_optional(args, "cursor"),
+            "limit": _a2a_limit(args),
+        }
+        _, _, identity = _client_and_identity()
+        method = _identity_method(identity, "a2a_messages", "a2aMessages")
+        result = _call_with_kwargs_or_payload(
+            method,
+            python_options,
+            {
+                "direction": python_options["direction"],
+                "requesterHandle": python_options["requester_handle"],
+                "workerHandle": python_options["worker_handle"],
+                "taskId": python_options["task_id"],
+                "contextId": python_options["context_id"],
+                "role": python_options["role"],
+                "q": python_options["q"],
+                "since": python_options["since"],
+                "cursor": python_options["cursor"],
+                "limit": python_options["limit"],
+            },
+        )
+        return _json({"ok": True, "page": _json_safe(result)})
+    except Exception as exc:
+        return _json({"error": str(exc)})
+
+
 def inkbox_list_a2a_sent_tasks(args: dict, **kwargs) -> str:
     """List the configured identity's caller-side A2A task history."""
     del kwargs
@@ -96,25 +194,37 @@ def inkbox_list_a2a_sent_tasks(args: dict, **kwargs) -> str:
             "a2a_sent_tasks",
             "a2aSentTasks",
         )
-        state = str(args.get("state") or "").strip() or None
-        context_id = str(
-            args.get("contextId") or args.get("context_id") or ""
-        ).strip() or None
-        cursor = str(args.get("cursor") or "").strip() or None
-        limit = int(args.get("limit", 50))
-        if not 1 <= limit <= 100:
-            raise ValueError("limit must be between 1 and 100")
+        requester_handle = _a2a_optional(
+            args, "requesterHandle", "requester_handle"
+        )
+        worker_handle = _a2a_optional(
+            args, "workerHandle", "worker_handle"
+        )
+        state = _a2a_optional(args, "state")
+        context_id = _a2a_optional(args, "contextId", "context_id")
+        query = _a2a_optional(args, "query", "q")
+        since = _a2a_optional(args, "since")
+        cursor = _a2a_optional(args, "cursor")
+        limit = _a2a_limit(args)
         result = _call_with_kwargs_or_payload(
             method,
             {
+                "requester_handle": requester_handle,
+                "worker_handle": worker_handle,
                 "state": state,
                 "context_id": context_id,
+                "q": query,
+                "since": since,
                 "cursor": cursor,
                 "limit": limit,
             },
             {
+                "requesterHandle": requester_handle,
+                "workerHandle": worker_handle,
                 "state": state,
                 "contextId": context_id,
+                "q": query,
+                "since": since,
                 "cursor": cursor,
                 "limit": limit,
             },
@@ -1037,7 +1147,7 @@ def inkbox_place_call(args: dict, **kwargs) -> str:
 
         def _place():
             if not hasattr(identity, "place_call"):
-                raise RuntimeError("Inkbox SDK identity has no place_call method (upgrade inkbox to >=0.5.1)")
+                raise RuntimeError("Inkbox SDK identity has no place_call method (upgrade inkbox to >=0.5.6)")
             try:
                 return identity.place_call(
                     to_number=to_number,
@@ -1479,6 +1589,128 @@ A2A_FAIL_SCHEMA = {
     },
 }
 
+A2A_HISTORY_DIRECTIONS = ["inbound", "outbound", "both"]
+A2A_TASK_STATES = [
+    "submitted",
+    "working",
+    "input_required",
+    "auth_required",
+    "completed",
+    "failed",
+    "canceled",
+    "rejected",
+]
+
+A2A_LIST_TASKS_SCHEMA = {
+    "name": "inkbox_list_a2a_tasks",
+    "description": (
+        "List this identity's A2A task history, newest first. Direction defaults "
+        "to inbound. Follow next_cursor until it is null to read every page."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "direction": {
+                "type": "string",
+                "enum": A2A_HISTORY_DIRECTIONS,
+                "description": "Optional inbound, outbound, or both filter.",
+            },
+            "requesterHandle": {
+                "type": "string",
+                "description": "Optional requester identity handle filter.",
+            },
+            "workerHandle": {
+                "type": "string",
+                "description": "Optional worker identity handle filter.",
+            },
+            "state": {
+                "type": "string",
+                "enum": A2A_TASK_STATES,
+                "description": "Optional task lifecycle-state filter.",
+            },
+            "contextId": {
+                "type": "string",
+                "description": "Optional A2A context UUID filter.",
+            },
+            "query": {
+                "type": "string",
+                "description": "Optional keyword search across task messages.",
+            },
+            "since": {
+                "type": "string",
+                "description": "Optional ISO 8601 lower timestamp bound.",
+            },
+            "cursor": {
+                "type": "string",
+                "description": "Opaque next_cursor from the previous page.",
+            },
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 100,
+                "default": 50,
+            },
+        },
+    },
+}
+
+A2A_LIST_MESSAGES_SCHEMA = {
+    "name": "inkbox_list_a2a_messages",
+    "description": (
+        "List messages from this identity's inbound and outbound A2A history, "
+        "newest first. Follow next_cursor until it is null to read every page."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "direction": {
+                "type": "string",
+                "enum": A2A_HISTORY_DIRECTIONS,
+                "description": "Optional inbound, outbound, or both filter.",
+            },
+            "requesterHandle": {
+                "type": "string",
+                "description": "Optional requester identity handle filter.",
+            },
+            "workerHandle": {
+                "type": "string",
+                "description": "Optional worker identity handle filter.",
+            },
+            "taskId": {
+                "type": "string",
+                "description": "Optional A2A task UUID filter.",
+            },
+            "contextId": {
+                "type": "string",
+                "description": "Optional A2A context UUID filter.",
+            },
+            "role": {
+                "type": "string",
+                "enum": ["caller", "agent"],
+                "description": "Optional message role filter.",
+            },
+            "query": {
+                "type": "string",
+                "description": "Optional keyword search across message text.",
+            },
+            "since": {
+                "type": "string",
+                "description": "Optional ISO 8601 lower timestamp bound.",
+            },
+            "cursor": {
+                "type": "string",
+                "description": "Opaque next_cursor from the previous page.",
+            },
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 100,
+                "default": 50,
+            },
+        },
+    },
+}
+
 A2A_LIST_SENT_TASKS_SCHEMA = {
     "name": "inkbox_list_a2a_sent_tasks",
     "description": (
@@ -1491,21 +1723,28 @@ A2A_LIST_SENT_TASKS_SCHEMA = {
         "properties": {
             "state": {
                 "type": "string",
-                "enum": [
-                    "submitted",
-                    "working",
-                    "input_required",
-                    "auth_required",
-                    "completed",
-                    "failed",
-                    "canceled",
-                    "rejected",
-                ],
+                "enum": A2A_TASK_STATES,
                 "description": "Optional task lifecycle-state filter.",
+            },
+            "requesterHandle": {
+                "type": "string",
+                "description": "Optional requester identity handle filter.",
+            },
+            "workerHandle": {
+                "type": "string",
+                "description": "Optional worker identity handle filter.",
             },
             "contextId": {
                 "type": "string",
                 "description": "Optional A2A context UUID filter.",
+            },
+            "query": {
+                "type": "string",
+                "description": "Optional keyword search across task messages.",
+            },
+            "since": {
+                "type": "string",
+                "description": "Optional ISO 8601 lower timestamp bound.",
             },
             "cursor": {
                 "type": "string",
@@ -1524,8 +1763,8 @@ A2A_LIST_SENT_TASKS_SCHEMA = {
 A2A_GET_SENT_TASK_SCHEMA = {
     "name": "inkbox_get_a2a_sent_task",
     "description": (
-        "Fetch one A2A task sent by this Inkbox identity, including its complete "
-        "message and state-transition history."
+        "Fetch one A2A task sent by this Inkbox identity, including its message "
+        "history."
     ),
     "parameters": {
         "type": "object",
@@ -1567,5 +1806,7 @@ def register_tools(ctx) -> None:
     ctx.register_tool("inkbox_a2a_complete", "inkbox", A2A_COMPLETE_SCHEMA, inkbox_a2a_complete, check_fn=_configured)
     ctx.register_tool("inkbox_a2a_ask_caller", "inkbox", A2A_ASK_CALLER_SCHEMA, inkbox_a2a_ask_caller, check_fn=_configured)
     ctx.register_tool("inkbox_a2a_fail", "inkbox", A2A_FAIL_SCHEMA, inkbox_a2a_fail, check_fn=_configured)
+    ctx.register_tool("inkbox_list_a2a_tasks", "inkbox", A2A_LIST_TASKS_SCHEMA, inkbox_list_a2a_tasks, check_fn=_configured)
+    ctx.register_tool("inkbox_list_a2a_messages", "inkbox", A2A_LIST_MESSAGES_SCHEMA, inkbox_list_a2a_messages, check_fn=_configured)
     ctx.register_tool("inkbox_list_a2a_sent_tasks", "inkbox", A2A_LIST_SENT_TASKS_SCHEMA, inkbox_list_a2a_sent_tasks, check_fn=_configured)
     ctx.register_tool("inkbox_get_a2a_sent_task", "inkbox", A2A_GET_SENT_TASK_SCHEMA, inkbox_get_a2a_sent_task, check_fn=_configured)

--- a/uv.lock
+++ b/uv.lock
@@ -484,7 +484,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent-plugin"
-version = "0.2.3"
+version = "0.2.4"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -501,7 +501,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9" },
-    { name = "inkbox", specifier = ">=0.4.24,<1.0.0" },
+    { name = "inkbox", specifier = ">=0.5.1,<1.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
     { name = "ruff", marker = "extra == 'test'", specifier = ">=0.11.0" },
     { name = "segno", specifier = ">=1.5" },
@@ -574,7 +574,7 @@ wheels = [
 
 [[package]]
 name = "inkbox"
-version = "0.4.24"
+version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "argon2-cffi" },
@@ -584,9 +584,9 @@ dependencies = [
     { name = "h2" },
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/42/ff93f58971b4d32f5e0c2d144c8e940466b0cf5b6205ba35143cba517387/inkbox-0.4.24.tar.gz", hash = "sha256:6495991355316faa4671c8e7bc6867eed62a03fc3499b9432632eb478e4f9df8", size = 339600, upload-time = "2026-07-13T07:29:30.2Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/50/db1bc5ef52259ae793080766c5d3332e492da5f3b89ad153a830c29f3748/inkbox-0.5.4.tar.gz", hash = "sha256:cccc993f5195383de8bc1cc37e4581c440d2bfde6653ff58866391371446b834", size = 357631, upload-time = "2026-07-23T07:15:57.851Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/13/3aea8bd266026ba5f168b2f960a1291e8f9ed0bc840d1551207a55550bd1/inkbox-0.4.24-py3-none-any.whl", hash = "sha256:862c5c41283ed23f1bb1b90bb495481e880653c6a11c9d3aaf6dc44b504ce2f3", size = 234801, upload-time = "2026-07-13T07:29:28.863Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/ab/9b544f2a85d585f0e01579045f68efd916fb8d1ae8746d2436cd7c269194/inkbox-0.5.4-py3-none-any.whl", hash = "sha256:3a7631c963cc921f54e88763927c9eb5488193af2f1d8d62056c911529c0128e", size = 245851, upload-time = "2026-07-23T07:15:56.48Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -503,7 +503,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.9" },
     { name = "inkbox", specifier = ">=0.5.1,<1.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
-    { name = "ruff", marker = "extra == 'test'", specifier = ">=0.11.0" },
+    { name = "ruff", marker = "extra == 'test'", specifier = ">=0.11.0,<0.16" },
     { name = "segno", specifier = ">=1.5" },
 ]
 provides-extras = ["test"]

--- a/uv.lock
+++ b/uv.lock
@@ -501,7 +501,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9" },
-    { name = "inkbox", git = "https://github.com/inkbox-ai/inkbox.git?subdirectory=sdk%2Fpython&rev=fdea6e55ac117f246624852aedeef0feabe08b9a" },
+    { name = "inkbox", specifier = ">=0.5.6,<1.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
     { name = "ruff", marker = "extra == 'test'", specifier = ">=0.11.0,<0.16" },
     { name = "segno", specifier = ">=1.5" },
@@ -575,7 +575,7 @@ wheels = [
 [[package]]
 name = "inkbox"
 version = "0.5.6"
-source = { git = "https://github.com/inkbox-ai/inkbox.git?subdirectory=sdk%2Fpython&rev=fdea6e55ac117f246624852aedeef0feabe08b9a#fdea6e55ac117f246624852aedeef0feabe08b9a" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "argon2-cffi" },
     { name = "certifi" },
@@ -583,6 +583,10 @@ dependencies = [
     { name = "h11" },
     { name = "h2" },
     { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/25/40ce6a1b74480cfbd747e27f658c93bb9b641c68b6de9c21c3a65a651ea0/inkbox-0.5.6.tar.gz", hash = "sha256:03abc18382deccd6ad8c9adba00fb9c77de11d740da46190cdc68ee46eff2720", size = 371398, upload-time = "2026-07-26T06:34:42.32Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/1c/4ec564d853d7f0419403d1fd3577dc3460e8641c13f7e2502081e40a93e3/inkbox-0.5.6-py3-none-any.whl", hash = "sha256:81b1baeab1a73aaf6b9a25dedd820d75f9218329743f5cbef758d4b08bf64c45", size = 255695, upload-time = "2026-07-26T06:34:41.035Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -501,7 +501,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9" },
-    { name = "inkbox", specifier = ">=0.5.1,<1.0.0" },
+    { name = "inkbox", git = "https://github.com/inkbox-ai/inkbox.git?subdirectory=sdk%2Fpython&rev=fdea6e55ac117f246624852aedeef0feabe08b9a" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
     { name = "ruff", marker = "extra == 'test'", specifier = ">=0.11.0,<0.16" },
     { name = "segno", specifier = ">=1.5" },
@@ -574,8 +574,8 @@ wheels = [
 
 [[package]]
 name = "inkbox"
-version = "0.5.4"
-source = { registry = "https://pypi.org/simple" }
+version = "0.5.6"
+source = { git = "https://github.com/inkbox-ai/inkbox.git?subdirectory=sdk%2Fpython&rev=fdea6e55ac117f246624852aedeef0feabe08b9a#fdea6e55ac117f246624852aedeef0feabe08b9a" }
 dependencies = [
     { name = "argon2-cffi" },
     { name = "certifi" },
@@ -583,10 +583,6 @@ dependencies = [
     { name = "h11" },
     { name = "h2" },
     { name = "httpx" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/be/50/db1bc5ef52259ae793080766c5d3332e492da5f3b89ad153a830c29f3748/inkbox-0.5.4.tar.gz", hash = "sha256:cccc993f5195383de8bc1cc37e4581c440d2bfde6653ff58866391371446b834", size = 357631, upload-time = "2026-07-23T07:15:57.851Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/ab/9b544f2a85d585f0e01579045f68efd916fb8d1ae8746d2436cd7c269194/inkbox-0.5.4-py3-none-any.whl", hash = "sha256:3a7631c963cc921f54e88763927c9eb5488193af2f1d8d62056c911529c0128e", size = 245851, upload-time = "2026-07-23T07:15:56.48Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Decisions

- **Durability:** Persist each `(task_id, message_id)` delivery before acknowledging it and reconcile non-final registry entries before paging submitted tasks after restart.
- **Session isolation:** Route each receiver context to `a2a:{identity}:{context}` and bind verified webhook data to a private Hermes session context for tool authorization.
- **Reply intent:** Add context-gated complete, ask-caller, and fail tools; retain guarded final-text completion only when no explicit intent was committed.
- **Cancellation:** Address cancellation by task and suppress late results so they cannot complete the next queued task.
- **SDK compatibility:** Require the released Inkbox SDK `0.5.6` or newer and resolve it from PyPI in local, CI, and live-test environments instead of a source commit.
- **Host compatibility:** Test against the latest Hermes `main` from outside the plugin checkout so the plugin's `tools.py` cannot shadow Hermes' package during contract collection.

## Changes

- Subscribe identity webhooks to all A2A lifecycle events and catch up submitted tasks after reconnect.
- Add durable inbound registry state, per-context routing, verified intent tools, and default final-answer completion.
- Record and route task cancellation without shifting a late response onto another task.
- Add `inkbox_list_a2a_sent_tasks` and `inkbox_get_a2a_sent_task` so a Hermes identity can read its outbound request history.
- Resolve `inkbox>=0.5.6,<1.0.0` from PyPI across the project lockfile and every CI/live installation path.
- Bump the plugin to `0.2.4`.

## Related pull requests

- SDK/CLI: [Inkbox SDK PR 123](https://github.com/inkbox-ai/inkbox/pull/123)
- Hosts: [Claude Code PR 45](https://github.com/inkbox-ai/claude-code-plugin/pull/45), [Codex PR 26](https://github.com/inkbox-ai/codex-plugin/pull/26), [OpenCode PR 9](https://github.com/inkbox-ai/opencode-plugin/pull/9), [OpenClaw PR 43](https://github.com/inkbox-ai/openclaw-plugin/pull/43)

## Merge order

Merge after the paused-contract base PR. Inkbox SDK `0.5.6` is published.

## Verification

- Ruff passes.
- Full local suite: `266 passed, 24 skipped`.
- Latest-Hermes contract suite: `12 passed` against `NousResearch/hermes-agent@d2e733e`.
- GitHub unit tests pass on Python 3.11 and 3.12.
- GitHub latest-Hermes contract check passes.
- GitHub mock and authorized live channel checks pass with the published SDK.
- Authorized live A2A verification covered card discovery, authenticated task delivery, webhook handling, input requests, receiver completion, context reuse, history reads, and durable recovery.
