### PR TITLE
Initialize the A2A test adapter platform

### DIFF
--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -33,6 +33,7 @@ def fake_web(monkeypatch):
 
 def _adapter(tmp_path):
     adapter = object.__new__(InkboxAdapter)
+    adapter.platform = "inkbox"
     adapter._identity_id = "identity-1"
     adapter._identity_handle = "agent"
     adapter._a2a_registry_path = tmp_path / "a2a.json"


### PR DESCRIPTION
## Decisions

- **Test adapter setup:** Initialize only the inherited platform field required by source construction, keeping the focused synthetic fixture otherwise unchanged.

## Changes

- Set the A2A test adapter platform before invoking inherited host helpers.

## Verification

- `uv run pytest tests/test_a2a.py -q` against the current host (14 passed)
- `uv run pytest -q` against the current host (278 passed, 23 skipped)