### PR TITLE
Use the full inbound email body; identify the plugin in the User-Agent

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -607,6 +607,28 @@ def _string_list_field(obj: Any, *names: str) -> list[str]:
     return [str(item).strip() for item in _list_field(obj, *names) if str(item).strip()]
 
 
+def _inbound_mail_body(message: Dict[str, Any]) -> str:
+    """Body text for an inbound email webhook.
+
+    ``message.received`` carries the full body; older payloads and replays
+    only have the 200-char ``snippet``, so fall back to it.
+    """
+    body = str(message.get("body") or "")
+    if not body.strip():
+        return str(message.get("snippet") or "")
+    if str(message.get("body_state") or "") != "truncated":
+        return body
+    total = message.get("body_total_chars")
+    included = message.get("body_included_chars")
+    msg_id = str(message.get("id") or "")
+    counts = f"{included} of {total} characters" if total and included else "part"
+    return (
+        f"{body}\n\n[inkbox: this email was too long to deliver in full. "
+        f"You are seeing {counts}."
+        + (f" Fetch email {msg_id} to read the rest.]" if msg_id else "]")
+    )
+
+
 def _webhook_list(data: Dict[str, Any], *names: str) -> list[Any]:
     for name in names:
         value = data.get(name)
@@ -3669,7 +3691,7 @@ class InkboxAdapter(BasePlatformAdapter):
             # actually threads the reply.
             message_id=rfc_message_id or message.get("id"),
         )
-        body_text = message.get("snippet") or subject or ""
+        body_text = _inbound_mail_body(message) or subject or ""
         # Modality marker — every inbound is prefixed with one line that
         # tells the agent which modality + which Inkbox Contact (if any)
         # this message belongs to.  PLATFORM_HINTS["inkbox"] explains how

--- a/config.py
+++ b/config.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
+import importlib.metadata
 import os
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Any, Dict
 
 
 # Empty means "do not override"; the Inkbox SDK owns its API default.
 INKBOX_BASE_URL_DEFAULT = ""
 INKBOX_WS_PATH = "/phone/media/ws"
+
+USER_AGENT_NAME = "inkbox-hermes"
+DISTRIBUTION_NAME = "hermes-agent-plugin"
 
 
 @dataclass
@@ -31,8 +36,22 @@ def inkbox_base_url_kwargs(base_url: str | None = None) -> Dict[str, str]:
     return {"base_url": normalized} if normalized else {}
 
 
+@lru_cache(maxsize=1)
+def plugin_user_agent() -> str:
+    """Identifies this plugin ahead of the SDK's own ``User-Agent`` token."""
+    try:
+        version = importlib.metadata.version(DISTRIBUTION_NAME)
+    except importlib.metadata.PackageNotFoundError:
+        version = "unknown"
+    return f"{USER_AGENT_NAME}/{version}"
+
+
 def inkbox_client_kwargs(api_key: str, base_url: str | None = None) -> Dict[str, str]:
-    return {"api_key": api_key, **inkbox_base_url_kwargs(base_url)}
+    return {
+        "api_key": api_key,
+        "user_agent_prefix": plugin_user_agent(),
+        **inkbox_base_url_kwargs(base_url),
+    }
 
 
 def env_flag(name: str, default: bool = False) -> bool:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: inkbox
 label: Inkbox
 kind: platform
-version: 0.2.4
+version: 0.2.5
 description: Inkbox email, SMS/MMS, iMessage, and voice platform plugin for Hermes Agent.
 author: Inkbox
 requires_env: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hermes-agent-plugin"
-version = "0.2.4"
+version = "0.2.5"
 description = "Inkbox platform plugin for Hermes Agent"
 # inkbox>=0.4.7 requires Python 3.11+, so we can't claim 3.10 support.
 requires-python = ">=3.11"

--- a/tests/test_inbound_mail_body.py
+++ b/tests/test_inbound_mail_body.py
@@ -1,0 +1,159 @@
+"""Inbound email turns carry the full body, not the 200-char snippet.
+
+``message.received`` ships the body alongside the snippet, self-describing
+when it had to abbreviate. The agent sees the whole email when one fits,
+a truncation notice naming the message id when it does not, and the
+snippet only on payloads that carry no body at all.
+"""
+
+import asyncio
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("inkbox_plugin")
+pkg.__path__ = [str(ROOT)]
+sys.modules.setdefault("inkbox_plugin", pkg)
+
+from inkbox_plugin import adapter as adapter_mod
+from inkbox_plugin.adapter import InkboxAdapter, _inbound_mail_body
+
+
+LONG_BODY = "Pricing details follow. " * 40
+
+
+@pytest.fixture(autouse=True)
+def fake_web(monkeypatch):
+    monkeypatch.setattr(
+        adapter_mod,
+        "web",
+        types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
+    )
+
+
+def _adapter():
+    """Bare adapter with just the state the mail path touches."""
+    adapter = object.__new__(InkboxAdapter)
+    adapter.platform = "inkbox"
+    adapter._inkbox = None
+    adapter._identity_handle = "smoke-agent"
+    adapter._identity_id = None
+    adapter._identity_email_addresses_loaded = True
+    adapter._identity_email_addresses = {"smoke-agent@inkboxmail.com"}
+    adapter._seen_request_ids = {}
+    adapter._inflight_request_ids = {}
+    adapter._outbound_failure_state = {}
+    adapter._last_inbound_modality = {}
+    adapter._last_inbound_email = {}
+    adapter._resolve_channel_overrides = lambda *_a, **_k: (None, None)
+
+    async def _resolve_contact_full(**_kwargs):
+        return None
+
+    adapter._resolve_contact_full = _resolve_contact_full
+    adapter._enqueued = []
+
+    async def _capture(event):
+        adapter._enqueued.append(event)
+
+    adapter._enqueue = _capture
+    return adapter
+
+
+def _mail_envelope(**message_overrides):
+    message = {
+        "id": "mail-in-1",
+        "thread_id": "thread-1",
+        "message_id": "<mail-in-1@inkboxmail.com>",
+        "from_address": "atlas@inkboxmail.com",
+        "to_addresses": ["smoke-agent@inkboxmail.com"],
+        "subject": "Coordinating",
+        "snippet": LONG_BODY[:200],
+        "direction": "inbound",
+    }
+    message.update(message_overrides)
+    return {
+        "id": "evt-mail-1",
+        "event_type": "message.received",
+        "data": {"contacts": [], "agent_identities": [], "message": message},
+    }
+
+
+def _only_event(adapter):
+    assert len(adapter._enqueued) == 1
+    return adapter._enqueued[0]
+
+
+# ── helper ───────────────────────────────────────────────────────────────
+
+
+def test_complete_body_is_used_verbatim():
+    message = {"body": LONG_BODY, "body_state": "complete", "snippet": LONG_BODY[:200]}
+
+    assert _inbound_mail_body(message) == LONG_BODY
+
+
+def test_truncated_body_appends_a_notice_with_the_message_id():
+    message = {
+        "id": "mail-in-9",
+        "body": LONG_BODY,
+        "body_state": "truncated",
+        "body_truncated": True,
+        "body_total_chars": 40_000,
+        "body_included_chars": len(LONG_BODY),
+        "snippet": LONG_BODY[:200],
+    }
+
+    result = _inbound_mail_body(message)
+
+    assert result.startswith(LONG_BODY)
+    assert "too long to deliver in full" in result
+    assert f"{len(LONG_BODY)} of 40000 characters" in result
+    assert "mail-in-9" in result
+
+
+def test_missing_body_falls_back_to_the_snippet():
+    # Replays and pre-body payloads carry a snippet and nothing else.
+    message = {"snippet": LONG_BODY[:200]}
+
+    assert _inbound_mail_body(message) == LONG_BODY[:200]
+
+
+def test_null_body_falls_back_to_the_snippet():
+    message = {"body": None, "body_state": None, "snippet": LONG_BODY[:200]}
+
+    assert _inbound_mail_body(message) == LONG_BODY[:200]
+
+
+def test_unavailable_body_falls_back_to_the_snippet():
+    message = {"body": "", "body_state": "unavailable", "snippet": LONG_BODY[:200]}
+
+    assert _inbound_mail_body(message) == LONG_BODY[:200]
+
+
+# ── inbound turn ─────────────────────────────────────────────────────────
+
+
+def test_inbound_turn_carries_the_full_body():
+    adapter = _adapter()
+
+    asyncio.run(
+        adapter._on_mail_received(
+            _mail_envelope(body=LONG_BODY, body_state="complete")
+        )
+    )
+
+    text = _only_event(adapter).text
+    assert LONG_BODY in text
+    assert text.rstrip().endswith(LONG_BODY.rstrip())
+
+
+def test_inbound_turn_without_a_body_still_delivers_the_snippet():
+    adapter = _adapter()
+
+    asyncio.run(adapter._on_mail_received(_mail_envelope()))
+
+    assert LONG_BODY[:200] in _only_event(adapter).text

--- a/tests/test_user_agent.py
+++ b/tests/test_user_agent.py
@@ -1,0 +1,42 @@
+"""The plugin identifies itself and its version in the SDK User-Agent."""
+
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("inkbox_plugin")
+pkg.__path__ = [str(ROOT)]
+sys.modules.setdefault("inkbox_plugin", pkg)
+
+from inkbox_plugin import config as config_mod
+
+
+def test_user_agent_names_the_plugin_and_its_version():
+    config_mod.plugin_user_agent.cache_clear()
+
+    ua = config_mod.plugin_user_agent()
+
+    assert ua.startswith("inkbox-hermes/")
+    assert ua.split("/", 1)[1]
+
+
+def test_client_kwargs_carry_the_prefix():
+    kwargs = config_mod.inkbox_client_kwargs("ak_test")
+
+    assert kwargs["api_key"] == "ak_test"
+    assert kwargs["user_agent_prefix"] == config_mod.plugin_user_agent()
+
+
+def test_unknown_distribution_still_yields_a_token(monkeypatch):
+    import importlib.metadata
+
+    def _missing(_name):
+        raise importlib.metadata.PackageNotFoundError
+
+    monkeypatch.setattr(importlib.metadata, "version", _missing)
+    config_mod.plugin_user_agent.cache_clear()
+
+    assert config_mod.plugin_user_agent() == "inkbox-hermes/unknown"
+
+    config_mod.plugin_user_agent.cache_clear()

--- a/uv.lock
+++ b/uv.lock
@@ -484,7 +484,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent-plugin"
-version = "0.2.4"
+version = "0.2.5"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Two changes to the inbound mail path and one fleet-wide version alignment.

**1. Inbound email used the snippet, not the body.** Turns were built from `snippet`, the 200-char preview. `message.received` carries the plain-text body alongside it, so the agent was seeing long emails cut off mid-sentence with nothing in the turn indicating content was missing. From the agent's side that is unrecoverable: it has no signal there is more to read, so it either answers on a fragment or asks the sender to resend.

**2. The plugin was anonymous to the API.** The SDK announces itself in the `User-Agent` and accepts a caller token ahead of its own, but the plugin never set one, so its requests were indistinguishable from any other Python SDK caller. There was no way to tell which plugin, or which version of it, an agent was running.

## What's here

### Full inbound body

- **`_inbound_mail_body(message)`** resolves the turn text: the body when present, the snippet otherwise.
- **Truncation is self-describing.** A body over the delivery cap arrives as a prefix with `body_state: "truncated"`. That case appends a single notice line giving the included/total character counts and the message id, so the agent can fetch the remainder instead of guessing the email ended where the text stopped.
- **Snippet stays the fallback.** Replays and events predating the body field carry no body; those turns are unchanged. Bounce and delivery-failure handlers are untouched, since `body` is null by contract on non-`received` events and the snippet is the only text available there.

### Plugin User-Agent

- `inkbox_client_kwargs` now passes `user_agent_prefix`, yielding `inkbox-hermes/<version> inkbox-python/<sdk version>`. That helper is the single place client kwargs are built, so every construction site is covered by one change.
- The version comes from installed package metadata, not a hardcoded constant, so the token cannot drift from the declared version.
- This adds no new data channel: the `User-Agent` header is already sent on every request. It fills in a field that was previously blank.

### Version

Realigned to **0.2.5**, the shared number across the plugin fleet. Previously each repo counted independently (0.2.4 / 0.2.2 / 0.1.4 / 0.1.3 / 0.1.0), so a version told you nothing about which fleet release you were on. 0.2.5 is one above the previous fleet maximum, so every repo moves strictly up and no version number is reused for different content.

## Behavior change

Inbound email turns get longer. Anything downstream that assumed a mail turn was at most ~200 chars of body will now see the whole email.

## Tests

`tests/test_inbound_mail_body.py` covers the body helper (complete / truncated / missing / null / unavailable) and the inbound turn end to end. `tests/test_user_agent.py` covers the token, its presence in the client kwargs, and the missing-distribution fallback. Full suite: 288 passed.