### PR TITLE
Add dedicated-outbound iMessage group chats

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ---
 
-Status: gateway platform adapter, setup wizard, doctor checks, SMS/MMS batching, 1:1 and group SMS conversations, inbound email/SMS/iMessage/voice, OpenAI Realtime phone calls, post-call actions, SMS and iMessage conversation tools, and package-included skills are implemented.
+Status: gateway platform adapter, setup wizard, doctor checks, SMS/MMS batching, 1:1 and group SMS/iMessage conversations, inbound email/SMS/iMessage/voice, OpenAI Realtime phone calls, post-call actions, conversation tools, and package-included skills are implemented.
 
 ## Prerequisites
 
@@ -173,16 +173,18 @@ Inbound answering is configured once per identity (`auto_accept` → open the ca
 
 ## iMessage
 
-iMessage works differently from SMS: the agent does not get its own iMessage number. People connect to the agent through the Inkbox iMessage router, and each connected person gets a dedicated thread with the agent.
+iMessage supports shared, dedicated inbound, and dedicated outbound lines. Shared and dedicated inbound lines are recipient-first. A dedicated outbound line can initiate 1:1 conversations and groups of 2–8 distinct recipients.
 
 1. Enable iMessage for the agent during `hermes inkbox setup` (or later by rerunning it). Enablement is stored on the Inkbox identity, not in local config.
 2. From an iPhone, text the connect command (for example `connect @my-agent-handle`) to the Inkbox iMessage router number. The wizard prints both, and the agent can also share them via the `inkbox_imessage_triage_number` tool.
-3. Inkbox texts back from the number assigned to that conversation. Send any first message there — the agent can only reply after you message it first (recipient-first; there is no cold outreach over iMessage).
-4. The setup wizard waits for that first message and replies with a welcome confirming the channel. From then on, the gateway routes the thread into the same contact-keyed Hermes session as email/SMS/voice, and the agent replies over iMessage by default to whoever last reached it there.
+3. On shared service, Inkbox texts back from the number assigned to that conversation. Send any first message there. Dedicated inbound lines likewise require the recipient to message first; dedicated outbound lines may initiate conversations.
+4. The setup wizard waits for that first message and replies with a welcome confirming the channel. From then on, a 1:1 thread joins the same contact-keyed Hermes session as email/SMS/voice, while each group gets its own shared conversation session. The agent replies over iMessage by default to the thread that woke it.
 
 If a person disconnects the agent, outbound sends to that conversation fail until they reconnect through the router and message the agent again. Conversation rows expose `assignment_status` (`active`/`released`) so the agent can see this, and `inkbox_list_imessage_assignments` lists who is currently connected. Outbound delivery transitions (`imessage.sent`, `imessage.delivered`) arrive as webhooks and are logged by the gateway without waking the agent; `imessage.delivery_failed` wakes the agent to fix and resend, matching the SMS lifecycle handling — where `text.delivery_unconfirmed` (carrier uncertainty, not a failure) is likewise logged without a wake.
 
 Native attachments work in both outbound paths. In a normal channel reply, Hermes `MEDIA:/absolute/path` directives are securely validated, uploaded with the Inkbox SDK, and sent as iMessage media. For explicit `inkbox_send_imessage` calls, use `mediaPaths` for local files; use `mediaUrls` only for already-hosted public HTTP(S) URLs. iMessage supports one attachment of up to 10 MiB per message.
+
+Group iMessage uses the same conversation-first behavior as group SMS. `inkbox_list_imessage_conversations` includes groups by default, `inkbox_get_imessage_conversation` returns their history, and `inkbox_send_imessage` replies with `conversationId`. To start a group, pass 2–8 distinct E.164 recipients in `to`; the plugin verifies that the identity has a dedicated outbound iMessage line first. Inbound group messages share a conversation session, include sender and participant context, and only trigger a visible reply when the agent is addressed or expected to act. Typing indicators and read receipts remain 1:1-only.
 
 Once someone is connected over iMessage, the agent can also place and receive **voice calls** with them over that same shared line — see [Two calling lines](#two-calling-lines). This works even for an agent that has no dedicated phone number.
 
@@ -221,7 +223,7 @@ After the gateway starts:
 3. Send the agent an SMS and verify it replies in the same SMS thread.
 4. Add the agent to a group SMS/MMS conversation and verify it stays silent for unrelated chatter, then replies in the same conversation when addressed.
 5. Send the agent an email and verify it replies from its Inkbox mailbox.
-6. If iMessage is enabled, connect via the iMessage router, message the agent, and verify it replies in the same iMessage thread.
+6. If iMessage is enabled, connect via the iMessage router, message the agent, and verify it replies in the same iMessage thread. For a dedicated outbound line, also start a group and verify addressed replies stay in that conversation while unrelated chatter receives no response.
 7. Call the agent phone number and ask for its handle, email, and phone.
 8. Ask during a call for a post-call SMS or email follow-up, then verify it sends after hangup.
 

--- a/adapter.py
+++ b/adapter.py
@@ -21,9 +21,9 @@ On ``connect()`` the adapter:
   2. Registers webhook subscriptions for the configured identity's
      mailbox (``message.*`` events), phone number (``text.*``
      events), and — when the identity is iMessage-enabled — the
-     identity itself (``imessage.*`` events; iMessage rides shared
-     Inkbox-managed numbers, so the subscription owner is the agent
-     identity rather than a phone number) pointing at the tunnel, and
+     identity itself (``imessage.*`` events; shared and dedicated iMessage
+     lines are all owned by the agent identity at the webhook layer) pointing
+     at the tunnel, and
      patches the phone number's incoming-call webhook URL + WebSocket
      URL on the resource itself (the call channel is a synchronous
      control-plane callback and is not a fan-out subscription).
@@ -46,7 +46,9 @@ Hermes session spans email + SMS + voice for the same remote party::
 
     inbound mail     → chat_id=contact_id, thread_id=f"email:{tid}"
     inbound SMS      → chat_id=contact_id, thread_id=None
-    inbound iMessage → chat_id=contact_id, thread_id=f"imessage:{cid}"
+    inbound iMessage → chat_id=contact_id, thread_id=f"imessage:{cid}" (1:1)
+    group iMessage   → chat_id=f"imessage:{cid}",
+                       thread_id=f"imessage:{cid}" (shared group context)
     inbound call     → chat_id=contact_id, thread_id=f"call:{call_id}"
     outbound call    → chat_id=contact_id, thread_id=None  (joins the
                        contact's main session so the agent inherits the
@@ -63,9 +65,9 @@ Outbound
   - ``sms``      → ``identity.send_text(conversation_id=..., text=...)``
                    for replies, falling back to ``to=...`` for legacy/new sends
   - ``imessage`` → ``identity.send_imessage(conversation_id=..., text=...)``.
-    iMessage is recipient-first: the remote party must have messaged the
-    agent at least once before outbound sends work, so replies always
-    target an existing conversation.
+    Replies always target the existing 1:1 or group conversation. The
+    ``inkbox_send_imessage`` tool may initiate a conversation by recipient;
+    groups require a dedicated outbound iMessage line.
   - ``voice``    → push a ``text`` frame onto the contact's active call
     WebSocket so Inkbox-managed TTS speaks it to the caller.
 
@@ -4122,6 +4124,34 @@ class InkboxAdapter(BasePlatformAdapter):
             )
             return None
 
+    async def _lookup_imessage_conversation(self, conversation_id: str) -> Any:
+        """Fetch iMessage conversation metadata for events that omit group fields."""
+        if not conversation_id or self._inkbox is None:
+            return None
+
+        def _lookup():
+            identity = self._inkbox.get_identity(self._identity_handle)
+            method = getattr(identity, "get_imessage_conversation", None)
+            if callable(method):
+                return method(conversation_id)
+            method = getattr(identity, "getImessageConversation", None)
+            if callable(method):
+                try:
+                    return method(conversation_id)
+                except TypeError:
+                    return method({"conversationId": conversation_id})
+            return None
+
+        try:
+            return await asyncio.to_thread(_lookup)
+        except Exception as exc:
+            logger.debug(
+                "[Inkbox] iMessage conversation lookup failed for %s: %s",
+                conversation_id,
+                exc,
+            )
+            return None
+
     def _build_sms_text_event(
         self,
         *,
@@ -4214,6 +4244,8 @@ class InkboxAdapter(BasePlatformAdapter):
             or text.startswith("[inkbox:group_sms_burst ")
             or text.startswith("[inkbox:imessage ")
             or text.startswith("[inkbox:imessage_burst ")
+            or text.startswith("[inkbox:group_imessage ")
+            or text.startswith("[inkbox:group_imessage_burst ")
         ):
             return {"mode": "queue", "merge_text": True}
         return None
@@ -4307,6 +4339,16 @@ class InkboxAdapter(BasePlatformAdapter):
                     "[inkbox:group_sms ",
                     (
                         f"[inkbox:group_sms_burst messages={len(fragments)} "
+                        f"first_at={_format_inkbox_timestamp(first_at)} "
+                        f"last_at={_format_inkbox_timestamp(last_at)} "
+                    ),
+                    1,
+                )
+            elif str(batch["marker"]).startswith("[inkbox:group_imessage "):
+                burst_marker = batch["marker"].replace(
+                    "[inkbox:group_imessage ",
+                    (
+                        f"[inkbox:group_imessage_burst messages={len(fragments)} "
                         f"first_at={_format_inkbox_timestamp(first_at)} "
                         f"last_at={_format_inkbox_timestamp(last_at)} "
                     ),
@@ -4912,14 +4954,26 @@ class InkboxAdapter(BasePlatformAdapter):
         media_urls: Optional[list[str]] = None,
         media_types: Optional[list[str]] = None,
         conversation_id: Optional[str] = None,
+        is_group: bool = False,
+        participants: Optional[list[str]] = None,
         agent_identity: Optional[Dict[str, str]] = None,
     ) -> MessageEvent:
         thread_id = f"imessage:{conversation_id}" if conversation_id else None
+        chat_name = (
+            f"Inkbox iMessage group {conversation_id or remote}"
+            if is_group
+            else contact_name or remote
+        )
+        user_id = (
+            str((contact or {}).get("id") or remote)
+            if is_group
+            else str(chat_id)
+        )
         source = self.build_source(
             chat_id=str(chat_id),
-            chat_name=contact_name or remote,
-            chat_type="dm",
-            user_id=str(chat_id),
+            chat_name=chat_name,
+            chat_type="group" if is_group else "dm",
+            user_id=user_id,
             user_name=contact_name or remote,
             user_id_alt=remote,
             thread_id=thread_id,
@@ -4927,10 +4981,27 @@ class InkboxAdapter(BasePlatformAdapter):
         )
         if text is None:
             contact_block = self._contact_marker(contact, agent_identity)
-            conversation_part = (
-                f" conversation_id={conversation_id}" if conversation_id else ""
-            )
-            text = f"[inkbox:imessage from={remote}{conversation_part} | {contact_block}]\n{body}"
+            if is_group:
+                marker_parts = [
+                    f"[inkbox:group_imessage conversation_id={conversation_id or 'unknown'}",
+                    f"from={remote}",
+                    f"participants={','.join(participants or [])}" if participants else None,
+                    "reply_mode=conversation_id",
+                    f"| {contact_block}]",
+                ]
+                marker = " ".join(part for part in marker_parts if part)
+                group_policy = "\n".join([
+                    "Group iMessage response policy: you receive every message in this group so you can track context.",
+                    "Reply only when the latest message clearly addresses this Inkbox agent, asks it to act, or a visible answer would be expected from the agent.",
+                    "Treat ordinary group chatter as context only.",
+                    "If no visible reply is warranted, return exactly [SILENT].",
+                ])
+                text = "\n".join(part for part in [marker, group_policy, body] if part)
+            else:
+                conversation_part = (
+                    f" conversation_id={conversation_id}" if conversation_id else ""
+                )
+                text = f"[inkbox:imessage from={remote}{conversation_part} | {contact_block}]\n{body}"
         # iMessage always carries the responder playbook alongside the general
         # guide; operator overrides for this channel layer on top.
         default_skills = (
@@ -4956,10 +5027,9 @@ class InkboxAdapter(BasePlatformAdapter):
     async def _on_imessage_received(self, envelope: Dict[str, Any]) -> "web.Response":
         """Route an inbound iMessage into the contact's Hermes session.
 
-        Mirrors ``_on_text_received`` minus the SMS-only concerns: there is
-        no group support, no opt-in control words, and no local number —
-        iMessage rides a shared Inkbox-managed line, so the conversation id
-        is the only stable reply target and is stashed for ``send()``.
+        Mirrors ``_on_text_received`` while preserving iMessage-specific
+        delivery behavior. The conversation id is the stable reply target for
+        both one-to-one and group chats and is stashed for ``send()``.
         """
         message = (envelope.get("data") or {}).get("message") or {}
         message_id = str(message.get("id") or "").strip()
@@ -4981,26 +5051,34 @@ class InkboxAdapter(BasePlatformAdapter):
         if direction and direction != "inbound":
             return web.Response(status=200, text="ok")
         remote = str(
-            message.get("remote_number") or message.get("remoteNumber") or ""
+            message.get("sender_number")
+            or message.get("senderNumber")
+            or message.get("remote_number")
+            or message.get("remoteNumber")
+            or ""
         ).strip()
         if not remote:
             return web.Response(status=200, text="ok")
         conversation_id = str(
             message.get("conversation_id") or message.get("conversationId") or ""
         ).strip()
+        participants = _string_list_field(message, "participants")
+        is_group = bool(_field(message, "isGroup", "is_group")) or len(participants) > 1
 
         contact = await self._resolve_contact_full(kind="phone", value=remote)
-        chat_id = _chat_id_for_route(
-            contact,
-            _channel_thread_key("imessage", conversation_id),
-            remote,
+        chat_id = (
+            _channel_thread_key("imessage", conversation_id) or remote
+            if is_group
+            else _chat_id_for_route(
+                contact,
+                _channel_thread_key("imessage", conversation_id),
+                remote,
+            )
         )
         contact_name = contact["name"] if contact and contact.get("name") else None
-        # Sender labelling fallback; no group iMessage, so the exactly-one
-        # rule alone guards against ambiguity.
         sender_identity = (
             None
-            if contact
+            if contact or is_group
             else _single_agent_identity(_webhook_list(
                 envelope.get("data") or {}, "agent_identities", "agentIdentities",
             ))
@@ -5021,6 +5099,7 @@ class InkboxAdapter(BasePlatformAdapter):
             "conversation_id": conversation_id,
             "remote_number": remote,
             "message_id": message_id,
+            "conversation_kind": "group" if is_group else "direct",
         }
         self._last_inbound_imessage[str(chat_id)] = imessage_state
         if conversation_id:
@@ -5048,6 +5127,8 @@ class InkboxAdapter(BasePlatformAdapter):
                 media_urls=media_urls,
                 media_types=media_types,
                 conversation_id=conversation_id,
+                is_group=is_group,
+                participants=participants,
                 agent_identity=sender_identity,
             )
             await self._enqueue(event)
@@ -5065,11 +5146,15 @@ class InkboxAdapter(BasePlatformAdapter):
             media_urls=media_urls,
             media_types=media_types,
             conversation_id=conversation_id,
+            is_group=is_group,
+            participants=participants,
             agent_identity=sender_identity,
         )
-        # Show the recipient a typing indicator while the agent works on the
-        # reply. The pulse is cancelled in send() once the response goes out.
-        self._start_imessage_typing(conversation_id)
+        # Group iMessage does not support typing indicators.
+        if not is_group:
+            # Show the recipient a typing indicator while the agent works on
+            # the reply. The pulse is cancelled in send() once it goes out.
+            self._start_imessage_typing(conversation_id)
         # iMessage users send fragment bursts just like SMS users — reuse
         # the quiet-window batcher (the burst marker rewrite understands
         # the [inkbox:imessage ...] prefix).
@@ -5308,17 +5393,37 @@ class InkboxAdapter(BasePlatformAdapter):
         ) or "unknown"
         timestamp = _parse_inkbox_timestamp(reaction.get("created_at"))
 
+        # One-to-one reactions carry an assignment id. Group reactions do not,
+        # so fetch conversation metadata only for that ambiguous/group-capable
+        # shape instead of adding a read to every ordinary tapback.
+        assignment_id = str(
+            reaction.get("assignment_id") or reaction.get("assignmentId") or ""
+        ).strip()
+        conversation = (
+            await self._lookup_imessage_conversation(conversation_id)
+            if not assignment_id
+            else None
+        )
+        participants = _string_list_field(conversation, "participants")
+        is_group = (
+            _conversation_summary_is_group(conversation)
+            or len(participants) > 1
+        )
         contact = await self._resolve_contact_full(kind="phone", value=remote)
-        chat_id = _chat_id_for_route(
-            contact,
-            _channel_thread_key("imessage", conversation_id),
-            remote,
+        chat_id = (
+            _channel_thread_key("imessage", conversation_id) or remote
+            if is_group
+            else _chat_id_for_route(
+                contact,
+                _channel_thread_key("imessage", conversation_id),
+                remote,
+            )
         )
         contact_name = contact["name"] if contact and contact.get("name") else None
         # Same sender-labelling fallback as an inbound iMessage body.
         sender_identity = (
             None
-            if contact
+            if contact or is_group
             else _single_agent_identity(_webhook_list(
                 envelope.get("data") or {}, "agent_identities", "agentIdentities",
             ))
@@ -5334,6 +5439,7 @@ class InkboxAdapter(BasePlatformAdapter):
             "conversation_id": conversation_id,
             "remote_number": remote,
             "message_id": target_message_id,
+            "conversation_kind": "group" if is_group else "direct",
         }
         self._last_inbound_imessage[str(chat_id)] = imessage_state
         if conversation_id:
@@ -5347,9 +5453,15 @@ class InkboxAdapter(BasePlatformAdapter):
         target_part = (
             f" target_message_id={target_message_id}" if target_message_id else ""
         )
+        marker_kind = (
+            "group_imessage_reaction" if is_group else "imessage_reaction"
+        )
+        participants_part = (
+            f" participants={','.join(participants)}" if participants else ""
+        )
         marker = (
-            f"[inkbox:imessage_reaction from={remote} reaction={reaction_label}"
-            f"{conversation_part}{target_part} | {contact_block}]"
+            f"[inkbox:{marker_kind} from={remote} reaction={reaction_label}"
+            f"{conversation_part}{target_part}{participants_part} | {contact_block}]"
         )
         policy = "\n".join([
             f"{contact_name or remote} reacted with a '{reaction_label}' tapback to your message.",
@@ -5364,9 +5476,17 @@ class InkboxAdapter(BasePlatformAdapter):
 
         source = self.build_source(
             chat_id=str(chat_id),
-            chat_name=contact_name or remote,
-            chat_type="dm",
-            user_id=str(chat_id),
+            chat_name=(
+                f"Inkbox iMessage group {conversation_id or remote}"
+                if is_group
+                else contact_name or remote
+            ),
+            chat_type="group" if is_group else "dm",
+            user_id=(
+                str((contact or {}).get("id") or remote)
+                if is_group
+                else str(chat_id)
+            ),
             user_name=contact_name or remote,
             user_id_alt=remote,
             thread_id=f"imessage:{conversation_id}" if conversation_id else None,
@@ -5392,7 +5512,7 @@ class InkboxAdapter(BasePlatformAdapter):
         # [SILENT] path if the agent decides no reply is warranted after all).
         # Other reaction types most often resolve to [SILENT], so we don't
         # promise a reply that isn't coming.
-        if reaction_type == "question":
+        if reaction_type == "question" and not is_group:
             self._start_imessage_typing(conversation_id)
         await self._enqueue(event)
         return web.Response(status=200, text="ok")

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: inkbox
 label: Inkbox
 kind: platform
-version: 0.2.6
+version: 0.2.7
 description: Inkbox email, SMS/MMS, iMessage, voice, and A2A platform plugin for Hermes Agent.
 author: Inkbox
 requires_env: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hermes-agent-plugin"
-version = "0.2.6"
+version = "0.2.7"
 description = "Inkbox platform plugin for Hermes Agent"
 # inkbox>=0.4.7 requires Python 3.11+, so we can't claim 3.10 support.
 requires-python = ">=3.11"

--- a/skills/inkbox-imessage-responder/SKILL.md
+++ b/skills/inkbox-imessage-responder/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: inkbox-imessage-responder
-description: Use when the user asks to send an iMessage, reply on iMessage, or explain how to reach the agent over iMessage — also use automatically when an inbound `imessage.received` event arrives from Inkbox. Handles the connect/router model, the recipient-first rule, and tapback reactions.
+description: Use when the user asks to send an iMessage, start or reply to an iMessage group, or explain how to reach the agent over iMessage — also use automatically when an inbound `imessage.received` event arrives from Inkbox. Handles shared and dedicated lines, group response policy, the recipient-first rule, and tapback reactions.
 user-invocable: false
 ---
 
 # Inkbox iMessage responder
 
-The Inkbox plugin makes this agent reachable over iMessage. Unlike SMS, the agent does not own an iMessage number: people connect through the Inkbox iMessage router, and each connected person gets a dedicated conversation with this agent. Use this skill for any iMessage conversation — short, conversational, reply-driven.
+The Inkbox plugin makes this agent reachable over iMessage. Most identities use the shared Inkbox router, while some have a dedicated inbound or dedicated outbound iMessage number. Use this skill for any iMessage conversation — short, conversational, reply-driven.
 
 ## How the channel works
 
-- A person texts the connect command (e.g. `connect @agent-handle`) to the Inkbox iMessage router number from their iPhone. Get both with `inkbox_imessage_triage_number`.
-- Inkbox texts them back from the number assigned to their conversation with this agent. All chat happens in that thread.
-- **Recipient-first:** the agent cannot message anyone over iMessage until that person has messaged it first. There is no cold outreach on this channel. If an outbound send returns a 409-style error saying the recipient hasn't messaged yet or is no longer connected, tell the user the person needs to (re)connect and send a message first.
+- On the shared service, a person texts the connect command (e.g. `connect @agent-handle`) to the Inkbox iMessage router number from their iPhone. Get both with `inkbox_imessage_triage_number`. Inkbox texts them back from the number assigned to their conversation with this agent.
+- **Recipient-first lines:** shared service and dedicated inbound lines cannot initiate a conversation. The person must message first. If an outbound send returns a 409-style error saying the recipient has not messaged yet or is no longer connected, explain the required setup instead of retrying.
+- **Dedicated outbound lines:** the agent may initiate a 1:1 conversation or a group with 2–8 distinct E.164 recipients, subject to contact rules. Group creation is not available on shared or dedicated inbound lines.
+- Existing 1:1 and group conversations are always addressed by `conversationId` when replying.
 - If someone asks "how do I iMessage you?", answer with the router number and connect command from `inkbox_imessage_triage_number`.
 
 ## Calling someone on iMessage Shared Line
@@ -21,26 +22,27 @@ If a person you're connected to over iMessage asks you to call them (or you deci
 
 ## Required tools
 
-- `inkbox_list_imessage_conversations` — start here for triage; returns conversation IDs, latest-message previews, unread counts, and assignment status
-- `inkbox_get_imessage_conversation` — pull message history (includes live tapback reactions on each message)
-- `inkbox_send_imessage` — outbound by `conversationId` (preferred) or `to` E.164
+- `inkbox_list_imessage_conversations` — start here for triage; includes groups by default and returns conversation IDs, participants, latest-message previews, unread counts, and assignment status
+- `inkbox_get_imessage_conversation` — pull 1:1 or group history (includes sender metadata and live tapback reactions)
+- `inkbox_send_imessage` — reply by `conversationId`, or initiate by `to`; a 2–8 recipient `to` list requires a dedicated outbound line
 
 ## Optional (allowlist needed)
 
 - `inkbox_imessage_triage_number` — router number + connect command for onboarding new people
 - `inkbox_list_imessage_assignments` — who is actively connected to this agent right now (one row per recipient)
 - `inkbox_send_imessage_reaction` — tapback (love/like/dislike/laugh/emphasize/question) on a received message
-- `inkbox_mark_imessage_conversation_read` — send a read receipt and clear unread state
+- `inkbox_mark_imessage_conversation_read` — send a read receipt and clear unread state for a 1:1 conversation; groups do not support read receipts
 
 ## Workflow
 
-1. **Pull conversations.** Call `inkbox_list_imessage_conversations` (defaults: `limit: 25`). Each row includes the conversation ID, remote number, latest text, unread count, total count, and assignment status. Field names may be snake_case or camelCase depending on the host. `released` means that person disconnected, so a reply will fail until they reconnect through the router; tell them how instead of retrying.
+1. **Pull conversations.** Call `inkbox_list_imessage_conversations` (defaults: `limit: 25`, groups included). Group rows have `is_group`, `participants`, and no assignment; 1:1 rows include a remote number and assignment status. Field names may be snake_case or camelCase depending on the host. On a 1:1 row, `released` means that person disconnected, so a reply will fail until they reconnect through the router; tell them how instead of retrying.
 
 2. **Pick a conversation to handle.** If you need history, call `inkbox_get_imessage_conversation` with `conversationId: row.id`. Inbound messages may carry `reactions` — live tapbacks the person put on a message.
 
 3. **Compose and send — reply vs. reach out.** These are different, and mixing them double-sends:
-   - **Replying to the iMessage that just woke you** (this turn carries an `[inkbox:imessage …]` marker): **just write your reply.** It is delivered automatically as an iMessage into that same thread. Do **NOT** also call `inkbox_send_imessage` for that reply — the tool would send the same message a second time.
-   - **Reaching a different conversation or recipient:** use `inkbox_send_imessage` with `conversationId` (preferred) or `to`. (Remember iMessage is recipient-first — no cold outreach.)
+   - **Replying to the iMessage that just woke you** (this turn carries an `[inkbox:imessage …]` or `[inkbox:group_imessage …]` marker): **just write your reply.** It is delivered automatically into that same thread. Do **NOT** also call `inkbox_send_imessage` for that reply — the tool would send the same message a second time.
+   - **Reaching a different existing conversation:** use `inkbox_send_imessage` with `conversationId`.
+   - **Starting a new conversation:** use `to` with one E.164 number for 1:1 or 2–8 distinct numbers for a group. Starting a group requires a dedicated outbound iMessage line. Shared and dedicated inbound lines are recipient-first.
 
    Keep the tone conversational — iMessage is a chat thread, not email. A `sendStyle` (confetti, balloons, …) is available for celebratory moments; use sparingly.
 
@@ -48,17 +50,21 @@ If a person you're connected to over iMessage asks you to call them (or you deci
 
 4. **React when a reply would be noise.** A tapback via `inkbox_send_imessage_reaction` (e.g. `like` on an acknowledgment) often beats a filler message.
 
-5. **Mark as handled** if you have the optional tool allowlisted: `inkbox_mark_imessage_conversation_read` with `conversationId` — this also shows the sender a read receipt.
+5. **Mark a 1:1 as handled** if you have the optional tool allowlisted: `inkbox_mark_imessage_conversation_read` with `conversationId` — this also shows the sender a read receipt. Do not call it for a group.
 
 ## Inbound markers
 
-Inbound iMessages arrive prefixed `[inkbox:imessage from=+1555… conversation_id=… | contact…]`. Bursts may arrive as `[inkbox:imessage_burst …]`, and attachments may add `[inkbox:imessage_attachment …]` lines. Use the marker for routing context; never echo it back.
+Inbound 1:1 iMessages arrive prefixed `[inkbox:imessage from=+1555… conversation_id=… | contact…]`. Groups use `[inkbox:group_imessage conversation_id=… from=+1555… participants=… reply_mode=conversation_id | contact…]` followed by a response policy. Bursts use the corresponding `*_burst` marker, and attachments may add `[inkbox:imessage_attachment …]` lines. Use the marker for routing context; never echo it back.
 
-While you compose a reply, the recipient automatically sees a typing indicator (the Inkbox bridge pulses it until your message sends), so there is no separate "I'm typing" tool to call.
+In a 1:1, the recipient automatically sees a typing indicator while you compose a reply. Group iMessage does not support typing indicators or read receipts.
+
+## Group response policy
+
+You receive every inbound group message so the session retains context. Reply only when the latest message clearly addresses this agent, asks it to act, or a visible answer would be expected from the agent. Treat ordinary chatter as context only. If no visible reply is warranted, return exactly `[SILENT]`.
 
 ## Reacting to your messages (tapbacks)
 
-When someone puts a tapback on one of **your** messages, you receive a turn prefixed `[inkbox:imessage_reaction from=+1555… reaction=<type> conversation_id=… target_message_id=… | contact…]` followed by a short response policy. A reaction is a lightweight signal, not always a request for a reply:
+When someone puts a tapback on one of **your** messages, you receive a turn prefixed `[inkbox:imessage_reaction …]` for a 1:1 or `[inkbox:group_imessage_reaction …]` for a group, followed by a short response policy. A reaction is a lightweight signal, not always a request for a reply:
 
 - A `question` tapback usually asks for clarification or a follow-up — replying is normally warranted.
 - `emphasize` may invite a brief acknowledgement or follow-up.

--- a/tests/test_agent_identity_marker.py
+++ b/tests/test_agent_identity_marker.py
@@ -234,8 +234,8 @@ def test_imessage_single_agent_identity_labels_sender():
 
 
 def test_imessage_two_identities_keep_unknown_fallback():
-    # iMessage has no group split, so this directly exercises the
-    # exactly-one rule: two entries must not collapse to the first.
+    # A non-group payload with ambiguous identity metadata must not collapse
+    # to the first entry.
     adapter = _adapter(contact=None)
     two = [
         IDENTITY,

--- a/tests/test_imessage.py
+++ b/tests/test_imessage.py
@@ -33,9 +33,17 @@ class FakeIMessage:
 
 
 class FakeIdentity:
-    def __init__(self):
+    def __init__(self, *, can_start_imessage_conversations=False):
         self.sent_imessages = []
         self.calls = []
+        self.imessage_number = (
+            types.SimpleNamespace(
+                type="dedicated_outbound",
+                can_start_conversations=True,
+            )
+            if can_start_imessage_conversations
+            else None
+        )
 
     def send_imessage(self, **kwargs):
         self.sent_imessages.append(kwargs)
@@ -112,6 +120,69 @@ def test_send_imessage_tool_prefers_conversation_id(monkeypatch):
     assert identity.sent_imessages == [{"text": "hello", "conversation_id": "imconv-123"}]
 
 
+def test_send_imessage_tool_starts_group_on_dedicated_outbound_line(monkeypatch):
+    identity = FakeIdentity(can_start_imessage_conversations=True)
+    monkeypatch.setattr(tools, "_client_and_identity", lambda: (None, None, identity))
+
+    out = json.loads(tools.inkbox_send_imessage({
+        "to": ["+15555550101", "+15555550102"],
+        "text": "Dinner at 7?",
+    }))
+
+    assert out["ok"] is True
+    assert identity.sent_imessages == [{
+        "text": "Dinner at 7?",
+        "to": ["+15555550101", "+15555550102"],
+    }]
+
+
+def test_send_imessage_tool_keeps_recipient_first_one_to_one_send(monkeypatch):
+    identity = FakeIdentity()
+    monkeypatch.setattr(tools, "_client_and_identity", lambda: (None, None, identity))
+
+    out = json.loads(tools.inkbox_send_imessage({
+        "to": "+15555550101",
+        "text": "hello",
+    }))
+
+    assert out["ok"] is True
+    assert identity.sent_imessages == [{
+        "text": "hello",
+        "to": "+15555550101",
+    }]
+
+
+def test_send_imessage_tool_rejects_group_without_dedicated_outbound_line(monkeypatch):
+    identity = FakeIdentity()
+    monkeypatch.setattr(tools, "_client_and_identity", lambda: (None, None, identity))
+
+    out = json.loads(tools.inkbox_send_imessage({
+        "to": ["+15555550101", "+15555550102"],
+        "text": "Dinner at 7?",
+    }))
+
+    assert out["error_code"] == "imessage_group_requires_dedicated_outbound"
+    assert identity.sent_imessages == []
+
+
+def test_send_imessage_tool_rejects_duplicate_or_too_many_group_recipients(monkeypatch):
+    identity = FakeIdentity(can_start_imessage_conversations=True)
+    monkeypatch.setattr(tools, "_client_and_identity", lambda: (None, None, identity))
+
+    duplicate = json.loads(tools.inkbox_send_imessage({
+        "to": ["+15555550101", "+15555550101"],
+        "text": "hello",
+    }))
+    too_many = json.loads(tools.inkbox_send_imessage({
+        "to": [f"+1555555010{index}" for index in range(9)],
+        "text": "hello",
+    }))
+
+    assert duplicate["error"] == "iMessage recipients must be distinct."
+    assert "at most 8 recipients" in too_many["error"]
+    assert identity.sent_imessages == []
+
+
 def test_send_imessage_tool_uploads_local_media_path(monkeypatch, tmp_path):
     identity = FakeIdentity()
     image = tmp_path / "chart.png"
@@ -175,6 +246,8 @@ def test_send_imessage_schema_distinguishes_urls_and_paths():
 
     assert properties["mediaUrls"]["items"]["format"] == "uri"
     assert "mediaPaths" in properties
+    assert properties["to"]["oneOf"][1]["maxItems"] == 8
+    assert properties["to"]["oneOf"][1]["uniqueItems"] is True
 
 
 def test_send_imessage_tool_rejects_text_over_limit(monkeypatch):
@@ -224,7 +297,11 @@ def test_imessage_conversation_tools_use_conversation_id(monkeypatch):
     assert marked["updated_count"] == 2
     assert reacted["ok"] is True
     assert identity.calls == [
-        ("list_imessage_conversations", {"limit": 25, "offset": 0}),
+        ("list_imessage_conversations", {
+            "limit": 25,
+            "offset": 0,
+            "include_groups": True,
+        }),
         ("list_imessages", {"conversation_id": "imconv-123", "limit": 50, "offset": 0}),
         ("mark_imessage_conversation_read", "imconv-123"),
         ("send_imessage_reaction", {"message_id": "im-1", "reaction": "like", "part_index": 0}),
@@ -462,6 +539,76 @@ def test_inbound_imessage_builds_marker_and_stashes_state(monkeypatch):
     assert adapter._last_inbound_modality["contact-123"] == "imessage"
     assert adapter._last_inbound_imessage["contact-123"]["conversation_id"] == "imconv-123"
     assert adapter._last_inbound_imessage["contact-123|imessage:imconv-123"]["remote_number"] == "+15555550101"
+
+
+def test_inbound_group_imessage_injects_silence_policy_without_typing(monkeypatch):
+    identity = FakeIdentity()
+
+    async def _resolve_contact_full(**_kwargs):
+        return {"id": "contact-123", "name": "Alex"}
+
+    events = []
+    typing_conversations = []
+
+    async def _enqueue_sms_text_event(event):
+        events.append(event)
+
+    monkeypatch.setattr(
+        adapter_mod,
+        "web",
+        types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
+    )
+    adapter = _new_test_adapter()
+    adapter._inkbox = FakeInkboxClient(identity)
+    adapter._identity_handle = "agent"
+    adapter._seen_request_ids = {}
+    adapter._last_inbound_modality = {}
+    adapter._last_inbound_imessage = {}
+    adapter._resolve_contact_full = _resolve_contact_full
+    adapter._enqueue_sms_text_event = _enqueue_sms_text_event
+    adapter._start_imessage_typing = typing_conversations.append
+
+    response = asyncio.run(adapter._on_imessage_received({
+        "event_type": "imessage.received",
+        "data": {
+            "message": {
+                "id": "im-group-in",
+                "direction": "inbound",
+                "remote_number": None,
+                "sender_number": "+15555550101",
+                "participants": ["+15555550101", "+15555550102"],
+                "is_group": True,
+                "conversation_id": "imconv-group",
+                "content": "Dinner moved to 7.",
+            },
+        },
+    }))
+
+    assert response.status == 200
+    assert len(events) == 1
+    assert events[0].text.startswith(
+        "[inkbox:group_imessage conversation_id=imconv-group "
+        "from=+15555550101 participants=+15555550101,+15555550102 "
+        "reply_mode=conversation_id"
+    )
+    assert "Group iMessage response policy" in events[0].text
+    assert "return exactly [SILENT]" in events[0].text
+    assert events[0].source.chat_id == "imessage:imconv-group"
+    assert events[0].source.chat_type == "group"
+    assert events[0].source.user_id == "contact-123"
+    assert events[0].source.thread_id == "imessage:imconv-group"
+    assert events[0].source.chat_name == "Inkbox iMessage group imconv-group"
+    assert (
+        adapter._last_inbound_imessage["imessage:imconv-group"]["conversation_kind"]
+        == "group"
+    )
+    assert (
+        adapter._last_inbound_imessage[
+            "imessage:imconv-group|imessage:imconv-group"
+        ]["conversation_id"]
+        == "imconv-group"
+    )
+    assert typing_conversations == []
 
 
 def test_unknown_inbound_imessage_uses_conversation_session_key(monkeypatch):
@@ -785,6 +932,76 @@ def test_inbound_reaction_enqueues_turn_with_silent_policy(monkeypatch):
     # Reply target is stashed so a follow-up send lands in the right thread.
     assert adapter._last_inbound_imessage["contact-123"]["conversation_id"] == "imconv-123"
     assert adapter._last_inbound_modality["contact-123"] == "imessage"
+
+
+def test_inbound_group_reaction_stays_in_group_without_typing(monkeypatch):
+    identity = FakeIdentity()
+    identity.get_imessage_conversation = lambda conversation_id: (
+        identity.calls.append(("get_imessage_conversation", conversation_id))
+        or types.SimpleNamespace(
+            id=conversation_id,
+            is_group=True,
+            participants=["+15555550101", "+15555550102"],
+        )
+    )
+
+    async def _resolve_contact_full(**_kwargs):
+        return {"id": "contact-123", "name": "Alex"}
+
+    enqueued = []
+    typing_conversations = []
+
+    async def _enqueue(event):
+        enqueued.append(event)
+
+    monkeypatch.setattr(
+        adapter_mod,
+        "web",
+        types.SimpleNamespace(Response=lambda **kwargs: types.SimpleNamespace(**kwargs)),
+    )
+    adapter = _new_test_adapter()
+    adapter._inkbox = FakeInkboxClient(identity)
+    adapter._identity_handle = "agent"
+    adapter._seen_request_ids = {}
+    adapter._last_inbound_modality = {}
+    adapter._last_inbound_imessage = {}
+    adapter._resolve_contact_full = _resolve_contact_full
+    adapter._enqueue = _enqueue
+    adapter._start_imessage_typing = typing_conversations.append
+
+    response = asyncio.run(adapter._on_imessage_reaction({
+        "event_type": "imessage.reaction_received",
+        "data": {
+            "reaction": {
+                "id": "react-group-1",
+                "direction": "inbound",
+                "remote_number": "+15555550101",
+                "conversation_id": "imconv-group",
+                "target_message_id": "im-target-9",
+                "reaction": "question",
+            },
+        },
+    }))
+
+    assert response.status == 200
+    assert len(enqueued) == 1
+    assert enqueued[0].text.startswith(
+        "[inkbox:group_imessage_reaction from=+15555550101 reaction=question"
+    )
+    assert "participants=+15555550101,+15555550102" in enqueued[0].text
+    assert enqueued[0].source.chat_id == "imessage:imconv-group"
+    assert enqueued[0].source.chat_type == "group"
+    assert enqueued[0].source.user_id == "contact-123"
+    assert (
+        adapter._last_inbound_imessage["imessage:imconv-group"][
+            "conversation_kind"
+        ]
+        == "group"
+    )
+    assert typing_conversations == []
+    assert identity.calls == [
+        ("get_imessage_conversation", "imconv-group"),
+    ]
 
 
 def test_unknown_imessage_reaction_uses_conversation_session_key(monkeypatch):

--- a/tools.py
+++ b/tools.py
@@ -380,6 +380,27 @@ def _normalize_recipients(value: Any) -> Optional[List[str]]:
     return []
 
 
+def _identity_can_start_imessage_conversations(identity: Any) -> bool:
+    """Whether the identity has a dedicated outbound iMessage line."""
+    number = getattr(identity, "imessage_number", None)
+    if number is None:
+        number = getattr(identity, "imessageNumber", None)
+    if number is None:
+        return False
+
+    can_start = getattr(number, "can_start_conversations", None)
+    if can_start is None:
+        can_start = getattr(number, "canStartConversations", None)
+    if isinstance(can_start, bool):
+        return can_start
+
+    number_type = getattr(number, "type", None)
+    if isinstance(number, dict):
+        number_type = number.get("type")
+    number_type = getattr(number_type, "value", number_type)
+    return str(number_type or "").strip().lower() == "dedicated_outbound"
+
+
 def _identity_method(identity: Any, snake_name: str, camel_name: Optional[str] = None):
     method = getattr(identity, snake_name, None)
     if callable(method):
@@ -980,9 +1001,29 @@ def inkbox_send_imessage(args: dict, **kwargs) -> str:
             })
 
         conversation_id = str(args.get("conversationId") or args.get("conversation_id") or "").strip()
-        to = str(args.get("to") or "").strip()
-        if bool(conversation_id) == bool(to):
+        to_list = _normalize_recipients(args.get("to"))
+        has_to = to_list is not None and len(to_list) > 0
+        has_conversation = bool(conversation_id)
+        if has_to == has_conversation:
             return _json({"error": "Specify exactly one of `to` or `conversationId`."})
+        if to_list is not None and len(to_list) == 0:
+            return _json({"error": "`to` must include at least one recipient."})
+        if to_list and len(to_list) > 8:
+            return _json({"error": "Inkbox iMessage groups support at most 8 recipients."})
+        if to_list and len(set(to_list)) != len(to_list):
+            return _json({"error": "iMessage recipients must be distinct."})
+        if (
+            to_list
+            and len(to_list) > 1
+            and not _identity_can_start_imessage_conversations(identity)
+        ):
+            return _json({
+                "error": (
+                    "Starting an iMessage group requires a dedicated outbound "
+                    "iMessage line. Reply to an existing group with `conversationId`."
+                ),
+                "error_code": "imessage_group_requires_dedicated_outbound",
+            })
 
         payload: dict[str, Any] = {"text": text or None}
         camel_payload: dict[str, Any] = {"text": text or None}
@@ -990,8 +1031,8 @@ def inkbox_send_imessage(args: dict, **kwargs) -> str:
             payload["conversation_id"] = conversation_id
             camel_payload["conversationId"] = conversation_id
         else:
-            payload["to"] = to
-            camel_payload["to"] = to
+            payload["to"] = to_list[0] if to_list and len(to_list) == 1 else to_list
+            camel_payload["to"] = payload["to"]
         if media_paths:
             media_urls = [_upload_imessage_media_path(identity, media_paths[0])]
         if media_urls:
@@ -1024,10 +1065,24 @@ def inkbox_list_imessage_conversations(args: dict, **kwargs) -> str:
     del kwargs
     try:
         _cfg, _client, identity = _client_and_identity()
-        options = {"limit": int(args.get("limit") or 25), "offset": int(args.get("offset") or 0)}
+        options = {
+            "limit": int(args.get("limit") or 25),
+            "offset": int(args.get("offset") or 0),
+            "include_groups": (
+                args.get("includeGroups")
+                if "includeGroups" in args
+                else args.get("include_groups", True)
+            ),
+        }
+        camel_options = {
+            "limit": options["limit"],
+            "offset": options["offset"],
+            "includeGroups": options["include_groups"],
+        }
         convos = _call_with_kwargs_or_payload(
             _identity_method(identity, "list_imessage_conversations", "listImessageConversations"),
             options,
+            camel_options,
         )
         return _json({"ok": True, "count": len(convos or []), "conversations": _json_safe(convos or [])})
     except Exception as exc:
@@ -1512,12 +1567,24 @@ IMESSAGE_TRIAGE_NUMBER_SCHEMA = {
 
 SEND_IMESSAGE_SCHEMA = {
     "name": "inkbox_send_imessage",
-    "description": "Send an iMessage from the configured Inkbox identity. Recipient-first channel: a person must have connected via the iMessage router and messaged this agent before outbound sends work, so prefer conversationId from an inbound message or inkbox_list_imessage_conversations.",
+    "description": "Send an iMessage from the configured Inkbox identity. Use conversationId to reply into an existing 1:1 or group conversation. A dedicated outbound iMessage line may initiate a 1:1 or 2-8 recipient group; shared and dedicated inbound lines remain recipient-first.",
     "parameters": {
         "type": "object",
         "properties": {
-            "conversationId": {"type": "string", "description": "Existing Inkbox iMessage conversation UUID. Preferred for replies. Mutually exclusive with `to`."},
-            "to": {"type": "string", "description": "Recipient phone number in E.164 format. Only works after that person has messaged this agent. Mutually exclusive with `conversationId`."},
+            "conversationId": {"type": "string", "description": "Existing Inkbox iMessage conversation UUID. Preferred for 1:1 and group replies. Mutually exclusive with `to`."},
+            "to": {
+                "description": "One E.164 recipient or a list of 1-8 distinct recipients. Two or more starts a group and requires a dedicated outbound iMessage line. Mutually exclusive with `conversationId`.",
+                "oneOf": [
+                    {"type": "string"},
+                    {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "minItems": 1,
+                        "maxItems": 8,
+                        "uniqueItems": True,
+                    },
+                ],
+            },
             "text": {"type": "string", "maxLength": IMESSAGE_MAX_LENGTH, "description": "Message body, max 18995 chars."},
             "mediaUrls": {
                 "type": "array",
@@ -1554,19 +1621,20 @@ LIST_IMESSAGE_ASSIGNMENTS_SCHEMA = {
 
 LIST_IMESSAGE_CONVERSATIONS_SCHEMA = {
     "name": "inkbox_list_imessage_conversations",
-    "description": "List iMessage conversation summaries for the configured Inkbox identity. Returns conversation IDs for replies, latest-message previews, unread counts, and assignment_status (released = that person disconnected; replies fail until they reconnect).",
+    "description": "List iMessage conversation summaries for the configured Inkbox identity. Includes group chats by default and returns conversation IDs for replies, participant lists, latest-message previews, unread counts, and assignment status.",
     "parameters": {
         "type": "object",
         "properties": {
             "limit": {"type": "integer", "minimum": 1, "maximum": 200, "default": 25},
             "offset": {"type": "integer", "minimum": 0, "default": 0},
+            "includeGroups": {"type": "boolean", "default": True, "description": "Include group conversations."},
         },
     },
 }
 
 GET_IMESSAGE_CONVERSATION_SCHEMA = {
     "name": "inkbox_get_imessage_conversation",
-    "description": "Fetch messages in one iMessage conversation, newest first. Messages include any live tapback reactions.",
+    "description": "Fetch messages in one 1:1 or group iMessage conversation, newest first. Messages include sender and participant metadata plus any live tapback reactions.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -1598,7 +1666,7 @@ SEND_IMESSAGE_REACTION_SCHEMA = {
 
 MARK_IMESSAGE_CONVERSATION_READ_SCHEMA = {
     "name": "inkbox_mark_imessage_conversation_read",
-    "description": "Send a read receipt and mark every inbound message in an iMessage conversation as read.",
+    "description": "Send a read receipt and mark every inbound message in a 1:1 iMessage conversation as read. Group iMessage conversations do not support read receipts.",
     "parameters": {
         "type": "object",
         "properties": {

--- a/uv.lock
+++ b/uv.lock
@@ -484,7 +484,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent-plugin"
-version = "0.2.5"
+version = "0.2.6"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Decisions

- New iMessage groups accept 2–8 distinct E.164 recipients only when the configured identity exposes a dedicated outbound iMessage line. Existing groups are always replied to by `conversationId`.
- Each group maps to one conversation-scoped Hermes session shared by its participants, while 1:1 iMessage keeps its existing contact-scoped behavior.
- Group turns use the existing group-chat response policy: retain all chatter as context, reply only when addressed or expected to act, and emit `[SILENT]` otherwise.
- Typing indicators and read receipts remain 1:1-only because group conversations do not support them.

## Changes

- Extend `inkbox_send_imessage` to accept one recipient or a 1–8 recipient list, validate distinct group recipients, and enforce the dedicated-outbound capability before group creation.
- Include group conversations in iMessage history by default and document group metadata in the tool schemas.
- Route inbound group messages and reactions with sender/participant markers, shared session identity, conversation-first replies, burst handling, and no typing pulse.
- Update the bundled iMessage responder skill and README, and bump the plugin version to 0.2.6.
- Add focused coverage for creation gates, recipient validation, history inclusion, inbound routing, response policy, reaction routing, and unsupported typing behavior.

## Verification

- `.venv/bin/ruff check .`
- `.venv/bin/python -m pytest -q` — 284 passed, 24 skipped
- Real Hermes contract suite — 12 passed