### PR TITLE
Bring the gateway up at the end of Inkbox setup

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: inkbox
 label: Inkbox
 kind: platform
-version: 0.2.5
+version: 0.2.6
 description: Inkbox email, SMS/MMS, iMessage, voice, and A2A platform plugin for Hermes Agent.
 author: Inkbox
 requires_env: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hermes-agent-plugin"
-version = "0.2.5"
+version = "0.2.6"
 description = "Inkbox platform plugin for Hermes Agent"
 # inkbox>=0.4.7 requires Python 3.11+, so we can't claim 3.10 support.
 requires-python = ">=3.11"

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -68,6 +68,9 @@ OPENAI_REALTIME_TEST_URL = "wss://api.openai.com/v1/realtime"
 # A restart drains in-flight agent runs before coming back up, so give it more
 # room than the CLI's own 90s service-restart timeout.
 GATEWAY_COMMAND_TIMEOUT = 180
+# A gateway only becomes visible to the CLI once it has taken its runtime lock
+# and written its PID record, which happens partway through its own startup.
+GATEWAY_START_CONFIRM_TIMEOUT = 15.0
 
 
 def print_header(title: str) -> None:
@@ -1505,12 +1508,34 @@ def _run_gateway_command(action: str) -> bool:
         return False
 
 
+def _wait_for_gateway_running(timeout: float = GATEWAY_START_CONFIRM_TIMEOUT) -> bool:
+    """Poll for gateway liveness after a start or install.
+
+    Args:
+        timeout (float): Seconds to keep polling before giving up.
+
+    Returns:
+        bool: True once a gateway reports running. A single immediate probe
+        races a gateway that is still coming up, so poll rather than ask once.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        running, _ = _gateway_runtime_state()
+        if running:
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(1.0)
+
+
 def _offer_gateway_restart() -> bool:
     """Offer to restart (or start) the gateway so the new config takes effect.
 
     Returns:
-        bool: True when a gateway is running by the time this returns, so the
-        caller can drop `hermes gateway run` from the closing next-steps list.
+        bool: True when the closing next-steps list should NOT tell the
+        operator to start a gateway - either one is confirmed running, or a
+        start/install we ran reported success and a second one would duplicate
+        it.
     """
     print()
     print(color("  --- Hermes gateway ---", Colors.CYAN))
@@ -1572,15 +1597,20 @@ def _offer_gateway_restart() -> bool:
         print_info("  Start one in the foreground instead: hermes gateway run")
         return False
 
-    # `install` only starts the gateway if the operator said yes to its own
-    # start-now prompt, so re-check rather than assuming it came up.
-    started, _ = _gateway_runtime_state()
-    if started:
+    # `install` brings the gateway up in whatever way the platform allows - a
+    # service slot, or a plain background process when the service manager
+    # refuses the bootstrap. Either way it needs a moment to become visible.
+    if _wait_for_gateway_running():
         print_success("  Gateway installed and running with the new Inkbox config.")
         return True
-    print_success("  Gateway service installed.")
-    print_info("  Start it with: hermes gateway start")
-    return False
+
+    # Install reported success, so never answer it with "now go start one":
+    # if it did bring a gateway up, a second start would duplicate it.
+    print_success("  Gateway install completed.")
+    print_info("  Could not confirm the gateway came up within "
+               f"{int(GATEWAY_START_CONFIRM_TIMEOUT)}s.")
+    print_info("  Check it with: hermes gateway status")
+    return True
 
 
 def interactive_setup() -> None:

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -1508,6 +1508,34 @@ def _run_gateway_command(action: str) -> bool:
         return False
 
 
+def _print_ready_banner(handle: str) -> None:
+    """Print the closing banner for a setup that ended with a live gateway.
+
+    Args:
+        handle (str): Inkbox agent identity the gateway is now running as.
+
+    Returns:
+        None: Replaces the next-steps list - there is nothing left to run.
+    """
+    rows = (("Inkbox identity", handle), ("Check its health", "hermes inkbox doctor"))
+    label_width = max(len(label) for label, _ in rows) + 1  # +1 for the colon
+    body = [
+        "Your Hermes agent is set up and running on Inkbox.",
+        "",
+        *(f"  {(label + ':').ljust(label_width)}  {value}" for label, value in rows),
+    ]
+    width = max(len(line) for line in body) + 4
+    print()
+    print(color("╭" + "─" * (width - 2) + "╮", Colors.GREEN))
+    for line in body:
+        print(
+            color("│ ", Colors.GREEN)
+            + color(line.ljust(width - 4), Colors.GREEN, Colors.BOLD)
+            + color(" │", Colors.GREEN)
+        )
+    print(color("╰" + "─" * (width - 2) + "╯", Colors.GREEN))
+
+
 def _running_gateway_pids() -> tuple[int, ...]:
     """Return the PIDs of every gateway process visible for this profile.
 
@@ -1758,8 +1786,13 @@ def interactive_setup() -> None:
     # as a printed instruction.
     gateway_live = _offer_gateway_restart()
 
+    # A live gateway means setup finished the job, so close on that rather than
+    # a to-do list. Only when nothing is listening is there a next step left.
+    if gateway_live:
+        _print_ready_banner(identity.agent_handle)
+        return
+
     print()
     print("Next steps:")
     print("  hermes inkbox doctor")
-    if not gateway_live:
-        print("  hermes gateway run")
+    print("  hermes gateway run")

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -65,6 +65,9 @@ _AVATAR_PATH = Path(__file__).resolve().parent / "assets" / "hermes_with_iphone.
 _RAW_AVATAR_BASE_URL_DEFAULT = "https://inkbox.ai"
 OPENAI_REALTIME_TEST_MODEL = "gpt-realtime-2"
 OPENAI_REALTIME_TEST_URL = "wss://api.openai.com/v1/realtime"
+# A restart drains in-flight agent runs before coming back up, so give it more
+# room than the CLI's own 90s service-restart timeout.
+GATEWAY_COMMAND_TIMEOUT = 180
 
 
 def print_header(title: str) -> None:
@@ -959,9 +962,10 @@ def _wait_for_imessage_first_message(client: Any, identity: Any, handle: str) ->
         identity.mark_imessage_conversation_read(conversation_id)
     except Exception:
         pass
-    print_info("  Start the gateway (`hermes gateway run`) and keep chatting there.")
-    print_info("  If the gateway is already running, restart it (`hermes gateway restart`)")
-    print_info("  so it picks up this new iMessage connection.")
+    # The wizard's closing step offers to start or restart the gateway, so
+    # point at that rather than handing out commands mid-flow.
+    print_info("  Keep chatting in that thread. Setup finishes by bringing the")
+    print_info("  gateway up so it picks up this new iMessage connection.")
 
 
 def _self_signup_flow(base_url: str, Inkbox: Any, InkboxAPIError: Any) -> tuple[Any | None, str, bool]:
@@ -1421,8 +1425,9 @@ def _print_agent_summary(identity: Any) -> None:
         print_info("  Phone:    (none - provision later in the Inkbox console)")
 
     print()
+    # The gateway (re)start is offered as the wizard's closing step, so don't
+    # tell the operator to run it here as well.
     print_info("  Wrote INKBOX_API_KEY and INKBOX_IDENTITY to .env.")
-    print_info("  Start the gateway with: hermes gateway run")
 
     if phone is not None and getattr(phone, "type", None) == "local":
         print()
@@ -1443,6 +1448,139 @@ def _print_agent_summary(identity: Any) -> None:
     print_info("  Open the Inkbox console to control who can reach this agent:")
     print_info("    https://inkbox.ai/console/contact-rules")
     print_info("  You can allow or block specific contacts, phone numbers, email addresses, and domains.")
+
+
+def _gateway_runtime_state() -> tuple[bool | None, bool]:
+    """Detect whether a Hermes gateway is live for the current profile.
+
+    Returns:
+        tuple[bool | None, bool]: ``(running, service_installed)``. ``running``
+        is None when neither liveness source is importable (plugin loaded
+        outside a Hermes install), in which case ``service_installed`` is False.
+    """
+    # Preferred: the CLI's unified snapshot — covers systemd/launchd/s6 service
+    # slots as well as a bare `hermes gateway run` process.
+    try:
+        from hermes_cli.gateway import get_gateway_runtime_snapshot
+
+        snapshot = get_gateway_runtime_snapshot()
+        return bool(snapshot.running), bool(snapshot.service_installed)
+    except Exception:
+        pass
+    # Fallback: the PID/lock file the gateway writes for itself. It knows
+    # nothing about installed services, so callers only get liveness here.
+    try:
+        from gateway.status import is_gateway_running
+
+        return bool(is_gateway_running()), False
+    except Exception:
+        return None, False
+
+
+def _run_gateway_command(action: str) -> bool:
+    """Run ``hermes gateway <action>`` in a subprocess.
+
+    Args:
+        action (str): Gateway subcommand to run - "restart", "start" or
+            "install".
+
+    Returns:
+        bool: True when the command exited 0. The Hermes profile carries over
+        via the inherited HERMES_HOME the CLI exported for this process.
+    """
+    hermes = shutil.which("hermes")
+    command = (
+        [hermes, "gateway", action]
+        if hermes
+        else [sys.executable, "-m", "hermes_cli.main", "gateway", action]
+    )
+    # `install` asks its own questions on this terminal — don't put a clock on
+    # the operator. The unattended actions keep the bound.
+    timeout = None if action == "install" else GATEWAY_COMMAND_TIMEOUT
+    try:
+        subprocess.check_call(command, timeout=timeout)
+        return True
+    except Exception as exc:
+        print_error(f"  `hermes gateway {action}` failed: {exc}")
+        return False
+
+
+def _offer_gateway_restart() -> bool:
+    """Offer to restart (or start) the gateway so the new config takes effect.
+
+    Returns:
+        bool: True when a gateway is running by the time this returns, so the
+        caller can drop `hermes gateway run` from the closing next-steps list.
+    """
+    print()
+    print(color("  --- Hermes gateway ---", Colors.CYAN))
+
+    # Hermes refuses a self-targeting restart (it would loop against the
+    # supervisor's KeepAlive), so don't offer one we can't actually run.
+    if os.getenv("_HERMES_GATEWAY") == "1":
+        print_info("  Setup is running inside the gateway process.")
+        print_info("  Restart it from a shell: hermes gateway restart")
+        return True
+
+    running, service_installed = _gateway_runtime_state()
+
+    if running is None:
+        print_info("  Could not tell whether a gateway is running.")
+        print_info("  Restart a running one with `hermes gateway restart` so it")
+        print_info("  picks up this config, or start one with `hermes gateway run`.")
+        return False
+
+    if running:
+        print_success("  Detected a running Hermes gateway.")
+        print_info("  It is still on the old config - Inkbox only takes effect")
+        print_info("  once the gateway restarts.")
+        if not prompt_yes_no("  Restart the gateway now?", True):
+            print_warning("  Skipped. Run `hermes gateway restart` before using Inkbox.")
+            return True
+        print_info("  Restarting...")
+        if _run_gateway_command("restart"):
+            print_success("  Gateway restarted with the new Inkbox config.")
+        else:
+            print_info("  Restart it manually: hermes gateway restart")
+        return True
+
+    print_warning("  Did not detect a running Hermes gateway - Inkbox is")
+    print_warning("  configured, but nothing is listening for it yet.")
+
+    if service_installed:
+        if not prompt_yes_no("  Launch the gateway now?", True):
+            print_info("  Skipped. Run `hermes gateway start` when you're ready.")
+            return False
+        print_info("  Starting...")
+        if _run_gateway_command("start"):
+            print_success("  Gateway started with the new Inkbox config.")
+            return True
+        print_info("  Start it manually: hermes gateway start")
+        return False
+
+    # No service slot yet: `install` sets one up under systemd/launchd/Windows
+    # and asks its own start-now question, so it covers install-and-launch in
+    # one step. It exits non-zero on platforms with no service manager (Termux,
+    # bare WSL) — fall back to the foreground command there.
+    print_info("  Installing the background service keeps it running across reboots.")
+    if not prompt_yes_no("  Install and launch the gateway service now?", True):
+        print_info("  Skipped. Run `hermes gateway install`, or `hermes gateway run`")
+        print_info("  to start one in the foreground.")
+        return False
+    print_info("  Installing...")
+    if not _run_gateway_command("install"):
+        print_info("  Start one in the foreground instead: hermes gateway run")
+        return False
+
+    # `install` only starts the gateway if the operator said yes to its own
+    # start-now prompt, so re-check rather than assuming it came up.
+    started, _ = _gateway_runtime_state()
+    if started:
+        print_success("  Gateway installed and running with the new Inkbox config.")
+        return True
+    print_success("  Gateway service installed.")
+    print_info("  Start it with: hermes gateway start")
+    return False
 
 
 def interactive_setup() -> None:
@@ -1536,7 +1674,13 @@ def interactive_setup() -> None:
 
     _setup_signing_key(api_key, base_url, Inkbox)
 
+    # Last, once every value is on disk: nothing above reaches the agent until
+    # the gateway reloads .env, so offer to do that here instead of leaving it
+    # as a printed instruction.
+    gateway_live = _offer_gateway_restart()
+
     print()
     print("Next steps:")
     print("  hermes inkbox doctor")
-    print("  hermes gateway run")
+    if not gateway_live:
+        print("  hermes gateway run")

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -1508,6 +1508,43 @@ def _run_gateway_command(action: str) -> bool:
         return False
 
 
+def _running_gateway_pids() -> tuple[int, ...]:
+    """Return the PIDs of every gateway process visible for this profile.
+
+    Returns:
+        tuple[int, ...]: Gateway PIDs, empty when none are visible or the CLI
+        cannot be asked. The snapshot deduplicates, so one gateway is one PID.
+    """
+    try:
+        from hermes_cli.gateway import get_gateway_runtime_snapshot
+
+        return tuple(get_gateway_runtime_snapshot().gateway_pids)
+    except Exception:
+        return ()
+
+
+def _warn_if_multiple_gateways() -> bool:
+    """Warn when more than one gateway is alive for this profile.
+
+    Only one process can hold the Inkbox platform lock and the adapter's listen
+    port, so the extras start with Inkbox dead - and the survivor may predate
+    the config this wizard just wrote.
+
+    Returns:
+        bool: True when a warning was printed.
+    """
+    pids = _running_gateway_pids()
+    if len(pids) < 2:
+        return False
+    print()
+    print_warning(f"  Found {len(pids)} running gateway processes: {', '.join(str(p) for p in pids)}")
+    print_info("  Only one can own this Inkbox identity - the rest start with")
+    print_info("  Inkbox dead (platform lock held, or listen port already in use),")
+    print_info("  and the one that wins may predate the config just written.")
+    print_info("  Clear them out with: hermes gateway stop --all")
+    return True
+
+
 def _wait_for_gateway_running(timeout: float = GATEWAY_START_CONFIRM_TIMEOUT) -> bool:
     """Poll for gateway liveness after a start or install.
 
@@ -1559,14 +1596,16 @@ def _offer_gateway_restart() -> bool:
         print_success("  Detected a running Hermes gateway.")
         print_info("  It is still on the old config - Inkbox only takes effect")
         print_info("  once the gateway restarts.")
+        _warn_if_multiple_gateways()
         if not prompt_yes_no("  Restart the gateway now?", True):
             print_warning("  Skipped. Run `hermes gateway restart` before using Inkbox.")
             return True
         print_info("  Restarting...")
-        if _run_gateway_command("restart"):
-            print_success("  Gateway restarted with the new Inkbox config.")
-        else:
+        if not _run_gateway_command("restart"):
             print_info("  Restart it manually: hermes gateway restart")
+            return True
+        if not _warn_if_multiple_gateways():
+            print_success("  Gateway restarted with the new Inkbox config.")
         return True
 
     print_warning("  Did not detect a running Hermes gateway - Inkbox is")
@@ -1577,11 +1616,20 @@ def _offer_gateway_restart() -> bool:
             print_info("  Skipped. Run `hermes gateway start` when you're ready.")
             return False
         print_info("  Starting...")
-        if _run_gateway_command("start"):
-            print_success("  Gateway started with the new Inkbox config.")
+        if not _run_gateway_command("start"):
+            print_info("  Start it manually: hermes gateway start")
+            return False
+        # Exit 0 only means the command ran. Confirm a gateway is actually up,
+        # and that a stale sibling is not holding the Inkbox lock against it.
+        if _wait_for_gateway_running():
+            if not _warn_if_multiple_gateways():
+                print_success("  Gateway started with the new Inkbox config.")
             return True
-        print_info("  Start it manually: hermes gateway start")
-        return False
+        print_success("  Gateway start completed.")
+        print_info("  Could not confirm the gateway came up within "
+                   f"{int(GATEWAY_START_CONFIRM_TIMEOUT)}s.")
+        print_info("  Check it with: hermes gateway status")
+        return True
 
     # No service slot yet: `install` sets one up under systemd/launchd/Windows
     # and asks its own start-now question, so it covers install-and-launch in
@@ -1601,7 +1649,8 @@ def _offer_gateway_restart() -> bool:
     # service slot, or a plain background process when the service manager
     # refuses the bootstrap. Either way it needs a moment to become visible.
     if _wait_for_gateway_running():
-        print_success("  Gateway installed and running with the new Inkbox config.")
+        if not _warn_if_multiple_gateways():
+            print_success("  Gateway installed and running with the new Inkbox config.")
         return True
 
     # Install reported success, so never answer it with "now go start one":

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -671,6 +671,158 @@ def test_avatar_offered_and_uploaded_for_existing_agent_without_one(monkeypatch)
     assert uploaded["handle"] == "dev-agent"
 
 
+def test_gateway_restart_offered_when_running(monkeypatch, capsys):
+    ran = []
+    monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+    monkeypatch.setattr(setup_wizard, "_gateway_runtime_state", lambda: (True, True))
+    monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(setup_wizard, "_run_gateway_command", lambda action: ran.append(action) or True)
+
+    assert setup_wizard._offer_gateway_restart() is True
+
+    assert ran == ["restart"]
+    assert "Detected a running Hermes gateway" in capsys.readouterr().out
+
+
+def test_gateway_restart_declined_still_reports_live(monkeypatch, capsys):
+    monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+    monkeypatch.setattr(setup_wizard, "_gateway_runtime_state", lambda: (True, True))
+    monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(
+        setup_wizard,
+        "_run_gateway_command",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("declined should not run a gateway command")),
+    )
+
+    # A declining operator still has a gateway up, so the closing next-steps
+    # list must not tell them to start one.
+    assert setup_wizard._offer_gateway_restart() is True
+    assert "hermes gateway restart" in capsys.readouterr().out
+
+
+def test_gateway_launch_offered_when_service_installed(monkeypatch, capsys):
+    ran = []
+    monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+    monkeypatch.setattr(setup_wizard, "_gateway_runtime_state", lambda: (False, True))
+    monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(setup_wizard, "_run_gateway_command", lambda action: ran.append(action) or True)
+
+    assert setup_wizard._offer_gateway_restart() is True
+
+    assert ran == ["start"]
+    assert "Did not detect a running Hermes gateway" in capsys.readouterr().out
+
+
+def test_gateway_install_offered_when_no_service_slot(monkeypatch, capsys):
+    ran = []
+    states = iter([(False, False), (True, True)])
+    monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+    monkeypatch.setattr(setup_wizard, "_gateway_runtime_state", lambda: next(states))
+    monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(setup_wizard, "_run_gateway_command", lambda action: ran.append(action) or True)
+
+    assert setup_wizard._offer_gateway_restart() is True
+
+    assert ran == ["install"]
+    assert "Gateway installed and running" in capsys.readouterr().out
+
+
+def test_gateway_install_that_did_not_start_reports_not_live(monkeypatch, capsys):
+    # `hermes gateway install` asks its own start-now question; a "no" there
+    # leaves the service installed but down.
+    states = iter([(False, False), (False, True)])
+    monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+    monkeypatch.setattr(setup_wizard, "_gateway_runtime_state", lambda: next(states))
+    monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(setup_wizard, "_run_gateway_command", lambda _action: True)
+
+    assert setup_wizard._offer_gateway_restart() is False
+    assert "hermes gateway start" in capsys.readouterr().out
+
+
+def test_gateway_install_declined_points_at_foreground_run(monkeypatch, capsys):
+    monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+    monkeypatch.setattr(setup_wizard, "_gateway_runtime_state", lambda: (False, False))
+    monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(
+        setup_wizard,
+        "_run_gateway_command",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("declined should not run a gateway command")),
+    )
+
+    assert setup_wizard._offer_gateway_restart() is False
+    assert "hermes gateway run" in capsys.readouterr().out
+
+
+def test_gateway_install_failure_falls_back_to_foreground_run(monkeypatch, capsys):
+    # Termux / bare WSL have no service manager and `install` exits non-zero.
+    monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+    monkeypatch.setattr(setup_wizard, "_gateway_runtime_state", lambda: (False, False))
+    monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(setup_wizard, "_run_gateway_command", lambda _action: False)
+
+    assert setup_wizard._offer_gateway_restart() is False
+    assert "hermes gateway run" in capsys.readouterr().out
+
+
+def test_gateway_restart_not_offered_from_inside_the_gateway(monkeypatch, capsys):
+    monkeypatch.setenv("_HERMES_GATEWAY", "1")
+    monkeypatch.setattr(
+        setup_wizard,
+        "_run_gateway_command",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("self-targeting restart must not run")),
+    )
+
+    assert setup_wizard._offer_gateway_restart() is True
+    assert "inside the gateway process" in capsys.readouterr().out
+
+
+def test_gateway_command_prefers_hermes_on_path(monkeypatch):
+    calls = []
+    monkeypatch.setattr(setup_wizard.shutil, "which", lambda name: "/bin/hermes" if name == "hermes" else None)
+    monkeypatch.setattr(setup_wizard.subprocess, "check_call", lambda cmd, **_kwargs: calls.append(cmd))
+
+    assert setup_wizard._run_gateway_command("restart") is True
+    assert calls == [["/bin/hermes", "gateway", "restart"]]
+
+
+def test_gateway_command_falls_back_to_hermes_cli_module(monkeypatch):
+    calls = []
+    monkeypatch.setattr(setup_wizard.sys, "executable", "/tmp/hermes/venv/bin/python")
+    monkeypatch.setattr(setup_wizard.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(setup_wizard.subprocess, "check_call", lambda cmd, **_kwargs: calls.append(cmd))
+
+    assert setup_wizard._run_gateway_command("start") is True
+    assert calls == [["/tmp/hermes/venv/bin/python", "-m", "hermes_cli.main", "gateway", "start"]]
+
+
+def test_gateway_install_runs_without_a_timeout(monkeypatch):
+    # `install` prompts on this terminal; a clock on it would kill the run
+    # while the operator is still answering.
+    seen = {}
+    monkeypatch.setattr(setup_wizard.shutil, "which", lambda _name: "/bin/hermes")
+    monkeypatch.setattr(
+        setup_wizard.subprocess, "check_call", lambda _cmd, **kwargs: seen.update(kwargs)
+    )
+
+    assert setup_wizard._run_gateway_command("install") is True
+    assert seen["timeout"] is None
+
+    assert setup_wizard._run_gateway_command("restart") is True
+    assert seen["timeout"] == setup_wizard.GATEWAY_COMMAND_TIMEOUT
+
+
+def test_gateway_command_failure_is_reported_not_raised(monkeypatch, capsys):
+    def boom(_cmd, **_kwargs):
+        raise OSError("no such file")
+
+    monkeypatch.setattr(setup_wizard.shutil, "which", lambda _name: "/bin/hermes")
+    monkeypatch.setattr(setup_wizard.subprocess, "check_call", boom)
+
+    assert setup_wizard._run_gateway_command("restart") is False
+    assert "no such file" in capsys.readouterr().out
+
+
 def test_avatar_declined_for_existing_agent(monkeypatch):
     monkeypatch.setattr(setup_wizard, "_identity_has_avatar", lambda *_args, **_kwargs: False)
     monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_args, **_kwargs: False)

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -675,6 +675,7 @@ def test_gateway_restart_offered_when_running(monkeypatch, capsys):
     ran = []
     monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
     monkeypatch.setattr(setup_wizard, "_gateway_runtime_state", lambda: (True, True))
+    monkeypatch.setattr(setup_wizard, "_running_gateway_pids", lambda: (111,))
     monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(setup_wizard, "_run_gateway_command", lambda action: ran.append(action) or True)
 
@@ -687,6 +688,7 @@ def test_gateway_restart_offered_when_running(monkeypatch, capsys):
 def test_gateway_restart_declined_still_reports_live(monkeypatch, capsys):
     monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
     monkeypatch.setattr(setup_wizard, "_gateway_runtime_state", lambda: (True, True))
+    monkeypatch.setattr(setup_wizard, "_running_gateway_pids", lambda: (111,))
     monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_args, **_kwargs: False)
     monkeypatch.setattr(
         setup_wizard,
@@ -704,6 +706,7 @@ def test_gateway_launch_offered_when_service_installed(monkeypatch, capsys):
     ran = []
     monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
     monkeypatch.setattr(setup_wizard, "_gateway_runtime_state", lambda: (False, True))
+    monkeypatch.setattr(setup_wizard, "_running_gateway_pids", lambda: (111,))
     monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(setup_wizard, "_run_gateway_command", lambda action: ran.append(action) or True)
 
@@ -717,6 +720,7 @@ def test_gateway_install_offered_when_no_service_slot(monkeypatch, capsys):
     ran = []
     monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
     monkeypatch.setattr(setup_wizard, "_gateway_runtime_state", lambda: (False, False))
+    monkeypatch.setattr(setup_wizard, "_running_gateway_pids", lambda: (111,))
     monkeypatch.setattr(setup_wizard, "_wait_for_gateway_running", lambda *_a, **_k: True)
     monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(setup_wizard, "_run_gateway_command", lambda action: ran.append(action) or True)
@@ -733,6 +737,7 @@ def test_unconfirmed_install_never_tells_the_operator_to_start_one(monkeypatch, 
     # another one on top of that would duplicate the gateway.
     monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
     monkeypatch.setattr(setup_wizard, "_gateway_runtime_state", lambda: (False, False))
+    monkeypatch.setattr(setup_wizard, "_running_gateway_pids", lambda: (111,))
     monkeypatch.setattr(setup_wizard, "_wait_for_gateway_running", lambda *_a, **_k: False)
     monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(setup_wizard, "_run_gateway_command", lambda _action: True)
@@ -770,6 +775,7 @@ def test_wait_for_gateway_running_gives_up_at_the_timeout(monkeypatch):
 def test_gateway_install_declined_points_at_foreground_run(monkeypatch, capsys):
     monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
     monkeypatch.setattr(setup_wizard, "_gateway_runtime_state", lambda: (False, False))
+    monkeypatch.setattr(setup_wizard, "_running_gateway_pids", lambda: (111,))
     monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_args, **_kwargs: False)
     monkeypatch.setattr(
         setup_wizard,
@@ -785,6 +791,7 @@ def test_gateway_install_failure_falls_back_to_foreground_run(monkeypatch, capsy
     # Termux / bare WSL have no service manager and `install` exits non-zero.
     monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
     monkeypatch.setattr(setup_wizard, "_gateway_runtime_state", lambda: (False, False))
+    monkeypatch.setattr(setup_wizard, "_running_gateway_pids", lambda: (111,))
     monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(setup_wizard, "_run_gateway_command", lambda _action: False)
 
@@ -861,3 +868,52 @@ def test_avatar_declined_for_existing_agent(monkeypatch):
 
     identity = types.SimpleNamespace(agent_handle="dev-agent")
     setup_wizard._configure_avatar("https://inkbox.ai", "ApiKey_x", identity, is_signup=False)
+
+
+def test_duplicate_gateways_are_reported(monkeypatch, capsys):
+    monkeypatch.setattr(setup_wizard, "_running_gateway_pids", lambda: (111, 222, 333))
+
+    assert setup_wizard._warn_if_multiple_gateways() is True
+
+    out = capsys.readouterr().out
+    assert "Found 3 running gateway processes: 111, 222, 333" in out
+    assert "hermes gateway stop --all" in out
+
+
+def test_single_gateway_is_not_reported(monkeypatch, capsys):
+    monkeypatch.setattr(setup_wizard, "_running_gateway_pids", lambda: (111,))
+
+    assert setup_wizard._warn_if_multiple_gateways() is False
+    assert capsys.readouterr().out == ""
+
+
+def test_restart_does_not_claim_success_over_a_stale_sibling(monkeypatch, capsys):
+    # A second gateway holds the Inkbox platform lock and listen port, so the
+    # one we just restarted comes up with Inkbox dead. Saying "restarted with
+    # the new Inkbox config" there would be a lie.
+    monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+    monkeypatch.setattr(setup_wizard, "_gateway_runtime_state", lambda: (True, True))
+    monkeypatch.setattr(setup_wizard, "_running_gateway_pids", lambda: (111, 222))
+    monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(setup_wizard, "_run_gateway_command", lambda _action: True)
+
+    assert setup_wizard._offer_gateway_restart() is True
+
+    out = capsys.readouterr().out
+    assert "Found 2 running gateway processes" in out
+    assert "restarted with the new Inkbox config" not in out
+
+
+def test_start_confirms_liveness_before_claiming_success(monkeypatch, capsys):
+    monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+    monkeypatch.setattr(setup_wizard, "_gateway_runtime_state", lambda: (False, True))
+    monkeypatch.setattr(setup_wizard, "_running_gateway_pids", lambda: (111,))
+    monkeypatch.setattr(setup_wizard, "_wait_for_gateway_running", lambda *_a, **_k: False)
+    monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(setup_wizard, "_run_gateway_command", lambda _action: True)
+
+    assert setup_wizard._offer_gateway_restart() is True
+
+    out = capsys.readouterr().out
+    assert "hermes gateway status" in out
+    assert "started with the new Inkbox config" not in out

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -707,6 +707,7 @@ def test_gateway_launch_offered_when_service_installed(monkeypatch, capsys):
     monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
     monkeypatch.setattr(setup_wizard, "_gateway_runtime_state", lambda: (False, True))
     monkeypatch.setattr(setup_wizard, "_running_gateway_pids", lambda: (111,))
+    monkeypatch.setattr(setup_wizard, "_wait_for_gateway_running", lambda *_a, **_k: True)
     monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(setup_wizard, "_run_gateway_command", lambda action: ran.append(action) or True)
 
@@ -917,3 +918,73 @@ def test_start_confirms_liveness_before_claiming_success(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "hermes gateway status" in out
     assert "started with the new Inkbox config" not in out
+
+
+def _stub_setup_dependencies(monkeypatch, *, gateway_live):
+    """Short-circuit every step of interactive_setup except its closing lines."""
+    identity = types.SimpleNamespace(agent_handle="stub-agent", mailbox=None, phone_number=None)
+
+    monkeypatch.setattr(setup_wizard, "_ensure_inkbox_sdk", lambda: {
+        "Inkbox": object,
+        "InkboxAPIError": Exception,
+        "IdentityPhoneNumberCreateOptions": object,
+        "WhoamiApiKeyResponse": object,
+        "ADMIN_SCOPED": "admin",
+        "AGENT_CLAIMED": "claimed",
+        "AGENT_UNCLAIMED": "unclaimed",
+    })
+    monkeypatch.setattr(setup_wizard, "_env", lambda _name: "")
+    monkeypatch.setattr(setup_wizard, "_save", lambda *_a, **_k: None)
+    monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        setup_wizard, "_self_signup_flow", lambda *_a, **_k: (identity, "ApiKey_stub", False)
+    )
+    monkeypatch.setattr(setup_wizard, "_configure_avatar", lambda *_a, **_k: None)
+    monkeypatch.setattr(setup_wizard, "_configure_imessage", lambda *_a, **_k: False)
+    monkeypatch.setattr(setup_wizard, "_offer_dedicated_number", lambda *_a, **_k: (identity, False))
+    monkeypatch.setattr(setup_wizard, "_seed_identity_state", lambda *_a, **_k: None)
+    monkeypatch.setattr(setup_wizard, "_print_agent_summary", lambda *_a, **_k: None)
+    monkeypatch.setattr(setup_wizard, "_configure_realtime_calls", lambda *_a, **_k: None)
+    monkeypatch.setattr(setup_wizard, "_setup_signing_key", lambda *_a, **_k: None)
+    monkeypatch.setattr(setup_wizard, "_offer_gateway_restart", lambda: gateway_live)
+    return identity
+
+
+def test_ready_banner_names_the_identity_and_the_health_command(capsys):
+    setup_wizard._print_ready_banner("dimas-clanker")
+
+    lines = [line for line in capsys.readouterr().out.splitlines() if line]
+    assert any("dimas-clanker" in line for line in lines)
+    assert any("hermes inkbox doctor" in line for line in lines)
+    # Every row is the same width, so the box closes cleanly.
+    assert len({len(line) for line in lines}) == 1
+
+
+def test_ready_banner_box_fits_a_long_handle(capsys):
+    setup_wizard._print_ready_banner("a-very-long-agent-handle-that-sets-the-width")
+
+    lines = [line for line in capsys.readouterr().out.splitlines() if line]
+    assert len({len(line) for line in lines}) == 1
+
+
+def test_live_gateway_closes_on_the_banner_not_a_todo_list(monkeypatch, capsys):
+    _stub_setup_dependencies(monkeypatch, gateway_live=True)
+
+    setup_wizard.interactive_setup()
+
+    out = capsys.readouterr().out
+    assert "Your Hermes agent is set up and running on Inkbox." in out
+    assert "stub-agent" in out
+    assert "Next steps:" not in out
+    assert "hermes gateway run" not in out
+
+
+def test_dead_gateway_still_gets_the_next_steps_list(monkeypatch, capsys):
+    _stub_setup_dependencies(monkeypatch, gateway_live=False)
+
+    setup_wizard.interactive_setup()
+
+    out = capsys.readouterr().out
+    assert "Next steps:" in out
+    assert "hermes gateway run" in out
+    assert "Your Hermes agent is set up and running" not in out

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -715,9 +715,9 @@ def test_gateway_launch_offered_when_service_installed(monkeypatch, capsys):
 
 def test_gateway_install_offered_when_no_service_slot(monkeypatch, capsys):
     ran = []
-    states = iter([(False, False), (True, True)])
     monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
-    monkeypatch.setattr(setup_wizard, "_gateway_runtime_state", lambda: next(states))
+    monkeypatch.setattr(setup_wizard, "_gateway_runtime_state", lambda: (False, False))
+    monkeypatch.setattr(setup_wizard, "_wait_for_gateway_running", lambda *_a, **_k: True)
     monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(setup_wizard, "_run_gateway_command", lambda action: ran.append(action) or True)
 
@@ -727,17 +727,44 @@ def test_gateway_install_offered_when_no_service_slot(monkeypatch, capsys):
     assert "Gateway installed and running" in capsys.readouterr().out
 
 
-def test_gateway_install_that_did_not_start_reports_not_live(monkeypatch, capsys):
-    # `hermes gateway install` asks its own start-now question; a "no" there
-    # leaves the service installed but down.
-    states = iter([(False, False), (False, True)])
+def test_unconfirmed_install_never_tells_the_operator_to_start_one(monkeypatch, capsys):
+    # `install` can come up as a plain background process when the platform's
+    # service manager refuses the bootstrap. Telling the operator to start
+    # another one on top of that would duplicate the gateway.
     monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
-    monkeypatch.setattr(setup_wizard, "_gateway_runtime_state", lambda: next(states))
+    monkeypatch.setattr(setup_wizard, "_gateway_runtime_state", lambda: (False, False))
+    monkeypatch.setattr(setup_wizard, "_wait_for_gateway_running", lambda *_a, **_k: False)
     monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(setup_wizard, "_run_gateway_command", lambda _action: True)
 
-    assert setup_wizard._offer_gateway_restart() is False
-    assert "hermes gateway start" in capsys.readouterr().out
+    assert setup_wizard._offer_gateway_restart() is True
+
+    out = capsys.readouterr().out
+    assert "hermes gateway status" in out
+    assert "hermes gateway start" not in out
+    assert "hermes gateway run" not in out
+
+
+def test_wait_for_gateway_running_polls_until_it_appears(monkeypatch):
+    # A gateway takes its runtime lock partway through startup, so the first
+    # probe after a start can legitimately miss it.
+    states = iter([(False, False), (False, False), (True, True)])
+    monkeypatch.setattr(setup_wizard, "_gateway_runtime_state", lambda: next(states))
+    monkeypatch.setattr(setup_wizard.time, "sleep", lambda _s: None)
+
+    assert setup_wizard._wait_for_gateway_running(timeout=30.0) is True
+
+
+def test_wait_for_gateway_running_gives_up_at_the_timeout(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        setup_wizard, "_gateway_runtime_state", lambda: calls.append(1) or (False, True)
+    )
+    monkeypatch.setattr(setup_wizard.time, "sleep", lambda _s: None)
+
+    assert setup_wizard._wait_for_gateway_running(timeout=0.0) is False
+    # Timeout 0 still probes once before giving up.
+    assert calls == [1]
 
 
 def test_gateway_install_declined_points_at_foreground_run(monkeypatch, capsys):


### PR DESCRIPTION
## Summary

`hermes inkbox setup` wrote credentials, channels, realtime config and a signing key to `~/.hermes/.env`, then printed `hermes gateway run` and exited. None of it reached the agent until someone re-read that line and acted on it — and on a **rerun**, where a gateway is already up on the old config, `run` was the wrong command entirely.

Setup now ends with a real step: detect the gateway, then offer to act on it. Every prompt defaults to **yes**.

| Detected | Prompt | Runs |
|---|---|---|
| Gateway running | `Restart the gateway now?` | `hermes gateway restart` |
| Not running, service slot exists | `Launch the gateway now?` | `hermes gateway start` |
| Not running, no service slot | `Install and launch the gateway service now?` | `hermes gateway install` |
| Can't tell | — prints both commands, asks nothing | — |

and closes on a banner rather than a to-do list with nothing left to do:

```
╭────────────────────────────────────────────────────╮
│ Your Hermes agent is set up and running on Inkbox. │
│                                                    │
│   Inkbox identity:   dimas-clanker                 │
│   Check its health:  hermes inkbox doctor          │
╰────────────────────────────────────────────────────╯
```

The next-steps list survives only for the case it was written for: nothing listening, so `hermes gateway run` really is the next thing.

## Detection

`_gateway_runtime_state()` returns `(running, service_installed)`:

1. `hermes_cli.gateway.get_gateway_runtime_snapshot()` — the CLI's unified view, covering systemd/launchd/s6 service slots **and** a bare `hermes gateway run` process.
2. Falls back to `gateway.status.is_gateway_running()` (the PID/lock file) when that import fails.
3. `(None, False)` when neither is importable — the wizard prints both commands rather than guessing.

## Two fixes that came out of running this on macOS

**Exit codes are not evidence.** `hermes gateway install` hit a launchd bootstrap failure, fell back to starting a plain background gateway, and exited 0:

```
⚠ launchd cannot manage the gateway on this macOS version (launchctl bootstrap exit 5).
✓ Started gateway as a background process instead
✓   Gateway service installed.
    Start it with: hermes gateway start
```

Both of those last lines were wrong — launchd installed nothing, and a second start on top of the running process would have duplicated the gateway. `get_running_pid()` only reports a gateway once it has taken its runtime lock and written its PID record, so a probe fired the instant `install` returns races the process it just spawned. Now `_wait_for_gateway_running()` polls for up to 15s, and an unconfirmed start or install reports `Could not confirm the gateway came up` and points at `hermes gateway status` rather than handing out a start command.

**A stale sibling can own Inkbox.** `hermes gateway stop` no-ops whenever the launchd plist exists but the job was never bootstrapped — it takes the launchd path on `get_launchd_plist_path().exists()`, boots out a job that was never loaded, and never reaches the code that kills the detached process:

```
Boot-out failed: 3: No such process
✓ Service stopped
✓ Stopped hermes-gateway service
```

Reported success, killed nothing. Every later `Launch the gateway now?` stacked another one on top. Only one can hold the Inkbox platform lock and the adapter's listen port (`adapter.py:1788`, and the `Port %d already in use` check below it), so the extras come up with **Inkbox dead** — and the survivor may predate the config just written. Inbound messages then have no receiver while this step reports success.

The runtime snapshot already carries a deduplicated `gateway_pids` tuple and this step was collapsing it to a bool. It now reports when more than one is alive, points at `hermes gateway stop --all`, and suppresses the success line — in the restart, start and install branches.

Both of those are host bugs and not fixable from the plugin; this only stops the wizard reporting a success that is not real.

## Decisions worth a look

- **Foreground `run` is never executed**, only printed — it would take over the wizard's terminal. That is why the no-slot branch offers `install` (which registers a supervised slot and asks its own start-now question) rather than `run`.
- **`install` gets no subprocess timeout** — it prompts on this same terminal, so a clock would kill it mid-answer. `restart`/`start` are bounded at 180s; the CLI's own service-restart timeout is 90s and a restart drains in-flight agent runs first.
- **Self-restart guard**: skipped when `_HERMES_GATEWAY=1`. Hermes refuses that itself to avoid a KeepAlive kill loop.
- **Profile-safe**: the subprocess inherits `HERMES_HOME`, which the CLI exports before argparse, so `hermes -p foo inkbox setup` targets foo's gateway.

## Also

- Removed two now-contradictory hints: `Start the gateway with: hermes gateway run` in the closing agent summary, and the run/restart commands printed mid-flow in the iMessage walkthrough. Both defer to the new step.
- Version 0.2.5 → 0.2.6.

Verified live on macOS across the restart and launch branches, including a launchd fallback to a background process. 22 tests cover every branch, the decline paths, the poll behaviour and its timeout, duplicate detection, the banner's content and box geometry, and the `hermes`-not-on-PATH fallback (`python -m hermes_cli.main`). **290 pass**; 3 pre-existing `tests/test_external_reply.py` failures come from a missing `aiohttp` in this environment and are unrelated — confirmed against a clean checkout.

Siblings: inkbox-ai/openclaw-plugin#46, inkbox-ai/claude-code-plugin#47, inkbox-ai/codex-plugin#29, inkbox-ai/opencode-plugin#11.