### PR TITLE
fix: preserve reply channel from thread id

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -506,6 +506,23 @@ def _imessage_conversation_target(raw: Any) -> Optional[str]:
     return None
 
 
+def _text_mode_from_thread_id(raw: Any) -> Optional[str]:
+    """Return the text channel encoded in an immutable gateway thread id."""
+    text = re.sub(
+        r"^(inkbox:)",
+        "",
+        str(raw or "").strip(),
+        flags=re.IGNORECASE,
+    ).lower()
+    if text.startswith("imessage:"):
+        return "imessage"
+    if text.startswith(("sms:", "text:")):
+        return "sms"
+    if text.startswith("email:"):
+        return "email"
+    return None
+
+
 def _public_http_media_url(value: Any) -> bool:
     """Return whether *value* is a hosted HTTP(S) media URL."""
     parsed = urlparse(str(value or "").strip())
@@ -2564,6 +2581,7 @@ class InkboxAdapter(BasePlatformAdapter):
 
         meta = metadata or {}
         mode = (meta.get("mode") or "").lower().strip()
+        thread_mode = _text_mode_from_thread_id(meta.get("thread_id"))
 
         # End-of-call grace window: when a voice call ends, the agent's last
         # in-flight turn often finishes generating *after* the WS has closed.
@@ -2588,6 +2606,7 @@ class InkboxAdapter(BasePlatformAdapter):
             and (time.time() - closed_at) < VOICE_GRACE_SECONDS
             and chat_id not in self._active_call_ws
             and not self._last_inbound_modality.get(str(chat_id))
+            and not thread_mode
         ):
             logger.info(
                 "[Inkbox] Suppressed post-call voice-leakage for chat %s: %s…",
@@ -2600,15 +2619,18 @@ class InkboxAdapter(BasePlatformAdapter):
 
         # Resolve mode if the gateway didn't pass one explicitly.  Order of
         # preference:
-        #   1. An open live-call WebSocket on this chat — voice trumps
-        #      everything because dropping it would leave the caller hearing
-        #      silence while we send an email.
-        #   2. The modality of the most-recent inbound from this chat —
+        #   1. The immutable gateway thread id. Concurrent channels for one
+        #      contact must not hijack an in-flight turn's eventual reply.
+        #   2. An open live-call WebSocket on this chat when the turn has no
+        #      text-channel thread id.
+        #   3. The modality of the most-recent inbound from this chat —
         #      SMS-conversations on contact-UUID chat_ids land here (the
         #      chat_id shape doesn't reveal which channel inbound came in
         #      on).
-        #   3. SMS if the chat target itself looks like an E.164 number.
-        #   4. Email otherwise (contact UUIDs, raw email addresses).
+        #   4. SMS if the chat target itself looks like an E.164 number.
+        #   5. Email otherwise (contact UUIDs, raw email addresses).
+        if not mode and thread_mode:
+            mode = thread_mode
         if not mode and chat_id in self._active_call_ws:
             mode = "voice"
         if not mode:

--- a/tests/test_imessage.py
+++ b/tests/test_imessage.py
@@ -412,6 +412,43 @@ def test_adapter_imessage_reply_uses_thread_conversation_id(monkeypatch):
     assert identity.sent_imessages == [{"conversation_id": "imconv-456", "text": "reply"}]
 
 
+def test_adapter_reply_keeps_imessage_thread_after_overlapping_call(monkeypatch):
+    identity = FakeIdentity()
+
+    async def _inline_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(adapter_mod.asyncio, "to_thread", _inline_to_thread)
+    adapter = _new_test_adapter()
+    adapter._active_call_ws = {}
+    adapter._voice_recently_closed = {"contact-123": adapter_mod.time.time() - 61}
+    adapter._last_inbound_modality = {}
+    adapter._last_inbound_imessage = {
+        "contact-123|imessage:imconv-456": {
+            "conversation_id": "imconv-456",
+            "remote_number": "+155****0101",
+            "message_id": "im-in",
+        },
+    }
+    adapter._inkbox = FakeInkboxClient(identity)
+    adapter._identity_handle = "agent"
+
+    # A voice call on the same contact can overwrite and then clear the shared
+    # modality while this iMessage turn is still running. The turn's immutable
+    # thread id must remain authoritative for its eventual reply.
+    result = asyncio.run(adapter.send(
+        "contact-123",
+        "receipt processed",
+        metadata={"thread_id": "imessage:imconv-456"},
+    ))
+
+    assert result.success is True
+    assert identity.sent_imessages == [{
+        "conversation_id": "imconv-456",
+        "text": "receipt processed",
+    }]
+
+
 def test_inbound_imessage_builds_marker_and_stashes_state(monkeypatch):
     identity = FakeIdentity()
 


### PR DESCRIPTION
## Summary
- derive outbound text modality from the gateway's immutable thread ID before mutable per-contact routing state
- prevent overlapping voice calls from hijacking or suppressing an in-flight iMessage reply
- add a regression test for the observed iMessage → call → accidental email race

## Root cause
Email, SMS, iMessage, and voice share a contact UUID as `chat_id`. A voice call could overwrite and then clear `_last_inbound_modality` while an earlier iMessage turn was still running. Once the call grace window expired, the iMessage response defaulted to email even though its metadata still contained `thread_id=imessage:<conversation>`.

## Test plan
- `pytest -q tests/test_imessage.py::test_adapter_reply_keeps_imessage_thread_after_overlapping_call`
- `pytest -q tests/test_imessage.py tests/test_sms_conversations.py tests/test_email_self_guard.py tests/test_voice_progress_suppression.py`
- `pytest -q --ignore=tests/test_external_reply.py` (296 passed, 24 skipped; the excluded file requires aiohttp, which is not installed in this local pytest environment)
