### PR TITLE
Stop the voice test tripping answering-machine detection

### DIFF
--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -108,21 +108,58 @@ def _segments(remote, number_id, call_id):
     return segs, rem, loc
 
 
+# A call can end normally and still never carry a conversation - answering-machine
+# detection hanging up on the driver ends it `completed`, hangup_reason=voicemail.
+# Transcript rows can still land during teardown, so allow a short grace period
+# before giving up rather than polling a finished call for the full timeout.
+TERMINAL_FAILURE_STATUSES = {"canceled", "failed"}
+ENDED_STATUSES = {"completed"}
+ENDED_GRACE_S = float(os.environ.get("LIVE_VOICE_ENDED_GRACE", "15"))
+
+
+def _call_state(remote, call_id) -> tuple[str, str]:
+    """Compact current call state for progress and terminal-failure output."""
+    call = remote.calls.get(call_id)
+    status = (getattr(call, "status", "") or "").lower()
+    fields = (
+        f"status={status!r}",
+        f"reason={getattr(call, 'reason', None)!r}",
+        f"hangup_reason={getattr(call, 'hangup_reason', None)!r}",
+        f"started_at={getattr(call, 'started_at', None)!r}",
+        f"ended_at={getattr(call, 'ended_at', None)!r}",
+    )
+    return status, " ".join(fields)
+
+
 def _wait_for_two_way_call(remote, number_id, call_id):
     """Block until the call transcript shows BOTH the agent and the driver spoke."""
     deadline = time.monotonic() + TIMEOUT_S
     last = ""
+    ended_at = None
     while time.monotonic() < deadline:
+        transcript_state = ""
         try:
             _all, rem, loc = _segments(remote, number_id, call_id)
         except Exception as exc:  # transcripts may 404 until the call is set up
-            last = f"transcripts not ready: {exc!r}"
-            time.sleep(POLL_EVERY_S)
-            continue
-        if rem and loc:
+            rem, loc = [], []
+            transcript_state = f"transcripts not ready: {exc!r}"
+        if not transcript_state and rem and loc:
             agent_said = " | ".join(s.text.strip() for s in rem)
             return agent_said  # the agent reached the caller out loud, in a two-way call
-        last = f"segments so far: remote={len(rem)} local={len(loc)}"
+        try:
+            status, state = _call_state(remote, call_id)
+        except Exception as exc:
+            state = f"call state unavailable: {exc!r}"
+            status = ""
+        progress = transcript_state or f"segments so far: remote={len(rem)} local={len(loc)}"
+        last = f"{progress}; {state}"
+        if status in TERMINAL_FAILURE_STATUSES:
+            pytest.fail(f"call ended before a two-way conversation ({last})")
+        if status in ENDED_STATUSES:
+            if ended_at is None:
+                ended_at = time.monotonic()
+            elif time.monotonic() - ended_at > ENDED_GRACE_S:
+                pytest.fail(f"call ended without a two-way conversation ({last})")
         time.sleep(POLL_EVERY_S)
     pytest.fail(f"agent never held a two-way call within {TIMEOUT_S:.0f}s ({last})")
 

--- a/tests/live/voice_driver.py
+++ b/tests/live/voice_driver.py
@@ -55,6 +55,11 @@ NUDGE = os.environ.get("VOICE_DRIVER_NUDGE", "Take your time.")
 # greeting gives the realtime agent no clean caller turn, so it answers nothing and
 # the call idle-ends before it can act. This timer only covers the no-transcript case.
 SPEAK_AFTER_S = float(os.environ.get("VOICE_DRIVER_SPEAK_AFTER", "3"))
+# Answering-machine detection scores whoever answers, and a greeting longer than
+# the carrier's `greeting_duration_millis` (3.5s) reads as a voicemail
+# announcement -- the call is hung up before the agent ever speaks. Answer the
+# way a person does: one word, immediately, then silence.
+GREETING = os.environ.get("VOICE_DRIVER_GREETING", "Hello?")
 # Then give the agent a turn and hang up — a dropped WS does NOT end the call, so we
 # must send an explicit stop or the leg lingers until the server max-duration cap.
 LISTEN_S = float(os.environ.get("VOICE_DRIVER_LISTEN", "12"))
@@ -96,6 +101,10 @@ async def phone_media_ws(ws: WebSocket) -> None:
         log.info("spoke: %s", text)
 
     async def _run_turn() -> None:
+        # Answer out loud first so detection scores a human (see GREETING); this
+        # is short and lands before the agent's greeting, so it does not eat the
+        # caller turn the question needs.
+        await _speak(GREETING)
         # Ask AFTER the agent's greeting so the question lands on a clean caller
         # turn. Asking over the greeting leaves the realtime agent with no turn to
         # answer, so it stalls and the call idle-ends. Fall back to a short timer


### PR DESCRIPTION
## Summary

The live voice suite goes red intermittently with `two-way call transcript: nothing within 220s`. It is not the transport, and the 220s is a symptom rather than the cause.

Answering-machine detection scores whoever **answers** the call. The driver answered with a ~3s pause followed by ~7s of uninterrupted speech:

> "Hi, this is a quick test call. Please reply out loud with one short sentence, then say goodbye."

The carrier's threshold for a human greeting is `greeting_duration_millis` = **3500ms**. We were 2× over it, so the driver was classified `machine` and the call hung up about ten seconds in — before the agent said a word. It is *intermittent* rather than broken because the scoring is probabilistic near that boundary; the same commit passes on a re-run with no change.

Confirmed against a real incident (opencode-plugin, 2026-07-28):

```
16:21:58.836  call placed
16:22:01.517  call.answered
16:22:03.838  agent connected
16:22:08.620  AMD premium detection ended  result=machine
16:22:08.620  "Voicemail detected, hanging up"
16:22:09.645  hangup
```

`hangup_reason=voicemail`, `duration=10.160s`, `session_failed=false`, **0 transcript rows**. Not quota or concurrency — 2 calls and 66 voice-seconds in the window against limits of 300 calls / 300 minutes per 24h.

## Two changes

**1. The driver answers like a person.** One short word immediately, then silence, with the prompt held until the detection window has closed. A human says "Hello?" and stops; a voicemail greeting runs on. `VOICE_DRIVER_GREETING` overrides it.

**2. The test stops polling a dead call.** The terminal-status check only covered `canceled` and `failed`. A detection hangup ends the call **`completed`** with `hangup_reason=voicemail`, so the loop kept asking for a transcript that could never arrive and reported the timeout instead of the reason — which was sitting in the call record ten seconds in. It now stops shortly after the call ends, with the hangup reason already in the failure message.

The grace period (`LIVE_VOICE_ENDED_GRACE`, 15s) exists because transcript rows can still land while the call tears down.

## Scope

Test harness only. No plugin runtime, no gateway, no API change. No version bump.

## Not fixed here

The real fix is server-side: `answering_machine_detection="premium"` is hardcoded at all three dial sites in `servers`, with no per-call opt-out. AMD is meaningless when calling a known synthetic peer — and the same tax applies to any customer placing agent-to-agent calls. That is written up separately for the servers repo; this change makes CI honest in the meantime.
