### PR TITLE
Move the CI agent model to gpt-5.6-terra

### DIFF
--- a/.github/workflows/live-a2a.yml
+++ b/.github/workflows/live-a2a.yml
@@ -91,7 +91,7 @@ jobs:
           } >> "$HERMES_HOME/.env"
           hermes config set model.provider custom || true
           hermes config set model.base_url https://api.openai.com/v1 || true
-          hermes config set model.default gpt-5.4 || true
+          hermes config set model.default gpt-5.6-terra || true
 
       - name: Start gateway
         run: |

--- a/.github/workflows/live-channels.yml
+++ b/.github/workflows/live-channels.yml
@@ -103,7 +103,7 @@ jobs:
             # OPENAI_API_KEY — no known-model alias, no OpenRouter aggregator.
             hermes config set model.provider custom || true
             hermes config set model.base_url https://api.openai.com/v1 || true
-            hermes config set model.default gpt-5.4 || true
+            hermes config set model.default gpt-5.6-terra || true
           else
             {
               echo "OPENAI_API_KEY=sk-mock-not-used"

--- a/.github/workflows/live-external-events.yml
+++ b/.github/workflows/live-external-events.yml
@@ -98,7 +98,7 @@ jobs:
           } >> "$HERMES_HOME/.env"
           hermes config set model.provider custom || true
           hermes config set model.base_url https://api.openai.com/v1 || true
-          hermes config set model.default gpt-5.4-mini || true
+          hermes config set model.default gpt-5.6-terra || true
 
       - name: Start gateway and wait for readiness
         run: |

--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -107,7 +107,7 @@ jobs:
           # the chat model; send it straight to OpenAI as-is.
           hermes config set model.provider custom || true
           hermes config set model.base_url https://api.openai.com/v1 || true
-          hermes config set model.default gpt-5.4-mini || true
+          hermes config set model.default gpt-5.6-terra || true
           if [ "${{ matrix.scenario }}" = "inbound_inkbox" ]; then
             echo "INKBOX_REALTIME_ENABLED=false" >> "$HERMES_HOME/.env"
           else


### PR DESCRIPTION
## Summary

Moves every live-suite agent model pin to **`gpt-5.6-terra`**.

The workflows pinned two different models — `gpt-5.4` on the a2a and channels suites, `gpt-5.4-mini` on voice and external-events. `gpt-5.6-terra` is the current mini tier and a generation newer than both, so that split stops buying anything and all four suites converge on one model.

| | value |
|---|---|
| Model id | `gpt-5.6-terra` |
| Tier | mini ("roughly corresponds to the mini model tier used in earlier GPT-5 families") |
| Context | 1,050,000 (max input 922,000) |
| Max output | 128,000 |
| Price | $2.50 in / $15 out / $0.25 cached, per 1M |

## Caveat worth recording

**Realtime is not a supported endpoint for terra** (nor Assistants, fine-tuning, embeddings, or the audio/image generation surfaces; Chat Completions and Batch are supported).

This does not affect the voice suite — it drives Realtime through `gpt-realtime-2`, a separate model from the agent's chat model — but it rules terra out for anything pointed at a realtime path.

## Scope

CI workflow pins only. No plugin runtime, no gateway, no API change, no version bump.

Deliberately **not** included: the Delphi Hermes gateway default in `servers` (`infra/variables.tf`), which moved to `gpt-5.6-sol` earlier today for price parity with 5.5. That is a production agent on the full tier; dropping it to mini is a product decision rather than a CI cleanup.

Source: [GPT-5.6 Terra model card](https://developers.openai.com/api/docs/models/gpt-5.6-terra)
