### PR TITLE
fix(a2a): add cross-platform atomic write safety & handle Windows chm…

### DIFF
--- a/a2a_context.py
+++ b/a2a_context.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import os
 import threading
+from contextlib import suppress
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -36,10 +37,18 @@ def _queue_path(session_id: str) -> Path:
 
 def _atomic_write(path: Path, value: Any) -> None:
     tmp = path.with_suffix(f"{path.suffix}.tmp")
-    tmp.write_text(json.dumps(value, sort_keys=True) + "\n")
-    tmp.chmod(0o600)
-    os.replace(tmp, path)
-    path.chmod(0o600)
+    try:
+        tmp.write_text(json.dumps(value, sort_keys=True) + "\n", encoding="utf-8")
+        with suppress(OSError):
+            tmp.chmod(0o600)
+        os.replace(tmp, path)
+        with suppress(OSError):
+            path.chmod(0o600)
+    finally:
+        with suppress(OSError):
+            if tmp.exists():
+                tmp.unlink()
+
 
 
 def write_a2a_turn_context(session_id: str, context: Dict[str, Any]) -> None:


### PR DESCRIPTION
Fixes #84 
####  Summary
Fixes an issue in `a2a_context.py` where `_atomic_write` raised unhandled `OSError` / `PermissionError` on Windows environments during `chmod(0o600)` calls, and left temporary `.tmp` context files dangling when atomic writes were interrupted.
####  Problem
1. **Windows Compatibility**: POSIX file permissions (`chmod(0o600)`) throw `OSError` / `PermissionError` on Windows or non-POSIX file systems.
2. **Leftover Temp Files**: If `_atomic_write` failed prior to `os.replace`, the `.tmp` file was left in the state directory, causing subsequent `os.replace` calls to fail with `PermissionError` or file lock conflicts.
####  Fix Applied
- **Cross-Platform Safety**: Wrapped POSIX `chmod(0o600)` calls in `contextlib.suppress(OSError)` so file creation succeeds across Windows and non-POSIX environments.
- **Guaranteed Cleanup**: Added a `finally` block in `_atomic_write` to safely unlink any leftover `.tmp` file on failure.
- **Explicit Encoding**: Specified `encoding="utf-8"` when writing JSON context files.
####  Verification
- Executed unit test suite for A2A context management:
  ```bash
  python -m pytest tests/test_a2a.py