### PR TITLE
fix: make A2A dispatch lifecycle observable

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,12 +404,17 @@ Hermes direct tools:
 - `inkbox_delete_contact`
 
 Inbound A2A tasks use isolated context sessions and a durable task registry.
-The three A2A outcome tools are accepted only during a verified inbound A2A
-turn. Outbound delegation tools can create tasks, wait for worker state changes,
-and answer requests for more input. The history tools support direction,
-participant, lifecycle, context, keyword, timestamp, and cursor filters. The
-sent-task tools remain available as outbound-only compatibility aliases. The
-plugin requires Inkbox SDK 0.5.9 or newer.
+After durable binding and queueing, the plugin sends a non-terminal progress
+receipt; generic assistant text never completes the task. The three A2A outcome
+tools are accepted only during a verified inbound A2A turn and are the only way
+to complete, fail, or request input for that task. `hermes inkbox doctor` reports
+the A2A subscription, recent delivery result, and bounded local dispatch phases
+without including task content or webhook response bodies. Outbound delegation
+tools can create tasks, wait for worker state changes, and answer requests for
+more input. The history tools support direction, participant, lifecycle,
+context, keyword, timestamp, and cursor filters. The sent-task tools remain
+available as outbound-only compatibility aliases. The plugin requires Inkbox
+SDK 0.5.9 or newer.
 
 Realtime-only call tools:
 

--- a/a2a_context.py
+++ b/a2a_context.py
@@ -131,7 +131,7 @@ def read_a2a_turn_context(session_id: str) -> Optional[Dict[str, Any]]:
     return value if isinstance(value, dict) else None
 
 
-def mark_a2a_reply_committed(session_id: str) -> None:
+def mark_a2a_reply_committed(session_id: str, intent: str) -> None:
     """Record that an explicit A2A intent tool already replied."""
     with _LOCK:
         path = _context_path(session_id)
@@ -142,4 +142,5 @@ def mark_a2a_reply_committed(session_id: str) -> None:
         if not isinstance(context, dict):
             return
         context["reply_intent_committed"] = True
+        context["reply_intent"] = intent
         _atomic_write(path, context)

--- a/adapter.py
+++ b/adapter.py
@@ -152,6 +152,7 @@ try:
         INKBOX_BASE_URL_DEFAULT,
         VoiceStack,
         inkbox_client_kwargs,
+        inkbox_state_path,
         resolve_voice_stack,
         set_runtime_config_extra,
     )
@@ -185,6 +186,7 @@ except ImportError:  # pragma: no cover - direct local import/test fallback
         INKBOX_BASE_URL_DEFAULT,
         VoiceStack,
         inkbox_client_kwargs,
+        inkbox_state_path,
         resolve_voice_stack,
         set_runtime_config_extra,
     )
@@ -644,6 +646,28 @@ _DESIRED_A2A_EVENTS: tuple[str, ...] = (
     "a2a.task.message",
     "a2a.task.canceled",
 )
+_A2A_RECEIPT_TEMPLATE = "Task {task_id} received. Work is queued and starting."
+_A2A_SETTLED_SERVER_STATES = frozenset({
+    "completed",
+    "failed",
+    "canceled",
+    "rejected",
+    "input_required",
+})
+_A2A_PHASE_RANK = {
+    "received": 1,
+    "bound": 2,
+    "acknowledged": 3,
+    "enqueued": 4,
+    "running": 5,
+    "finalized": 6,
+}
+_A2A_ERROR_PHASE_RANK = {
+    "binding": 2,
+    "acknowledgement": 3,
+    "queueing": 4,
+    "execution": 5,
+}
 
 
 def _is_unsupported_a2a_event_types(exc: Exception) -> bool:
@@ -664,8 +688,7 @@ def _inkbox_state_path():
     path can never drift between them. Imports are local because the
     hermes_cli package may not be importable in every consumer (tests).
     """
-    from hermes_cli.config import get_hermes_home
-    return get_hermes_home() / "inkbox_identity_state.json"
+    return inkbox_state_path()
 
 
 def _read_previous_webhook_url() -> Optional[str]:
@@ -2147,6 +2170,7 @@ class InkboxAdapter(BasePlatformAdapter):
         self._a2a_session_by_chat: Dict[str, str] = {}
         self._a2a_session_key_by_chat: Dict[str, str] = {}
         self._a2a_suppress_next_reply_by_chat: set[str] = set()
+        self._a2a_ingest_lock = asyncio.Lock()
         self._a2a_registry_path = _inkbox_state_path().with_name(
             "inkbox_a2a_tasks.json"
         )
@@ -4170,18 +4194,86 @@ class InkboxAdapter(BasePlatformAdapter):
             auto_skill=event.auto_skill,
         )
 
-    def _write_a2a_registry(self, key: str, data: Dict[str, Any], state: str) -> None:
-        """Durably record an A2A delivery before acknowledging its webhook."""
+    def _write_a2a_registry(
+        self,
+        key: str,
+        data: Dict[str, Any],
+        state: str,
+        *,
+        error_phase: str = "",
+        error_code: str = "",
+        outcome: str = "",
+        new_attempt: bool = False,
+    ) -> None:
+        """Durably record an A2A dispatch phase and its outcome."""
         try:
+            now = time.time()
             current = self._read_a2a_registry()
-            current[key] = {
+            previous = current.get(key)
+            entry = dict(previous) if isinstance(previous, dict) else {}
+            phases = entry.get("phases")
+            if new_attempt or not isinstance(phases, dict):
+                phases = {}
+            if new_attempt:
+                try:
+                    previous_attempt = int(entry.get("attempt") or 1)
+                except (TypeError, ValueError):
+                    previous_attempt = 1
+                entry["attempt"] = previous_attempt + 1
+                entry["last_error"] = None
+                entry.pop("outcome", None)
+            elif "attempt" not in entry:
+                entry["attempt"] = 1
+            if not error_code:
+                phases[state] = now
+            previous_error = entry.get("last_error")
+            previous_error = (
+                previous_error if isinstance(previous_error, dict) else None
+            )
+            latest_phase = max(
+                phases,
+                key=lambda phase: _A2A_PHASE_RANK.get(str(phase), 0),
+                default="",
+            )
+            effective_state = state
+            preserve_error = False
+            if error_code and "finalized" in phases:
+                effective_state = "finalized"
+                preserve_error = True
+            elif not error_code:
+                state_rank = _A2A_PHASE_RANK.get(state, 0)
+                latest_rank = _A2A_PHASE_RANK.get(str(latest_phase), 0)
+                error_rank = _A2A_ERROR_PHASE_RANK.get(
+                    str((previous_error or {}).get("phase") or ""),
+                    0,
+                )
+                if previous_error and state_rank < error_rank:
+                    effective_state = str(entry.get("state") or state)
+                    preserve_error = True
+                elif state_rank < latest_rank:
+                    effective_state = str(latest_phase)
+            entry.update({
                 "task_id": str(data.get("task_id") or ""),
                 "context_id": str(data.get("context_id") or ""),
                 "message_id": str(data.get("message_id") or ""),
-                "state": state,
+                "state": effective_state,
                 "data": data,
-                "updated_at": time.time(),
-            }
+                "phases": phases,
+                "updated_at": now,
+            })
+            if preserve_error:
+                entry["last_error"] = previous_error
+            elif error_code:
+                entry["last_error"] = {
+                    "phase": error_phase,
+                    "code": error_code,
+                    "at": now,
+                }
+            else:
+                entry["last_error"] = None
+            if outcome:
+                entry["outcome"] = outcome
+            current[key] = entry
             tmp = self._a2a_registry_path.with_suffix(".tmp")
             tmp.write_text(json.dumps(current, indent=2, sort_keys=True) + "\n")
             tmp.chmod(0o600)
@@ -4191,7 +4283,12 @@ class InkboxAdapter(BasePlatformAdapter):
             logger.exception("[Inkbox] Could not persist A2A task registry")
             raise
 
-    def _finalize_a2a_task_registry(self, task_id: str) -> None:
+    def _finalize_a2a_task_registry(
+        self,
+        task_id: str,
+        *,
+        outcome: str = "",
+    ) -> None:
         for key, entry in self._read_a2a_registry().items():
             if (
                 str(entry.get("task_id") or "") == task_id
@@ -4204,7 +4301,12 @@ class InkboxAdapter(BasePlatformAdapter):
                         "context_id": entry.get("context_id"),
                         "message_id": entry.get("message_id"),
                     }
-                self._write_a2a_registry(key, data, "finalized")
+                self._write_a2a_registry(
+                    key,
+                    data,
+                    "finalized",
+                    outcome=outcome,
+                )
 
     def _bind_a2a_turn_context(
         self,
@@ -4213,7 +4315,7 @@ class InkboxAdapter(BasePlatformAdapter):
         task_id: str,
         context_id: str,
         message_id: str,
-    ) -> None:
+    ) -> bool:
         """Bind verified webhook data to the host session used by tool calls."""
         handler_owner = getattr(
             getattr(self, "_message_handler", None),
@@ -4222,7 +4324,7 @@ class InkboxAdapter(BasePlatformAdapter):
         )
         session_store = getattr(handler_owner, "session_store", None)
         if session_store is None:
-            return
+            return False
         try:
             entry = session_store.get_or_create_session(source)
             session_id = str(entry.session_id)
@@ -4238,10 +4340,71 @@ class InkboxAdapter(BasePlatformAdapter):
                     "reply_intent_committed": False,
                 },
             )
+            return True
         except Exception:
             logger.exception("[Inkbox] Could not bind the A2A turn context")
+            return False
+
+    @staticmethod
+    def _a2a_task_has_receipt(task: Any, receipt: str) -> bool:
+        for message in _list_field(task, "messages"):
+            for part in _list_field(message, "parts"):
+                if str(_field(part, "text") or "") == receipt:
+                    return True
+        return False
+
+    async def _acknowledge_a2a_task(self, task_id: str) -> None:
+        """Advance the caller-visible task once local work is durably queued."""
+        identity = await asyncio.to_thread(
+            self._inkbox.get_identity,
+            self._identity_handle,
+        )
+        authoritative = await asyncio.to_thread(identity.a2a_task, task_id)
+        state = str(
+            getattr(authoritative.state, "value", authoritative.state)
+        )
+        receipt = _A2A_RECEIPT_TEMPLATE.format(task_id=task_id)
+        if state in _A2A_SETTLED_SERVER_STATES:
+            return
+        if self._a2a_task_has_receipt(authoritative, receipt):
+            return
+        await asyncio.to_thread(
+            identity.a2a_reply,
+            task_id,
+            intent="progress",
+            text=receipt,
+        )
+
+    async def _record_a2a_acknowledgement(
+        self,
+        key: str,
+        data: Dict[str, Any],
+        task_id: str,
+    ) -> bool:
+        try:
+            await self._acknowledge_a2a_task(task_id)
+        except Exception:
+            self._write_a2a_registry(
+                key,
+                data,
+                "acknowledgement_failed",
+                error_phase="acknowledgement",
+                error_code="receipt_delivery_failed",
+            )
+            logger.exception("[Inkbox] Could not acknowledge the A2A task")
+            return False
+        self._write_a2a_registry(key, data, "acknowledged")
+        return True
 
     async def _on_a2a_event(self, envelope: Dict[str, Any]) -> "web.Response":
+        """Serialize A2A admission so duplicate receipts cannot race."""
+        async with self._a2a_ingest_lock:
+            return await self._on_a2a_event_locked(envelope)
+
+    async def _on_a2a_event_locked(
+        self,
+        envelope: Dict[str, Any],
+    ) -> "web.Response":
         event_type = str(envelope.get("event_type") or "")
         data = envelope.get("data") if isinstance(envelope.get("data"), dict) else {}
         task_id = str(data.get("task_id") or "")
@@ -4281,7 +4444,7 @@ class InkboxAdapter(BasePlatformAdapter):
                     ).get("task_id") or ""
                 ) != task_id
             ]
-            self._finalize_a2a_task_registry(task_id)
+            self._finalize_a2a_task_registry(task_id, outcome="canceled")
             return web.Response(status=200, text="ok")
         if event_type == "a2a.sent_task.updated":
             logger.info("[Inkbox] Outbound A2A task updated: %s", task_id)
@@ -4290,15 +4453,37 @@ class InkboxAdapter(BasePlatformAdapter):
         key = f"{task_id}:{message_id}"
         existing = self._read_a2a_registry().get(key)
         is_resume = str(envelope.get("id") or "").startswith("resume:")
-        if existing and not (
-            is_resume and existing.get("state") != "finalized"
-        ):
+        existing = existing if isinstance(existing, dict) else {}
+        phases = existing.get("phases")
+        phases = phases if isinstance(phases, dict) else {}
+        legacy_state = str(existing.get("state") or "")
+        finalized = "finalized" in phases or legacy_state == "finalized"
+        if finalized:
+            return web.Response(status=200, text="duplicate")
+        if is_resume and existing:
+            self._write_a2a_registry(
+                key,
+                data,
+                "received",
+                new_attempt=True,
+            )
+            existing = self._read_a2a_registry().get(key) or {}
+            phases = existing.get("phases")
+            phases = phases if isinstance(phases, dict) else {}
+            legacy_state = str(existing.get("state") or "")
+        enqueued = (
+            "enqueued" in phases
+            or "running" in phases
+            or legacy_state in {"queued", "running"}
+        )
+        acknowledged = (
+            "acknowledged" in phases
+            or legacy_state in {"acknowledged", "finalized"}
+        )
+        if existing and enqueued and acknowledged and not is_resume:
             return web.Response(status=200, text="duplicate")
         if not existing:
-            self._write_a2a_registry(key, data, "queued")
-        queue = self._a2a_tasks_by_chat.setdefault(chat_id, [])
-        if task_id not in queue:
-            queue.append(task_id)
+            self._write_a2a_registry(key, data, "received")
         caller = data.get("caller") if isinstance(data.get("caller"), dict) else {}
         parts = data.get("parts") if isinstance(data.get("parts"), list) else []
         body = "\n".join(
@@ -4315,34 +4500,99 @@ class InkboxAdapter(BasePlatformAdapter):
             thread_id=None,
             message_id=message_id,
         )
-        self._bind_a2a_turn_context(
-            source,
-            task_id=task_id,
-            context_id=context_id,
-            message_id=message_id,
-        )
-        marker = (
-            f"[inkbox:a2a_task caller=@{str(caller.get('handle') or 'unknown').lstrip('@')} "
-            f"caller_org={caller.get('organization_id') or 'unknown'}]"
-        )
-        message_event = MessageEvent(
-            text=(
-                f"{marker}\n"
-                "Use inkbox_a2a_complete, inkbox_a2a_ask_caller, or "
-                "inkbox_a2a_fail when an explicit outcome is appropriate.\n"
-                f"{body}"
-            ).rstrip(),
-            message_type=MessageType.TEXT,
-            source=source,
-            raw_message=envelope,
-            message_id=message_id,
-            internal=True,
-        )
-        event_queue = self._a2a_events_by_chat.setdefault(chat_id, [])
-        event_queue.append(message_event)
-        if chat_id not in self._a2a_active_chats:
-            self._a2a_active_chats.add(chat_id)
-            await self._enqueue(message_event)
+
+        if is_resume or not enqueued:
+            if not self._bind_a2a_turn_context(
+                source,
+                task_id=task_id,
+                context_id=context_id,
+                message_id=message_id,
+            ):
+                self._write_a2a_registry(
+                    key,
+                    data,
+                    "bind_failed",
+                    error_phase="binding",
+                    error_code="session_unavailable",
+                )
+                return web.Response(status=503, text="a2a session unavailable")
+            self._write_a2a_registry(key, data, "bound")
+
+            queue = self._a2a_tasks_by_chat.setdefault(chat_id, [])
+            if task_id not in queue:
+                queue.append(task_id)
+            marker = (
+                f"[inkbox:a2a_task caller=@{str(caller.get('handle') or 'unknown').lstrip('@')} "
+                f"caller_org={caller.get('organization_id') or 'unknown'}]"
+            )
+            message_event = MessageEvent(
+                text=(
+                    f"{marker}\n"
+                    "Use inkbox_a2a_complete, inkbox_a2a_ask_caller, or "
+                    "inkbox_a2a_fail when an explicit outcome is appropriate.\n"
+                    f"{body}"
+                ).rstrip(),
+                message_type=MessageType.TEXT,
+                source=source,
+                raw_message=envelope,
+                message_id=message_id,
+                internal=True,
+            )
+            event_queue = self._a2a_events_by_chat.setdefault(chat_id, [])
+            if not any(event.message_id == message_id for event in event_queue):
+                event_queue.append(message_event)
+            if not acknowledged:
+                if not await self._record_a2a_acknowledgement(
+                    key,
+                    data,
+                    task_id,
+                ):
+                    return web.Response(
+                        status=503,
+                        text="a2a receipt unavailable",
+                    )
+                acknowledged = True
+            if chat_id not in self._a2a_active_chats:
+                self._a2a_active_chats.add(chat_id)
+                try:
+                    await self._enqueue(message_event)
+                except (Exception, asyncio.CancelledError) as exc:
+                    self._a2a_active_chats.discard(chat_id)
+                    with suppress(ValueError):
+                        event_queue.remove(message_event)
+                    if not event_queue:
+                        self._a2a_events_by_chat.pop(chat_id, None)
+                    with suppress(ValueError):
+                        queue.remove(task_id)
+                    if not queue:
+                        self._a2a_tasks_by_chat.pop(chat_id, None)
+                    session_id = self._a2a_session_by_chat.get(chat_id)
+                    if session_id:
+                        remove_queued_a2a_turn_context(session_id, task_id)
+                    self._write_a2a_registry(
+                        key,
+                        data,
+                        "enqueue_failed",
+                        error_phase="queueing",
+                        error_code=(
+                            "queue_activation_canceled"
+                            if isinstance(exc, asyncio.CancelledError)
+                            else "queue_activation_failed"
+                        ),
+                    )
+                    if isinstance(exc, asyncio.CancelledError):
+                        raise
+                    logger.exception("[Inkbox] Could not enqueue the A2A task")
+                    return web.Response(status=503, text="a2a queue unavailable")
+            self._write_a2a_registry(key, data, "enqueued")
+
+        if enqueued and not acknowledged:
+            if not await self._record_a2a_acknowledgement(
+                key,
+                data,
+                task_id,
+            ):
+                return web.Response(status=503, text="a2a receipt unavailable")
         return web.Response(status=200, text="ok")
 
     async def on_processing_start(self, event: MessageEvent) -> None:
@@ -4496,9 +4746,23 @@ class InkboxAdapter(BasePlatformAdapter):
 
         if not chat_id.startswith("a2a:"):
             return
-        self._a2a_default_reply_allowed[chat_id] = (
-            str(getattr(outcome, "value", outcome)) == "success"
-        )
+        outcome_value = str(
+            getattr(outcome, "value", outcome)
+        ).strip().lower()
+        self._a2a_default_reply_allowed[chat_id] = outcome_value == "success"
+        if outcome_value != "success":
+            raw = event.raw_message if isinstance(event.raw_message, dict) else {}
+            data = raw.get("data") if isinstance(raw.get("data"), dict) else {}
+            task_id = str(data.get("task_id") or "")
+            message_id = str(data.get("message_id") or event.message_id or "")
+            if task_id and message_id:
+                self._write_a2a_registry(
+                    f"{task_id}:{message_id}",
+                    data,
+                    "turn_failed",
+                    error_phase="execution",
+                    error_code="turn_failed",
+                )
         queue = self._a2a_events_by_chat.get(chat_id, [])
         if queue:
             if queue[0] is event:
@@ -4536,7 +4800,13 @@ class InkboxAdapter(BasePlatformAdapter):
                     continue
                 full = await asyncio.to_thread(identity.a2a_task, task_id)
                 state = str(getattr(full.state, "value", full.state))
-                if state in {"completed", "failed", "canceled", "rejected"}:
+                if state in {
+                    "completed",
+                    "failed",
+                    "canceled",
+                    "rejected",
+                    "input_required",
+                }:
                     data = entry.get("data")
                     self._write_a2a_registry(
                         key,
@@ -4546,6 +4816,7 @@ class InkboxAdapter(BasePlatformAdapter):
                             "message_id": entry.get("message_id"),
                         },
                         "finalized",
+                        outcome=state,
                     )
                     continue
                 context_id = str(full.context_id)
@@ -4599,13 +4870,11 @@ class InkboxAdapter(BasePlatformAdapter):
             logger.exception("[Inkbox] A2A catch-up failed")
 
     async def _send_a2a_reply(self, chat_id: str, content: str) -> SendResult:
-        if not self._a2a_default_reply_allowed.get(chat_id, True):
-            return SendResult(success=True, message_id="a2a-no-reply")
         if chat_id in self._a2a_suppress_next_reply_by_chat:
             self._a2a_suppress_next_reply_by_chat.discard(chat_id)
             return SendResult(success=True, message_id="a2a-canceled")
         queue = self._a2a_tasks_by_chat.get(chat_id) or []
-        if not queue or not content.strip() or content.strip().upper() == "[SILENT]":
+        if not queue:
             return SendResult(success=True, message_id="a2a-no-reply")
         session_id = self._a2a_session_by_chat.get(chat_id)
         turn_context = (
@@ -4619,18 +4888,29 @@ class InkboxAdapter(BasePlatformAdapter):
             else ""
         ) or queue[0]
 
-        def finish_task() -> None:
+        def finish_task(outcome: str = "") -> None:
             with suppress(ValueError):
                 queue.remove(task_id)
-            self._finalize_a2a_task_registry(task_id)
+            self._finalize_a2a_task_registry(task_id, outcome=outcome)
 
         if (
             turn_context
             and str(turn_context.get("task_id") or "") == task_id
             and turn_context.get("reply_intent_committed") is True
         ):
-            finish_task()
+            reply_outcome = {
+                "complete": "completed",
+                "ask_caller": "input_required",
+                "fail": "failed",
+            }.get(str(turn_context.get("reply_intent") or ""), "")
+            finish_task(reply_outcome)
             return SendResult(success=True, message_id=f"a2a:{task_id}")
+        if (
+            not self._a2a_default_reply_allowed.get(chat_id, True)
+            or not content.strip()
+            or content.strip().upper() == "[SILENT]"
+        ):
+            return SendResult(success=True, message_id="a2a-no-reply")
         try:
             identity = await asyncio.to_thread(
                 self._inkbox.get_identity, self._identity_handle
@@ -4642,22 +4922,20 @@ class InkboxAdapter(BasePlatformAdapter):
             state = str(
                 getattr(authoritative.state, "value", authoritative.state)
             )
-            if state in {"completed", "failed", "canceled", "rejected"}:
-                finish_task()
+            if state in {
+                "completed",
+                "failed",
+                "canceled",
+                "rejected",
+                "input_required",
+            }:
+                finish_task(state)
                 return SendResult(success=True, message_id=f"a2a:{task_id}")
-            await asyncio.to_thread(
-                identity.a2a_reply,
-                task_id,
-                intent="complete",
-                text=content,
+            return SendResult(
+                success=True,
+                message_id="a2a-explicit-outcome-required",
             )
-            finish_task()
-            return SendResult(success=True, message_id=f"a2a:{task_id}")
         except Exception as exc:
-            detail = str(exc).lower()
-            if "terminal" in detail:
-                finish_task()
-                return SendResult(success=True, message_id=f"a2a:{task_id}")
             return SendResult(success=False, error=str(exc), retryable=True)
 
     async def _on_mail_received(self, envelope: Dict[str, Any]) -> "web.Response":

--- a/config.py
+++ b/config.py
@@ -7,6 +7,7 @@ import os
 from dataclasses import dataclass
 from enum import Enum
 from functools import lru_cache
+from pathlib import Path
 from typing import Any, Dict
 
 
@@ -17,6 +18,18 @@ INKBOX_WS_PATH = "/phone/media/ws"
 USER_AGENT_NAME = "inkbox-hermes"
 DISTRIBUTION_NAME = "hermes-agent-plugin"
 _RUNTIME_EXTRA: Dict[str, Any] = {}
+
+
+def inkbox_state_path() -> Path:
+    """Return the shared path for the plugin's resolved identity state."""
+    try:
+        from hermes_cli.config import get_hermes_home
+
+        home = Path(get_hermes_home())
+    except ImportError:  # pragma: no cover - direct local import/test fallback
+        configured = os.getenv("HERMES_HOME")
+        home = Path(configured).expanduser() if configured else Path.home() / ".hermes"
+    return home / "inkbox_identity_state.json"
 
 
 class VoiceStack(str, Enum):

--- a/doctor.py
+++ b/doctor.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import json
+from datetime import date, datetime
 from typing import Any, Dict, List
+from urllib.parse import urlsplit, urlunsplit
 
 try:
     from .config import (
         VoiceStack,
         inkbox_client_kwargs,
+        inkbox_state_path,
         object_summary,
         read_runtime_config,
     )
@@ -17,10 +20,187 @@ except ImportError:  # pragma: no cover - direct local import/test fallback
     from config import (
         VoiceStack,
         inkbox_client_kwargs,
+        inkbox_state_path,
         object_summary,
         read_runtime_config,
     )
     from diagnostics import inkbox_api_error_message, missing_config_message
+
+
+_DESIRED_A2A_EVENTS = frozenset({
+    "a2a.task.created",
+    "a2a.task.message",
+    "a2a.task.canceled",
+})
+
+
+def _field(value: Any, name: str, default: Any = None) -> Any:
+    if isinstance(value, dict):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    return str(value)
+
+
+def _positive_int(value: Any, default: int = 1) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _safe_receiver_url(value: Any) -> str | None:
+    """Return a useful receiver location without query credentials."""
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    parsed = urlsplit(raw)
+    hostname = parsed.hostname
+    if parsed.scheme not in {"http", "https"} or not hostname:
+        return None
+    netloc = f"[{hostname}]" if ":" in hostname else hostname
+    try:
+        if parsed.port is not None:
+            netloc = f"{netloc}:{parsed.port}"
+    except ValueError:
+        return None
+    return urlunsplit((parsed.scheme, netloc, parsed.path, "", ""))
+
+
+def _local_a2a_tasks(limit: int = 10) -> List[Dict[str, Any]]:
+    """Read bounded lifecycle metadata without exposing stored task content."""
+    registry_path = inkbox_state_path().with_name("inkbox_a2a_tasks.json")
+    try:
+        loaded = json.loads(registry_path.read_text())
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return []
+    if not isinstance(loaded, dict):
+        return []
+
+    rows: List[Dict[str, Any]] = []
+
+    def updated_at(entry: Dict[str, Any]) -> float:
+        try:
+            return float(entry.get("updated_at") or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    entries = sorted(
+        (entry for entry in loaded.values() if isinstance(entry, dict)),
+        key=updated_at,
+        reverse=True,
+    )
+    for entry in entries[:limit]:
+        phases = entry.get("phases")
+        last_error = entry.get("last_error")
+        row: Dict[str, Any] = {
+            "taskId": str(entry.get("task_id") or ""),
+            "contextId": str(entry.get("context_id") or ""),
+            "messageId": str(entry.get("message_id") or ""),
+            "state": str(entry.get("state") or ""),
+            "attempt": _positive_int(entry.get("attempt")),
+            "updatedAt": _json_value(entry.get("updated_at")),
+        }
+        if entry.get("outcome"):
+            row["outcome"] = str(entry["outcome"])
+        if isinstance(phases, dict):
+            row["phases"] = {
+                str(name): _json_value(timestamp)
+                for name, timestamp in phases.items()
+            }
+        if isinstance(last_error, dict):
+            row["lastError"] = {
+                "phase": str(last_error.get("phase") or ""),
+                "code": str(last_error.get("code") or ""),
+                "at": _json_value(last_error.get("at")),
+            }
+        rows.append(row)
+    return rows
+
+
+def _delivery_result(row: Any) -> str:
+    status = _field(row, "response_status")
+    if isinstance(status, int) and 200 <= status < 300:
+        return "delivered"
+    if status in {401, 403}:
+        return "authentication"
+    if isinstance(status, int):
+        return "http_error"
+    return "transport_error"
+
+
+def _a2a_diagnostics(client: Any, identity_id: Any) -> Dict[str, Any]:
+    subscriptions = client.webhooks.subscriptions.list(
+        agent_identity_id=identity_id,
+    )
+    a2a_subscriptions = [
+        row
+        for row in subscriptions
+        if any(
+            str(event_type).startswith("a2a.")
+            for event_type in (_field(row, "event_types", []) or [])
+        )
+    ]
+    ready = any(
+        set(
+            str(event_type)
+            for event_type in (_field(row, "event_types", []) or [])
+        ) == _DESIRED_A2A_EVENTS
+        and str(_field(row, "status", "")) == "active"
+        for row in a2a_subscriptions
+    )
+    a2a_subscriptions.sort(
+        key=lambda row: str(_field(row, "updated_at", "") or ""),
+        reverse=True,
+    )
+    subscription_rows: List[Dict[str, Any]] = []
+    delivery_rows: List[Dict[str, Any]] = []
+    for subscription in a2a_subscriptions[:10]:
+        subscription_id = _field(subscription, "id")
+        event_types = sorted(
+            str(event_type)
+            for event_type in (_field(subscription, "event_types", []) or [])
+        )
+        subscription_rows.append({
+            "id": str(subscription_id),
+            "eventTypes": event_types,
+            "status": str(_field(subscription, "status", "")),
+            "receiverUrl": _safe_receiver_url(_field(subscription, "url")),
+            "createdAt": _json_value(_field(subscription, "created_at")),
+            "updatedAt": _json_value(_field(subscription, "updated_at")),
+        })
+        for delivery in client.webhooks.deliveries.list(
+            subscription_id=subscription_id,
+            limit=10,
+        ):
+            delivery_rows.append({
+                "id": str(_field(delivery, "id", "")),
+                "subscriptionId": str(subscription_id),
+                "eventId": str(_field(delivery, "event_id", "")),
+                "eventType": str(_field(delivery, "event_type", "")),
+                "responseStatus": _field(delivery, "response_status"),
+                "result": _delivery_result(delivery),
+                "isReplay": bool(_field(delivery, "is_replay", False)),
+                "createdAt": _json_value(_field(delivery, "created_at")),
+            })
+
+    delivery_rows.sort(
+        key=lambda row: str(row.get("createdAt") or ""),
+        reverse=True,
+    )
+    return {
+        "ready": ready,
+        "subscriptions": subscription_rows,
+        "recentDeliveries": delivery_rows[:10],
+        "localTasks": _local_a2a_tasks(),
+    }
 
 
 def run_doctor() -> Dict[str, Any]:
@@ -107,6 +287,12 @@ def run_doctor() -> Dict[str, Any]:
         "voiceAiAuthorityMode": cfg.voice_ai_authority_mode,
         "voicemailDetection": cfg.voicemail_detection,
         "realtimeConfigured": bool(cfg.realtime_api_key),
+        "a2a": {
+            "ready": False,
+            "subscriptions": [],
+            "recentDeliveries": [],
+            "localTasks": _local_a2a_tasks(),
+        },
         "findings": findings,
     }
 
@@ -161,6 +347,49 @@ def run_doctor() -> Dict[str, Any]:
                                 "Rerun `hermes inkbox setup` to reconcile it."
                             ),
                         })
+                try:
+                    a2a = _a2a_diagnostics(client, identity.id)
+                    summary["a2a"] = a2a
+                    if not a2a["ready"]:
+                        findings.append({
+                            "id": "inkbox/a2a-subscription-not-ready",
+                            "severity": "warning",
+                            "message": (
+                                "The active A2A webhook subscription does not "
+                                "match the required event set. Restart the gateway "
+                                "to reconcile it."
+                            ),
+                        })
+                    recent_deliveries = a2a["recentDeliveries"]
+                    if (
+                        recent_deliveries
+                        and recent_deliveries[0]["result"] != "delivered"
+                    ):
+                        result = recent_deliveries[0]["result"]
+                        findings.append({
+                            "id": "inkbox/a2a-latest-delivery-failed",
+                            "severity": "warning",
+                            "message": (
+                                "The latest A2A webhook delivery was not accepted "
+                                f"({result}). Check the receiver and signing-key "
+                                "configuration before replaying it."
+                            ),
+                        })
+                except Exception:
+                    summary["a2a"] = {
+                        "ready": False,
+                        "subscriptions": [],
+                        "recentDeliveries": [],
+                        "localTasks": _local_a2a_tasks(),
+                    }
+                    findings.append({
+                        "id": "inkbox/a2a-diagnostics-unavailable",
+                        "severity": "warning",
+                        "message": (
+                            "A2A webhook diagnostics are unavailable. Confirm the "
+                            "installed Inkbox SDK supports webhook delivery logs."
+                        ),
+                    })
         except Exception as exc:
             findings.append({
                 "id": "inkbox/api-check-failed",

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -44,7 +44,26 @@ def _adapter(tmp_path):
     adapter._a2a_session_by_chat = {}
     adapter._a2a_session_key_by_chat = {}
     adapter._a2a_suppress_next_reply_by_chat = set()
+    adapter._a2a_ingest_lock = asyncio.Lock()
     adapter._enqueued = []
+    adapter._a2a_receipts = []
+
+    task = types.SimpleNamespace(state="submitted", messages=[])
+
+    class Identity:
+        def a2a_task(self, _task_id):
+            return task
+
+        def a2a_reply(self, task_id, **kwargs):
+            adapter._a2a_receipts.append((task_id, kwargs))
+            task.messages.append(types.SimpleNamespace(
+                parts=[{"text": kwargs["text"]}],
+            ))
+
+    adapter._inkbox = types.SimpleNamespace(
+        get_identity=lambda _handle: Identity(),
+    )
+    adapter._bind_a2a_turn_context = lambda *_args, **_kwargs: True
 
     async def enqueue(event):
         adapter._enqueued.append(event)
@@ -99,7 +118,179 @@ def test_a2a_event_is_persisted_before_enqueue_and_deduplicated(tmp_path):
     assert adapter._enqueued[0].source.chat_id == "a2a:identity-1:context-1"
     assert adapter._a2a_registry_path.exists()
     registry = json.loads(adapter._a2a_registry_path.read_text())
-    assert registry["task-1:message-1"]["state"] == "queued"
+    entry = registry["task-1:message-1"]
+    assert entry["state"] == "enqueued"
+    assert list(entry["phases"]) == [
+        "acknowledged",
+        "bound",
+        "enqueued",
+        "received",
+    ]
+    assert adapter._a2a_receipts == [(
+        "task-1",
+        {
+            "intent": "progress",
+            "text": "Task task-1 received. Work is queued and starting.",
+        },
+    )]
+
+
+def test_concurrent_duplicate_a2a_delivery_sends_one_receipt(tmp_path):
+    adapter = _adapter(tmp_path)
+
+    async def deliver_duplicates():
+        return await asyncio.gather(
+            adapter._on_a2a_event(_event("evt-1")),
+            adapter._on_a2a_event(_event("evt-2")),
+        )
+
+    responses = asyncio.run(deliver_duplicates())
+
+    assert {response.text for response in responses} == {"ok", "duplicate"}
+    assert len(adapter._enqueued) == 1
+    assert len(adapter._a2a_receipts) == 1
+
+
+def test_a2a_bind_failure_is_retryable_before_enqueue(tmp_path):
+    adapter = _adapter(tmp_path)
+    adapter._bind_a2a_turn_context = lambda *_args, **_kwargs: False
+
+    failed = asyncio.run(adapter._on_a2a_event(_event()))
+
+    assert failed.status == 503
+    assert adapter._enqueued == []
+    registry = json.loads(adapter._a2a_registry_path.read_text())
+    assert registry["task-1:message-1"]["last_error"] == {
+        "at": registry["task-1:message-1"]["last_error"]["at"],
+        "code": "session_unavailable",
+        "phase": "binding",
+    }
+
+    adapter._bind_a2a_turn_context = lambda *_args, **_kwargs: True
+    retried = asyncio.run(adapter._on_a2a_event(_event("evt-retry")))
+
+    assert retried.status == 200
+    assert len(adapter._enqueued) == 1
+    assert len(adapter._a2a_receipts) == 1
+
+
+def test_a2a_enqueue_failure_rolls_back_and_retries(tmp_path):
+    adapter = _adapter(tmp_path)
+    attempts = 0
+
+    async def flaky_enqueue(event):
+        nonlocal attempts
+        attempts += 1
+        registry = json.loads(adapter._a2a_registry_path.read_text())
+        assert "acknowledged" in registry["task-1:message-1"]["phases"]
+        if attempts == 1:
+            raise RuntimeError("queue unavailable")
+        adapter._enqueued.append(event)
+
+    adapter._enqueue = flaky_enqueue
+
+    failed = asyncio.run(adapter._on_a2a_event(_event()))
+
+    assert failed.status == 503
+    assert adapter._a2a_tasks_by_chat == {}
+    assert adapter._a2a_events_by_chat == {}
+    assert adapter._a2a_active_chats == set()
+
+    retried = asyncio.run(adapter._on_a2a_event(_event("evt-retry")))
+
+    assert retried.status == 200
+    assert attempts == 2
+    assert len(adapter._enqueued) == 1
+    assert len(adapter._a2a_receipts) == 1
+
+
+def test_a2a_enqueue_cancellation_rolls_back_before_propagating(tmp_path):
+    adapter = _adapter(tmp_path)
+
+    async def canceled_enqueue(_event):
+        raise asyncio.CancelledError
+
+    adapter._enqueue = canceled_enqueue
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(adapter._on_a2a_event(_event()))
+
+    assert adapter._a2a_tasks_by_chat == {}
+    assert adapter._a2a_events_by_chat == {}
+    assert adapter._a2a_active_chats == set()
+    registry = json.loads(adapter._a2a_registry_path.read_text())
+    assert registry["task-1:message-1"]["last_error"]["code"] == (
+        "queue_activation_canceled"
+    )
+
+
+def test_a2a_receipt_failure_retries_without_reenqueue(tmp_path):
+    adapter = _adapter(tmp_path)
+    attempts = 0
+
+    class Identity:
+        task = types.SimpleNamespace(state="submitted", messages=[])
+
+        def a2a_task(self, _task_id):
+            return self.task
+
+        def a2a_reply(self, task_id, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise RuntimeError("receipt unavailable")
+            adapter._a2a_receipts.append((task_id, kwargs))
+
+    identity = Identity()
+    adapter._inkbox = types.SimpleNamespace(
+        get_identity=lambda _handle: identity,
+    )
+
+    failed = asyncio.run(adapter._on_a2a_event(_event()))
+
+    assert adapter._enqueued == []
+
+    retried = asyncio.run(adapter._on_a2a_event(_event("evt-retry")))
+
+    assert failed.status == 503
+    assert retried.status == 200
+    assert len(adapter._enqueued) == 1
+    assert attempts == 2
+    assert len(adapter._a2a_receipts) == 1
+
+
+def test_a2a_receipt_is_idempotent_when_response_is_lost(tmp_path):
+    adapter = _adapter(tmp_path)
+    attempts = 0
+    receipt = "Task task-1 received. Work is queued and starting."
+    task = types.SimpleNamespace(state="submitted", messages=[])
+
+    class Identity:
+        def a2a_task(self, _task_id):
+            return task
+
+        def a2a_reply(self, _task_id, **_kwargs):
+            nonlocal attempts
+            attempts += 1
+            task.messages.append(types.SimpleNamespace(
+                parts=[{"text": receipt}],
+            ))
+            raise RuntimeError("response lost")
+
+    identity = Identity()
+    adapter._inkbox = types.SimpleNamespace(
+        get_identity=lambda _handle: identity,
+    )
+
+    failed = asyncio.run(adapter._on_a2a_event(_event()))
+    retried = asyncio.run(adapter._on_a2a_event(_event("evt-retry")))
+
+    assert failed.status == 503
+    assert retried.status == 200
+    assert len(adapter._enqueued) == 1
+    assert attempts == 1
+    registry = json.loads(adapter._a2a_registry_path.read_text())
+    assert registry["task-1:message-1"]["state"] == "enqueued"
 
 
 def test_a2a_cancel_removes_only_the_addressed_task(tmp_path):
@@ -159,6 +350,66 @@ def test_same_context_a2a_events_are_dispatched_one_at_a_time(tmp_path):
     assert [event.message_id for event in handed_off] == ["message-2"]
 
 
+def test_a2a_running_and_turn_failure_are_durable(tmp_path):
+    adapter = _adapter(tmp_path)
+    asyncio.run(adapter._on_a2a_event(_event()))
+    event = adapter._enqueued[0]
+
+    asyncio.run(adapter.on_processing_start(event))
+
+    registry = json.loads(adapter._a2a_registry_path.read_text())
+    entry = registry["task-1:message-1"]
+    assert entry["state"] == "running"
+    assert "running" in entry["phases"]
+
+    asyncio.run(adapter.on_processing_complete(
+        event,
+        types.SimpleNamespace(value="failure"),
+    ))
+
+    registry = json.loads(adapter._a2a_registry_path.read_text())
+    entry = registry["task-1:message-1"]
+    assert entry["state"] == "turn_failed"
+    assert entry["last_error"]["phase"] == "execution"
+    assert entry["last_error"]["code"] == "turn_failed"
+
+
+def test_late_receipt_cannot_regress_running_or_failed_state(tmp_path):
+    adapter = _adapter(tmp_path)
+
+    async def start_before_enqueue_returns(event):
+        adapter._enqueued.append(event)
+        await adapter.on_processing_start(event)
+
+    adapter._enqueue = start_before_enqueue_returns
+
+    response = asyncio.run(adapter._on_a2a_event(_event()))
+
+    assert response.status == 200
+    registry = json.loads(adapter._a2a_registry_path.read_text())
+    entry = registry["task-1:message-1"]
+    assert entry["state"] == "running"
+    assert "acknowledged" in entry["phases"]
+
+    adapter._write_a2a_registry(
+        "task-1:message-1",
+        _event()["data"],
+        "turn_failed",
+        error_phase="execution",
+        error_code="turn_failed",
+    )
+    adapter._write_a2a_registry(
+        "task-1:message-1",
+        _event()["data"],
+        "acknowledged",
+    )
+
+    registry = json.loads(adapter._a2a_registry_path.read_text())
+    entry = registry["task-1:message-1"]
+    assert entry["state"] == "turn_failed"
+    assert entry["last_error"]["phase"] == "execution"
+
+
 def test_failed_a2a_turn_cannot_default_complete(tmp_path):
     adapter = _adapter(tmp_path)
     chat_id = "a2a:identity-1:context-1"
@@ -189,7 +440,7 @@ def test_a2a_home_channel_notice_does_not_complete_task(tmp_path):
     assert adapter._a2a_tasks_by_chat[chat_id] == ["task-1"]
 
 
-def test_default_a2a_reply_completes_oldest_task(monkeypatch, tmp_path):
+def test_generic_a2a_reply_cannot_complete_task(monkeypatch, tmp_path):
     adapter = _adapter(tmp_path)
     chat_id = "a2a:identity-1:context-1"
     adapter._a2a_tasks_by_chat[chat_id] = ["task-1", "task-2"]
@@ -213,8 +464,40 @@ def test_default_a2a_reply_completes_oldest_task(monkeypatch, tmp_path):
     result = asyncio.run(adapter._send_a2a_reply(chat_id, "Done."))
 
     assert result.success is True
-    assert replies == [("task-1", {"intent": "complete", "text": "Done."})]
-    assert adapter._a2a_tasks_by_chat[chat_id] == ["task-2"]
+    assert result.message_id == "a2a-explicit-outcome-required"
+    assert replies == []
+    assert adapter._a2a_tasks_by_chat[chat_id] == ["task-1", "task-2"]
+
+
+def test_explicit_a2a_intent_finalizes_with_outcome(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _adapter(tmp_path)
+    chat_id = "a2a:identity-1:context-1"
+    adapter._a2a_tasks_by_chat[chat_id] = ["task-1"]
+    adapter._a2a_session_by_chat[chat_id] = "session-1"
+    adapter._write_a2a_registry(
+        "task-1:message-1",
+        _event()["data"],
+        "running",
+    )
+    write_a2a_turn_context(
+        "session-1",
+        {
+            "task_id": "task-1",
+            "context_id": "context-1",
+            "message_id": "message-1",
+            "reply_intent_committed": True,
+            "reply_intent": "fail",
+        },
+    )
+
+    result = asyncio.run(adapter._send_a2a_reply(chat_id, "[SILENT]"))
+
+    assert result.success is True
+    assert adapter._a2a_tasks_by_chat[chat_id] == []
+    registry = json.loads(adapter._a2a_registry_path.read_text())
+    assert registry["task-1:message-1"]["state"] == "finalized"
+    assert registry["task-1:message-1"]["outcome"] == "failed"
 
 
 def test_a2a_intent_tools_require_verified_turn_context(
@@ -258,6 +541,7 @@ def test_a2a_intent_tools_require_verified_turn_context(
         ("task-1", {"intent": "ask_caller", "text": "Which region?"})
     ]
     assert read_a2a_turn_context("session-1")["reply_intent_committed"] is True
+    assert read_a2a_turn_context("session-1")["reply_intent"] == "ask_caller"
 
 
 def test_a2a_delegation_tools_send_check_wait_and_reply(monkeypatch):
@@ -590,6 +874,7 @@ def test_a2a_catch_up_resumes_nonfinal_registry_entries(
     )
     identity = types.SimpleNamespace(
         a2a_task=lambda _task_id: task,
+        a2a_reply=lambda *_args, **_kwargs: None,
         iter_a2a_tasks=lambda **_kwargs: iter(()),
     )
     adapter._inkbox = types.SimpleNamespace(
@@ -607,6 +892,9 @@ def test_a2a_catch_up_resumes_nonfinal_registry_entries(
     assert adapter._a2a_tasks_by_chat[
         "a2a:identity-1:context-1"
     ] == ["task-1"]
+    registry = json.loads(adapter._a2a_registry_path.read_text())
+    assert registry["task-1:message-1"]["state"] == "enqueued"
+    assert registry["task-1:message-1"]["attempt"] == 2
 
 
 def test_a2a_catch_up_skips_sdk_without_task_inbox(

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,3 +1,4 @@
+import json
 import sys
 import types
 from pathlib import Path
@@ -208,3 +209,131 @@ def test_doctor_ignores_inactive_voice_ai_authority(monkeypatch):
 
     finding_ids = {finding["id"] for finding in summary["findings"]}
     assert "inkbox/config-invalid-voice-ai-authority" not in finding_ids
+
+
+def test_doctor_reports_safe_a2a_delivery_and_local_lifecycle(
+    monkeypatch,
+    tmp_path,
+):
+    _clear_inkbox_env(monkeypatch)
+    monkeypatch.setenv("INKBOX_API_KEY", "ApiKey_fake")
+    monkeypatch.setenv("INKBOX_IDENTITY", "fake-agent")
+    monkeypatch.setenv("INKBOX_SIGNING_KEY", "whsec_fake")
+    state_path = tmp_path / "inkbox_identity_state.json"
+    monkeypatch.setattr(doctor, "inkbox_state_path", lambda: state_path)
+    state_path.with_name("inkbox_a2a_tasks.json").write_text(json.dumps({
+        "task-1:message-1": {
+            "task_id": "task-1",
+            "context_id": "context-1",
+            "message_id": "message-1",
+            "state": "acknowledgement_failed",
+            "updated_at": 123.0,
+            "phases": {"received": 120.0, "enqueued": 122.0},
+            "last_error": {
+                "phase": "acknowledgement",
+                "code": "receipt_delivery_failed",
+                "at": 123.0,
+            },
+            "data": {"parts": [{"text": "private task body"}]},
+        },
+    }))
+
+    class Identity:
+        id = "identity-1"
+        mailbox = None
+        phone_number = None
+        imessage_enabled = False
+
+        def get_incoming_call_action(self):
+            return types.SimpleNamespace(incoming_call_action="auto_accept")
+
+    subscription = types.SimpleNamespace(
+        id="subscription-1",
+        event_types=[
+            "a2a.task.created",
+            "a2a.task.message",
+            "a2a.task.canceled",
+        ],
+        status="active",
+        url="https://agent.example/inkbox/webhook?key=secret-value",
+        created_at="2026-08-01T00:00:00Z",
+        updated_at="2026-08-02T00:00:00Z",
+    )
+    delivery = types.SimpleNamespace(
+        id="delivery-1",
+        event_id="event-1",
+        event_type="a2a.task.created",
+        response_status=401,
+        response_body="sensitive response body",
+        request_payload="sensitive request body",
+        error_detail="sensitive transport detail",
+        is_replay=False,
+        created_at="2026-08-03T00:00:00Z",
+    )
+
+    class FakeInkbox:
+        def __init__(self, **_kwargs):
+            self.webhooks = types.SimpleNamespace(
+                subscriptions=types.SimpleNamespace(
+                    list=lambda **_kwargs: [subscription],
+                ),
+                deliveries=types.SimpleNamespace(
+                    list=lambda **_kwargs: [delivery],
+                ),
+            )
+
+        def whoami(self):
+            return {"scope": "agent"}
+
+        def get_identity(self, _handle):
+            return Identity()
+
+    monkeypatch.setitem(
+        sys.modules, "inkbox", types.SimpleNamespace(Inkbox=FakeInkbox),
+    )
+
+    summary = doctor.run_doctor()
+
+    assert summary["a2a"]["ready"] is True
+    assert summary["a2a"]["subscriptions"][0]["receiverUrl"] == (
+        "https://agent.example/inkbox/webhook"
+    )
+    assert summary["a2a"]["recentDeliveries"][0]["result"] == (
+        "authentication"
+    )
+    assert summary["a2a"]["localTasks"][0]["state"] == (
+        "acknowledgement_failed"
+    )
+    finding_ids = {finding["id"] for finding in summary["findings"]}
+    assert "inkbox/a2a-latest-delivery-failed" in finding_ids
+    rendered = json.dumps(summary)
+    assert "secret-value" not in rendered
+    assert "private task body" not in rendered
+    assert "sensitive response body" not in rendered
+    assert "sensitive request body" not in rendered
+    assert "sensitive transport detail" not in rendered
+
+
+def test_a2a_diagnostics_marks_drifted_subscription_not_ready(monkeypatch):
+    monkeypatch.setattr(doctor, "_local_a2a_tasks", lambda: [])
+    subscription = types.SimpleNamespace(
+        id="subscription-1",
+        event_types=["a2a.task.created"],
+        status="active",
+        url="https://agent.example/inkbox/webhook",
+        created_at=None,
+        updated_at=None,
+    )
+    client = types.SimpleNamespace(webhooks=types.SimpleNamespace(
+        subscriptions=types.SimpleNamespace(
+            list=lambda **_kwargs: [subscription],
+        ),
+        deliveries=types.SimpleNamespace(list=lambda **_kwargs: []),
+    ))
+
+    result = doctor._a2a_diagnostics(client, "identity-1")
+
+    assert result["ready"] is False
+    assert result["subscriptions"][0]["eventTypes"] == [
+        "a2a.task.created",
+    ]

--- a/tools.py
+++ b/tools.py
@@ -96,7 +96,7 @@ def _a2a_intent(intent: str, text: str, session_id: str) -> str:
             }:
                 raise
             result = authoritative
-        mark_a2a_reply_committed(session_id)
+        mark_a2a_reply_committed(session_id, intent)
         return _json({"ok": True, "result": _json_safe(result)})
     except Exception as exc:
         return _json({"error": str(exc)})


### PR DESCRIPTION
## Executive Summary

Makes inbound A2A dispatch retry-safe and observable from verified admission through explicit terminal outcome. Callers now receive one non-terminal progress receipt before host activation, while operators can inspect subscription readiness, recent delivery results, and bounded local lifecycle state with `hermes inkbox doctor`.

## Description

- Replaces the single queued registry marker with attempt-aware `received`, `bound`, `acknowledged`, `enqueued`, `running`, and `finalized` phases plus a structured current error boundary.
- Serializes A2A admission, rolls back failed or canceled queue activation, and safely resumes unfinished work through startup catch-up.
- Sends a deterministic progress receipt after durable session binding; retries inspect the authoritative task before sending so a lost HTTP response does not create a second receipt.
- Requires `complete`, `fail`, or `ask_caller` intent tools for terminal outcomes. Generic assistant text and status notices cannot complete a task.
- Extends `hermes inkbox doctor` with the concrete A2A subscription, sanitized receiver URL, recent delivery classification, and bounded local lifecycle metadata. Task content, request payloads, response bodies, transport details, URL credentials, and query parameters are excluded.
- Documents the caller-visible receipt and terminal-only behavior.

## Reason

A successful server-side task submission or delivery attempt did not prove that Hermes had accepted, durably bound, activated, or acknowledged the work. The previous registry also treated any existing entry as a duplicate, so a partial bind or enqueue failure could suppress the retry needed to recover. Operators had no built-in way to distinguish subscription or delivery failure from local dispatch failure.

## Decisions

- Acknowledgement follows durable turn-context binding and precedes host activation, preserving caller-visible ordering without claiming a terminal result.
- Admission uses one process-local lock because the receipt API has no idempotency key; authoritative task history provides crash/retry recovery across process restarts.
- Lifecycle writes are monotonic within an attempt so a late acknowledgement cannot overwrite `running`, execution failure, or terminal state. Startup recovery begins a new numbered attempt.
- Delivery and subscription problems remain doctor warnings with explicit A2A readiness state, while existing configuration and API errors continue to control the overall doctor result.
- Existing sender admission, contact authorization, and read-only email behavior are unchanged.

## Testing

- `.venv/bin/ruff check .`
- Python 3.11: `499 passed, 25 skipped`
- Python 3.12: `499 passed, 25 skipped`
- Real Hermes main contract suite: `12 passed`
- Added regressions for webhook and startup catch-up admission, concurrent duplicates, response-loss idempotency, bind/acknowledgement/enqueue failures, cancellation rollback, lifecycle write races, diagnostics redaction, and terminal-only outcomes.

Closes #90