### PR TITLE
Handle nameless contacts in realtime calls

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -7220,7 +7220,7 @@ class InkboxAdapter(BasePlatformAdapter):
             self._call_ws_meta[hash(str(call_id))] = {
                 "call_id": str(call_id),
                 "contact_id": str(contact_id or remote),
-                "contact_name": contact_name or remote,
+                "contact_name": contact_name,
                 "contact": contact,
                 "contact_memories": contact_memories,
                 "remote_phone_number": remote,
@@ -7331,9 +7331,7 @@ class InkboxAdapter(BasePlatformAdapter):
             meta = {
                 "call_id": call_id,
                 "contact_id": (contact["id"] if contact else (remote or call_id or "unknown")),
-                "contact_name": (
-                    contact["name"] if contact and contact.get("name") else (remote or "unknown")
-                ),
+                "contact_name": contact["name"] if contact and contact.get("name") else None,
                 "contact": contact,
                 "contact_memories": contact_memories,
                 "remote_phone_number": remote,
@@ -7341,8 +7339,9 @@ class InkboxAdapter(BasePlatformAdapter):
             }
 
         contact_id = meta.get("contact_id") or call_id or "unknown"
-        contact_name = meta.get("contact_name") or contact_id
         remote_phone_number = (meta.get("remote_phone_number") or "").strip() or None
+        contact_name = meta.get("contact_name") or None
+        contact_label = contact_name or remote_phone_number or str(contact_id)
         direction = (meta.get("direction") or "inbound").strip().lower()
 
         # Direction-aware session keying:
@@ -7408,7 +7407,7 @@ class InkboxAdapter(BasePlatformAdapter):
                 rt_meta = RealtimeCallMeta(
                     call_id=call_id or "unknown",
                     contact_id=str(contact_id),
-                    contact_name=str(contact_name),
+                    contact_name=contact_name,
                     remote_phone_number=remote_phone_number,
                     direction=direction or "inbound",
                     agent_identity_handle=self._identity_handle,
@@ -7579,10 +7578,10 @@ class InkboxAdapter(BasePlatformAdapter):
             )
             source = self.build_source(
                 chat_id=str(contact_id),
-                chat_name=contact_name,
+                chat_name=contact_label,
                 chat_type="dm",
                 user_id=str(contact_id),
-                user_name=contact_name,
+                user_name=contact_label,
                 user_id_alt=remote_phone_number,
                 thread_id=call_thread_id,
                 chat_topic="voice_call",
@@ -7634,10 +7633,10 @@ class InkboxAdapter(BasePlatformAdapter):
                         continue
                     source = self.build_source(
                         chat_id=str(contact_id),
-                        chat_name=contact_name,
+                        chat_name=contact_label,
                         chat_type="dm",
                         user_id=str(contact_id),
-                        user_name=contact_name,
+                        user_name=contact_label,
                         user_id_alt=remote_phone_number,
                         thread_id=call_thread_id,
                         chat_topic="voice_call",
@@ -7718,10 +7717,10 @@ class InkboxAdapter(BasePlatformAdapter):
                 )
                 source = self.build_source(
                     chat_id=str(contact_id),
-                    chat_name=contact_name,
+                    chat_name=contact_label,
                     chat_type="dm",
                     user_id=str(contact_id),
-                    user_name=contact_name,
+                    user_name=contact_label,
                     user_id_alt=remote_phone_number,
                     thread_id=call_thread_id,
                     chat_topic="voice_call",

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: inkbox
 label: Inkbox
 kind: platform
-version: 0.2.8
+version: 0.2.9
 description: Inkbox email, SMS/MMS, iMessage, voice, and A2A platform plugin for Hermes Agent.
 author: Inkbox
 requires_env: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hermes-agent-plugin"
-version = "0.2.8"
+version = "0.2.9"
 description = "Inkbox platform plugin for Hermes Agent"
 # inkbox>=0.4.7 requires Python 3.11+, so we can't claim 3.10 support.
 requires-python = ">=3.11"

--- a/realtime.py
+++ b/realtime.py
@@ -467,7 +467,7 @@ class RealtimeCallMeta:
 
     call_id: str
     contact_id: str
-    contact_name: str
+    contact_name: Optional[str]
     remote_phone_number: Optional[str]
     direction: str  # "inbound" or "outbound"
     agent_identity_handle: Optional[str] = None
@@ -603,12 +603,18 @@ def build_realtime_instructions(
         )
     if meta.remote_phone_number:
         lines.append(f"Caller is calling from: {meta.remote_phone_number}.")
-    if meta.contact_known and meta.contact_name and meta.contact_name not in ("unknown", ""):
-        lines.append(
-            "You already know who this is — do NOT look them up or ask for "
-            "details you already have below.",
-        )
-        lines.append(f"Caller name: {_escape_contact_memory_tokens(meta.contact_name)}.")
+    if meta.contact_known:
+        if meta.contact_name and meta.contact_name not in ("unknown", ""):
+            lines.append(
+                "You already know who this is — do NOT look them up or ask for "
+                "details you already have below.",
+            )
+            lines.append(f"Caller name: {_escape_contact_memory_tokens(meta.contact_name)}.")
+        else:
+            lines.append(
+                "A matching contact record is loaded, but their name is unknown. "
+                "Greet them neutrally and never use their phone number as a name.",
+            )
         if meta.contact_emails:
             lines.append(f"Caller email(s): {', '.join(meta.contact_emails)}.")
         if meta.contact_phones:

--- a/tests/test_contact_memories.py
+++ b/tests/test_contact_memories.py
@@ -144,17 +144,19 @@ def test_incoming_call_carries_payload_memories_to_live_call():
     adapter._call_ws_meta = {}
 
     async def _resolve_contact_full(**_kwargs):
-        return {"id": "contact-1", "name": "Alex"}
+        return {"id": "contact-1", "name": None}
 
     adapter._resolve_contact_full = _resolve_contact_full
     response = asyncio.run(adapter._on_incoming_call({
         "id": "call-1",
         "remote_phone_number": "+15555550101",
-        "contacts": [{"id": "contact-1", "name": "Alex", "memories": ["Likes concise calls."]}],
+        "contacts": [{"id": "contact-1", "name": None, "memories": ["Likes concise calls."]}],
     }))
 
     assert response.status == 200
-    assert adapter._call_ws_meta[hash("call-1")]["contact_memories"] == ["Likes concise calls."]
+    meta = adapter._call_ws_meta[hash("call-1")]
+    assert meta["contact_name"] is None
+    assert meta["contact_memories"] == ["Likes concise calls."]
 
 
 def test_contact_resolution_keeps_notes_separate_from_payload_memories():
@@ -316,14 +318,14 @@ def test_auto_accept_call_context_carries_memories_without_webhook_prestash(monk
     adapter._voice_recently_closed = {}
 
     async def resolve_contact(**_kwargs):
-        return {"id": "contact-1", "name": "Alex", "emails": [], "phones": []}
+        return {"id": "contact-1", "name": None, "emails": [], "phones": []}
 
     adapter._resolve_contact_full = resolve_contact
     context = json.dumps({
         "call_id": "call-1",
         "remote_phone_number": "+15555550101",
         "contacts": [
-            {"id": "contact-1", "name": "Alex", "memories": ["Likes concise calls."]}
+            {"id": "contact-1", "name": None, "memories": ["Likes concise calls."]}
         ],
     })
     request = types.SimpleNamespace(
@@ -333,4 +335,6 @@ def test_auto_accept_call_context_carries_memories_without_webhook_prestash(monk
 
     asyncio.run(adapter._handle_call_ws(request))
 
+    assert captured["meta"].contact_known is True
+    assert captured["meta"].contact_name is None
     assert captured["meta"].contact_memories == ["Likes concise calls."]

--- a/tests/test_realtime_bridge_parity.py
+++ b/tests/test_realtime_bridge_parity.py
@@ -235,6 +235,24 @@ def test_unknown_contact_greeting_does_not_use_raw_phone_as_name():
     assert "there" in greeting
 
 
+def test_known_contact_without_name_keeps_context_and_greets_neutrally():
+    meta = _meta(
+        contact_name=None,
+        contact_emails=["caller@example.com"],
+        contact_company="Example Co",
+    )
+
+    instructions = build_realtime_instructions(meta)
+    greeting = build_realtime_greeting(meta)
+
+    assert "matching contact record is loaded" in instructions
+    assert "never use their phone number as a name" in instructions
+    assert "caller@example.com" in instructions
+    assert "Example Co" in instructions
+    assert "+15555550101" not in greeting
+    assert "there" in greeting
+
+
 def test_proactive_greeting_fires_once_without_output_modalities():
     ws = _FakeWS()
     state = _BridgeState()

--- a/uv.lock
+++ b/uv.lock
@@ -484,7 +484,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent-plugin"
-version = "0.2.8"
+version = "0.2.9"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Executive Summary

Prevents realtime voice calls from treating a nameless contact's phone number as their name.

- Keeps a missing contact name as `None` through call setup and realtime metadata.
- Retains the matched contact's profile and memory context.
- Ships the fix as plugin version `0.2.9`.

## Description

Realtime call metadata now models `contact_name` as optional and preserves a null name instead of replacing it with the remote number or contact ID. Session routing still receives a stable display label, but greeting and prompt logic only use an actual contact name.

Matched nameless contacts remain known contacts, so their email, phone, company, notes, and memories stay available. Realtime instructions explicitly require a neutral greeting and prohibit using the phone number as a name.

Package, manifest, and lockfile versions move together from `0.2.8` to `0.2.9`.

## Reason

A matched contact can legitimately have no known name. Substituting the phone number caused voice agents to address callers by their number even though the webhook correctly represented the name as unknown.

## Decisions

- **Name versus label:** Keep the real contact name separate from the session display label so routing remains stable without turning an identifier into a name.
- **Known nameless contacts:** Preserve `contact_known=True` because missing a name should not discard the contact's other trusted context.

## Testing

- Realtime inbound call with a matched nameless contact: Greets with "there", never uses the phone number as a name, and retains profile and memory context.
- `uv run pytest tests/test_contact_memories.py tests/test_realtime_bridge_parity.py -q`: 39 passed.
- `uv run pytest tests/test_registration.py tests/test_user_agent.py tests/test_setup_wizard.py -q`: 69 passed.
- `uv run pytest -q`: 499 passed, 25 skipped; one pre-existing diagnostics failure reproduced unchanged on `origin/main`.
- `uv run ruff check adapter.py realtime.py tests/test_contact_memories.py tests/test_realtime_bridge_parity.py`: Passed.