### PR TITLE
Add noninteractive Inkbox bootstrap

### DIFF
--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -151,7 +151,7 @@ jobs:
             DIGITS="${GITHUB_RUN_ID: -4}${GITHUB_RUN_ATTEMPT: -1}"
             HOSTED_MARKER="$("$PY" "$GITHUB_WORKSPACE/tests/live/voice_marker.py" "$DIGITS")"
             echo "HOSTED_POST_CALL_MARKER=$HOSTED_MARKER" >> "$GITHUB_ENV"
-            export VOICE_DRIVER_LINE="After we hang up, send me one SMS. Create the post-call action now with this exact SMS body: $HOSTED_MARKER. Read those five words back to me after the action is saved. Do not send it during the call."
+            export VOICE_DRIVER_LINE="After we hang up, send me one SMS. Create one post-call action now with the title Send SMS and put this exact five-word SMS body in the action details: $HOSTED_MARKER. Wait for the action tool to succeed, then read all five words back to me. Do not paraphrase, omit a word, or send the SMS during the call."
             # Pytest owns the early hangup after both the transcript and open
             # action gates pass. This is only the media peer's safety ceiling.
             export VOICE_DRIVER_LISTEN=180

--- a/README.md
+++ b/README.md
@@ -66,6 +66,33 @@ Keep that process running. On startup the plugin opens an Inkbox tunnel,
 configures mail/text/iMessage webhook subscriptions and incoming-call handling,
 and routes inbound email, SMS, iMessage, and calls into Hermes sessions.
 
+### Non-interactive bootstrap
+
+For an existing Inkbox identity, an automation harness can configure the plugin
+without stepping through the setup wizard. Pass the API key through standard
+input so it does not appear in the process list:
+
+```bash
+read -rsp "Inkbox API key: " INKBOX_BOOTSTRAP_KEY
+printf '%s' "$INKBOX_BOOTSTRAP_KEY" | hermes inkbox bootstrap \
+  --identity my-agent-handle \
+  --api-key-stdin \
+  --voice-ai \
+  --start-gateway
+unset INKBOX_BOOTSTRAP_KEY
+```
+
+The command validates that the key can access the requested identity, stores an
+agent-scoped key in the active Hermes profile, configures Inkbox Voice AI
+without widening its saved authority, creates the identity's signing key when
+one does not exist, and starts or restarts the gateway. It emits a JSON result
+and is safe to rerun.
+
+If the identity already has a signing key but this Hermes profile does not have
+its plaintext value, bootstrap stops with `requires_human`. Supply the existing
+key as `INKBOX_SIGNING_KEY`, or use `--rotate-signing-key` only when replacing
+the key is intentional.
+
 To update an existing install:
 
 ```bash

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,0 +1,372 @@
+"""Non-interactive Inkbox bootstrap for an existing Hermes identity."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+try:
+    from .config import INKBOX_BASE_URL_DEFAULT, VoiceStack, inkbox_client_kwargs
+    from .setup_wizard import _enum_value, _env, _load_inkbox_symbols, _save, _seed_identity_state
+except ImportError:  # pragma: no cover - direct local import/test fallback
+    from config import INKBOX_BASE_URL_DEFAULT, VoiceStack, inkbox_client_kwargs
+    from setup_wizard import _enum_value, _env, _load_inkbox_symbols, _save, _seed_identity_state
+
+
+def _normalize_handle(value: str) -> str:
+    return value.strip().removeprefix("@").strip()
+
+
+def _redact_error(exc: Exception, secrets: list[str]) -> str:
+    message = str(exc)
+    for secret in secrets:
+        if secret:
+            message = message.replace(secret, "[redacted]")
+    return message
+
+
+def _identity_for_agent_key(client: Any, expected_handle: str) -> Any:
+    identities = list(client.list_identities())
+    handles = {_normalize_handle(str(getattr(item, "agent_handle", ""))) for item in identities}
+    if expected_handle not in handles:
+        raise ValueError("The API key is not scoped to the requested identity.")
+    return client.get_identity(expected_handle)
+
+
+def _saved_agent_key(
+    *,
+    expected_handle: str,
+    base_url: str,
+    Inkbox: Any,
+    agent_subtype: str,
+) -> tuple[str, Any] | None:
+    saved_key = _env("INKBOX_API_KEY").strip()
+    saved_handle = _normalize_handle(_env("INKBOX_IDENTITY"))
+    if not saved_key or saved_handle != expected_handle:
+        return None
+    try:
+        client = Inkbox(**inkbox_client_kwargs(saved_key, base_url))
+        info = client.whoami()
+        if _enum_value(getattr(info, "auth_subtype", "")) != agent_subtype:
+            return None
+        return saved_key, _identity_for_agent_key(client, expected_handle)
+    except Exception:
+        return None
+
+
+def _resolve_credentials(
+    *,
+    api_key: str,
+    expected_handle: str,
+    base_url: str,
+    symbols: dict[str, Any],
+    actions: list[str],
+) -> tuple[str, Any]:
+    Inkbox = symbols["Inkbox"]
+    client = Inkbox(**inkbox_client_kwargs(api_key, base_url))
+    info = client.whoami()
+    if _enum_value(getattr(info, "auth_type", "")) != "api_key":
+        raise ValueError("Bootstrap requires an Inkbox API key.")
+
+    subtype = _enum_value(getattr(info, "auth_subtype", ""))
+    agent_subtype = _enum_value(symbols["AGENT_CLAIMED"])
+    admin_subtype = _enum_value(symbols["ADMIN_SCOPED"])
+
+    if subtype == agent_subtype:
+        return api_key, _identity_for_agent_key(client, expected_handle)
+
+    if subtype == _enum_value(symbols["AGENT_UNCLAIMED"]):
+        raise ValueError("The API key is not attached to a claimed identity yet.")
+
+    if subtype != admin_subtype:
+        raise ValueError("Use an agent-scoped or admin-scoped Inkbox API key.")
+
+    saved = _saved_agent_key(
+        expected_handle=expected_handle,
+        base_url=base_url,
+        Inkbox=Inkbox,
+        agent_subtype=agent_subtype,
+    )
+    if saved is not None:
+        actions.append("reused_saved_agent_key")
+        return saved
+
+    identity = client.get_identity(expected_handle)
+    created = client.api_keys.create(
+        label=f"Hermes gateway - {expected_handle}",
+        description="Agent-scoped key created by the Hermes Inkbox bootstrap.",
+        scoped_identity_id=identity.id,
+    )
+    agent_key = str(getattr(created, "api_key", "") or "")
+    if not agent_key:
+        raise RuntimeError("Inkbox did not return the new agent-scoped API key.")
+    actions.append("minted_agent_scoped_key")
+    return agent_key, Inkbox(**inkbox_client_kwargs(agent_key, base_url)).get_identity(expected_handle)
+
+
+def _default_voice_ai_instructions(identity: Any, client: Any) -> str:
+    handle = _normalize_handle(str(getattr(identity, "agent_handle", "")))
+    mailbox = getattr(identity, "mailbox", None)
+    email = getattr(identity, "email_address", None) or getattr(mailbox, "email_address", None)
+    phone = getattr(getattr(identity, "phone_number", None), "number", None)
+    tunnel = getattr(getattr(identity, "tunnel", None), "public_host", None)
+    imessage_number = getattr(getattr(identity, "imessage_number", None), "number", None)
+
+    channels = []
+    if email:
+        channels.append(f"Email: {email}.")
+    if phone:
+        channels.append(f"VoIP phone: {phone}.")
+    if tunnel:
+        channels.append(f"Public address: https://{tunnel}.")
+    if imessage_number:
+        channels.append(f"Dedicated iMessage line: {imessage_number}.")
+    elif bool(getattr(identity, "imessage_enabled", False)):
+        try:
+            triage = client.imessages.get_triage_number()
+            command = str(getattr(triage, "connect_command", "") or f"connect @{handle}")
+            number = str(getattr(triage, "number", "") or "")
+            if number:
+                channels.append(f"Shared iMessage: text '{command}' to {number}.")
+        except Exception:
+            channels.append("Shared iMessage is enabled; use the current Inkbox connection instructions.")
+
+    channel_text = " ".join(channels) or "No direct communication channel is currently configured."
+    return (
+        f"You are the hosted voice interface for Inkbox agent @{handle}. "
+        "Help the caller understand how to connect with this agent and accurately repeat only the "
+        f"configured channels below. {channel_text}"
+    )
+
+
+def _configure_voice_ai(identity: Any, client: Any, instructions: str | None) -> None:
+    hosted = identity.get_hosted_agent_config()
+    existing_instructions = getattr(hosted, "instructions", None)
+    desired_instructions = (
+        instructions
+        if instructions is not None
+        else existing_instructions or _default_voice_ai_instructions(identity, client)
+    )
+    if len(desired_instructions) > 8000:
+        raise ValueError("Voice AI instructions must be 8,000 characters or fewer.")
+
+    if getattr(hosted, "instructions", None) != desired_instructions:
+        identity.set_hosted_agent_config(
+            voice=getattr(hosted, "voice", None),
+            model=getattr(hosted, "model", None),
+            instructions=desired_instructions,
+        )
+
+    incoming = identity.get_incoming_call_action()
+    if (
+        _enum_value(getattr(incoming, "incoming_call_action", "")) != "hosted_agent"
+        or getattr(incoming, "client_websocket_url", None) is not None
+        or getattr(incoming, "incoming_call_webhook_url", None) is not None
+    ):
+        identity.set_incoming_call_action(
+            incoming_call_action="hosted_agent",
+            client_websocket_url=None,
+            incoming_call_webhook_url=None,
+        )
+
+    _save("INKBOX_VOICE_STACK", VoiceStack.INKBOX_VOICE_AI.value)
+    _save("INKBOX_VOICE_AI_AUTHORITY_MODE", _enum_value(getattr(hosted, "authority_mode", "contact_scoped")))
+    _save("INKBOX_REALTIME_ENABLED", "false")
+
+
+def _configure_signing_key(
+    identity: Any,
+    *,
+    rotate: bool,
+    local_key_matches_identity: bool,
+    actions: list[str],
+) -> str | None:
+    local_key = _env("INKBOX_SIGNING_KEY").strip()
+    status = identity.get_signing_key_status()
+    configured = bool(getattr(status, "configured", False))
+    if local_key and local_key_matches_identity and configured and not rotate:
+        _save("INKBOX_REQUIRE_SIGNATURE", "true")
+        actions.append("reused_local_signing_key")
+        return None
+
+    if configured and not rotate:
+        return (
+            "A signing key already exists for this identity, but it is not available in this Hermes profile. "
+            "Set INKBOX_SIGNING_KEY and rerun, or explicitly allow rotation with --rotate-signing-key."
+        )
+
+    created = identity.create_signing_key()
+    signing_key = str(getattr(created, "signing_key", "") or "")
+    if not signing_key:
+        raise RuntimeError("Inkbox did not return the new signing key.")
+    _save("INKBOX_SIGNING_KEY", signing_key)
+    _save("INKBOX_REQUIRE_SIGNATURE", "true")
+    actions.append("rotated_signing_key" if configured else "created_signing_key")
+    return None
+
+
+def _gateway_command() -> list[str]:
+    executable = shutil.which("hermes")
+    return [executable] if executable else [sys.executable, "-m", "hermes_cli.main"]
+
+
+def _gateway_state() -> tuple[bool, bool]:
+    try:
+        from hermes_cli.gateway import get_gateway_runtime_snapshot
+
+        snapshot = get_gateway_runtime_snapshot()
+        return bool(snapshot.running), bool(snapshot.service_installed)
+    except Exception:
+        return False, False
+
+
+def _wait_for_gateway(timeout: float = 20.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if _gateway_state()[0]:
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def _start_gateway(actions: list[str]) -> bool:
+    running, service_installed = _gateway_state()
+    command = _gateway_command()
+    if running:
+        result = subprocess.run(
+            [*command, "gateway", "restart"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=180,
+            check=False,
+        )
+        if result.returncode != 0:
+            return False
+        actions.append("restarted_gateway")
+        return _wait_for_gateway()
+
+    if service_installed:
+        result = subprocess.run(
+            [*command, "gateway", "start"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=180,
+            check=False,
+        )
+        if result.returncode != 0:
+            return False
+        actions.append("started_gateway_service")
+        return _wait_for_gateway()
+
+    try:
+        from hermes_cli.config import get_hermes_home
+
+        log_path = Path(get_hermes_home()) / "inkbox-bootstrap-gateway.log"
+    except Exception:
+        log_path = Path.home() / ".hermes" / "inkbox-bootstrap-gateway.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("ab") as log_file:
+        subprocess.Popen(
+            [*command, "gateway", "run"],
+            stdin=subprocess.DEVNULL,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+    actions.append("started_gateway_process")
+    return _wait_for_gateway()
+
+
+def bootstrap(
+    *,
+    identity_handle: str,
+    api_key: str,
+    base_url: str = INKBOX_BASE_URL_DEFAULT,
+    voice_ai: bool = False,
+    voice_ai_instructions: str | None = None,
+    rotate_signing_key: bool = False,
+    start_gateway: bool = False,
+) -> dict[str, Any]:
+    """Configure an existing Inkbox identity without interactive prompts."""
+    handle = _normalize_handle(identity_handle)
+    if not handle:
+        return {"status": "error", "error": "identity is required"}
+    if not api_key.strip():
+        return {"status": "error", "error": "API key is required"}
+
+    actions: list[str] = []
+    secrets = [api_key.strip()]
+    try:
+        previous_handle = _normalize_handle(_env("INKBOX_IDENTITY"))
+        symbols = _load_inkbox_symbols()
+        agent_key, identity = _resolve_credentials(
+            api_key=api_key.strip(),
+            expected_handle=handle,
+            base_url=base_url,
+            symbols=symbols,
+            actions=actions,
+        )
+        secrets.append(agent_key)
+        client = symbols["Inkbox"](**inkbox_client_kwargs(agent_key, base_url))
+
+        _save("INKBOX_API_KEY", agent_key)
+        _save("INKBOX_IDENTITY", handle)
+        if base_url:
+            _save("INKBOX_BASE_URL", base_url)
+        _save("INKBOX_ALLOW_ALL_USERS", "true")
+        actions.append("saved_hermes_configuration")
+
+        if voice_ai:
+            _configure_voice_ai(identity, client, voice_ai_instructions)
+            actions.append("configured_voice_ai")
+
+        signing_blocker = _configure_signing_key(
+            identity,
+            rotate=rotate_signing_key,
+            local_key_matches_identity=not previous_handle or previous_handle == handle,
+            actions=actions,
+        )
+        _seed_identity_state(identity)
+
+        if signing_blocker:
+            return {
+                "status": "requires_human",
+                "identity": handle,
+                "actions": actions,
+                "human_actions": [signing_blocker],
+                "next_commands": ["hermes inkbox bootstrap --identity <handle> --start-gateway"],
+            }
+
+        gateway_running = False
+        if start_gateway:
+            gateway_running = _start_gateway(actions)
+            if not gateway_running:
+                return {
+                    "status": "error",
+                    "identity": handle,
+                    "actions": actions,
+                    "error": "Hermes gateway did not become ready. Check inkbox-bootstrap-gateway.log.",
+                }
+
+        return {
+            "status": "configured",
+            "identity": handle,
+            "actions": actions,
+            "gateway_running": gateway_running,
+            "next_commands": [] if gateway_running else ["hermes inkbox doctor", "hermes gateway run"],
+        }
+    except Exception as exc:
+        return {
+            "status": "error",
+            "identity": handle,
+            "actions": actions,
+            "error": _redact_error(exc, secrets),
+        }

--- a/cli.py
+++ b/cli.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import json
+import os
+import sys
 
 try:
+    from .bootstrap import bootstrap
     from .doctor import run_doctor
     from .setup_wizard import interactive_setup
     from .tools import inkbox_whoami
 except ImportError:  # pragma: no cover - direct local import/test fallback
+    from bootstrap import bootstrap
     from doctor import run_doctor
     from setup_wizard import interactive_setup
     from tools import inkbox_whoami
@@ -17,6 +21,36 @@ except ImportError:  # pragma: no cover - direct local import/test fallback
 def setup_argparse(subparser) -> None:
     subs = subparser.add_subparsers(dest="inkbox_command")
     subs.add_parser("setup", help="Run the Inkbox setup wizard")
+    bootstrap_parser = subs.add_parser(
+        "bootstrap",
+        help="Configure an existing Inkbox identity without interactive prompts",
+    )
+    bootstrap_parser.add_argument("--identity", required=True, help="Existing Inkbox identity handle")
+    bootstrap_parser.add_argument(
+        "--api-key-stdin",
+        action="store_true",
+        help="Read the API key from standard input instead of INKBOX_API_KEY",
+    )
+    bootstrap_parser.add_argument("--base-url", default="", help="Optional Inkbox API base URL")
+    bootstrap_parser.add_argument(
+        "--voice-ai",
+        action="store_true",
+        help="Use Inkbox Voice AI for incoming calls",
+    )
+    bootstrap_parser.add_argument(
+        "--voice-ai-instructions-file",
+        help="Optional UTF-8 file containing Voice AI instructions",
+    )
+    bootstrap_parser.add_argument(
+        "--rotate-signing-key",
+        action="store_true",
+        help="Rotate an existing identity signing key when it is unavailable locally",
+    )
+    bootstrap_parser.add_argument(
+        "--start-gateway",
+        action="store_true",
+        help="Start or restart the Hermes gateway after configuration",
+    )
     subs.add_parser("doctor", help="Run Inkbox readiness checks")
     subs.add_parser("whoami", help="Show the configured Inkbox identity")
     subparser.set_defaults(func=handle_cli)
@@ -27,13 +61,32 @@ def handle_cli(args) -> None:
     if command == "setup":
         interactive_setup()
         return
+    if command == "bootstrap":
+        api_key = sys.stdin.read().strip() if args.api_key_stdin else os.getenv("INKBOX_API_KEY", "").strip()
+        instructions = None
+        if args.voice_ai_instructions_file:
+            with open(args.voice_ai_instructions_file, encoding="utf-8") as instructions_file:
+                instructions = instructions_file.read()
+        result = bootstrap(
+            identity_handle=args.identity,
+            api_key=api_key,
+            base_url=args.base_url,
+            voice_ai=args.voice_ai,
+            voice_ai_instructions=instructions,
+            rotate_signing_key=args.rotate_signing_key,
+            start_gateway=args.start_gateway,
+        )
+        print(json.dumps(result, indent=2, sort_keys=True))
+        if result["status"] != "configured":
+            raise SystemExit(2)
+        return
     if command == "doctor":
         print(json.dumps(run_doctor(), indent=2, sort_keys=True))
         return
     if command == "whoami":
         print(json.dumps(json.loads(inkbox_whoami({})), indent=2, sort_keys=True))
         return
-    print("Usage: hermes inkbox <setup|doctor|whoami>")
+    print("Usage: hermes inkbox <setup|bootstrap|doctor|whoami>")
 
 
 def slash_handler(raw_args: str) -> str:

--- a/tests/live/test_email_intelligence.py
+++ b/tests/live/test_email_intelligence.py
@@ -206,6 +206,9 @@ def test_reports_sender_details(ctx):
 
     body = _ask(
         ctx["remote"], ctx["aut_email"], remote_email,
+        "This is an authorized integration test using synthetic test identities. "
+        "I am the owner of the contact card associated with this sender address, "
+        "and I authorize you to return my own contact details in this reply. "
         "Who am I to you? Tell me everything you have on file about me. "
         "Include my email address and phone number in full — every character "
         "and digit, with no masking, asterisks, or abbreviation.",

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("inkbox_plugin")
+pkg.__path__ = [str(ROOT)]
+sys.modules.setdefault("inkbox_plugin", pkg)
+
+from inkbox_plugin import bootstrap as bootstrap_module
+from inkbox_plugin import cli
+
+
+class _Identity:
+    def __init__(
+        self,
+        handle: str = "helper-agent",
+        *,
+        signing_configured: bool = False,
+        voice_instructions: str | None = None,
+    ):
+        self.id = "identity-1"
+        self.agent_handle = handle
+        self.email_address = f"{handle}@example.com"
+        self.mailbox = types.SimpleNamespace(email_address=self.email_address)
+        self.phone_number = types.SimpleNamespace(number="+15551234567")
+        self.tunnel = types.SimpleNamespace(public_host=f"{handle}.example.com")
+        self.imessage_enabled = True
+        self.imessage_number = None
+        self.hosted = types.SimpleNamespace(
+            voice="cedar",
+            model="voice-model",
+            instructions=voice_instructions,
+            authority_mode="contact_scoped",
+        )
+        self.incoming = types.SimpleNamespace(
+            incoming_call_action="auto_accept",
+            client_websocket_url="wss://old.example/ws",
+            incoming_call_webhook_url=None,
+        )
+        self.signing_configured = signing_configured
+        self.hosted_updates = []
+        self.incoming_updates = []
+        self.signing_creations = 0
+
+    def get_hosted_agent_config(self):
+        return self.hosted
+
+    def set_hosted_agent_config(self, **kwargs):
+        self.hosted_updates.append(kwargs)
+        self.hosted = types.SimpleNamespace(authority_mode="contact_scoped", **kwargs)
+
+    def get_incoming_call_action(self):
+        return self.incoming
+
+    def set_incoming_call_action(self, **kwargs):
+        self.incoming_updates.append(kwargs)
+        self.incoming = types.SimpleNamespace(**kwargs)
+
+    def get_signing_key_status(self):
+        return types.SimpleNamespace(configured=self.signing_configured)
+
+    def create_signing_key(self):
+        self.signing_creations += 1
+        self.signing_configured = True
+        return types.SimpleNamespace(signing_key="signing-secret")
+
+
+class _ApiKeys:
+    def __init__(self, owner):
+        self.owner = owner
+
+    def create(self, **kwargs):
+        self.owner.minted.append(kwargs)
+        return types.SimpleNamespace(api_key="agent-secret")
+
+
+class _Client:
+    def __init__(self, key: str, identity: _Identity):
+        self.key = key
+        self.identity = identity
+        self.minted = []
+        self.api_keys = _ApiKeys(self)
+        self.imessages = types.SimpleNamespace(
+            get_triage_number=lambda: types.SimpleNamespace(
+                number="+15550001111",
+                connect_command=f"connect @{identity.agent_handle}",
+            ),
+        )
+
+    def whoami(self):
+        subtype = "api_key.admin_scoped" if self.key == "admin-secret" else "api_key.agent_scoped.claimed"
+        return types.SimpleNamespace(auth_type="api_key", auth_subtype=subtype)
+
+    def list_identities(self):
+        return [types.SimpleNamespace(agent_handle=self.identity.agent_handle)]
+
+    def get_identity(self, handle):
+        if handle != self.identity.agent_handle:
+            raise RuntimeError("not found")
+        return self.identity
+
+
+def _install_fakes(monkeypatch, identity: _Identity):
+    clients = {}
+    saved = {}
+
+    class FakeInkbox:
+        def __new__(cls, *, api_key, **_kwargs):
+            client = clients.setdefault(api_key, _Client(api_key, identity))
+            return client
+
+    monkeypatch.setattr(
+        bootstrap_module,
+        "_load_inkbox_symbols",
+        lambda: {
+            "Inkbox": FakeInkbox,
+            "ADMIN_SCOPED": "api_key.admin_scoped",
+            "AGENT_CLAIMED": "api_key.agent_scoped.claimed",
+            "AGENT_UNCLAIMED": "api_key.agent_scoped.unclaimed",
+        },
+    )
+    monkeypatch.setattr(bootstrap_module, "_save", lambda name, value: saved.__setitem__(name, value))
+    monkeypatch.setattr(bootstrap_module, "_env", lambda name: saved.get(name, ""))
+    monkeypatch.setattr(bootstrap_module, "_seed_identity_state", lambda _identity: None)
+    return clients, saved
+
+
+def test_bootstrap_mints_scoped_key_configures_voice_and_is_resumable(monkeypatch):
+    identity = _Identity()
+    clients, saved = _install_fakes(monkeypatch, identity)
+
+    first = bootstrap_module.bootstrap(
+        identity_handle="@helper-agent",
+        api_key="admin-secret",
+        voice_ai=True,
+    )
+
+    assert first["status"] == "configured"
+    assert first["gateway_running"] is False
+    assert clients["admin-secret"].minted[0]["scoped_identity_id"] == "identity-1"
+    assert saved["INKBOX_API_KEY"] == "agent-secret"
+    assert saved["INKBOX_IDENTITY"] == "helper-agent"
+    assert saved["INKBOX_SIGNING_KEY"] == "signing-secret"
+    assert saved["INKBOX_VOICE_STACK"] == "inkbox_voice_ai"
+    assert "Shared iMessage: text 'connect @helper-agent' to +15550001111." in identity.hosted_updates[0]["instructions"]
+    assert identity.incoming_updates == [
+        {
+            "incoming_call_action": "hosted_agent",
+            "client_websocket_url": None,
+            "incoming_call_webhook_url": None,
+        }
+    ]
+
+    second = bootstrap_module.bootstrap(
+        identity_handle="helper-agent",
+        api_key="admin-secret",
+        voice_ai=True,
+    )
+
+    assert second["status"] == "configured"
+    assert "reused_saved_agent_key" in second["actions"]
+    assert len(clients["admin-secret"].minted) == 1
+    assert identity.signing_creations == 1
+    assert len(identity.hosted_updates) == 1
+    assert len(identity.incoming_updates) == 1
+
+
+def test_bootstrap_requires_explicit_rotation_when_remote_key_is_not_local(monkeypatch):
+    identity = _Identity(signing_configured=True)
+    _install_fakes(monkeypatch, identity)
+
+    result = bootstrap_module.bootstrap(
+        identity_handle="helper-agent",
+        api_key="agent-secret",
+    )
+
+    assert result["status"] == "requires_human"
+    assert "--rotate-signing-key" in result["human_actions"][0]
+    assert identity.signing_creations == 0
+
+
+def test_bootstrap_does_not_reuse_another_identitys_local_signing_key(monkeypatch):
+    identity = _Identity(signing_configured=True)
+    _clients, saved = _install_fakes(monkeypatch, identity)
+    saved.update(
+        {
+            "INKBOX_IDENTITY": "previous-agent",
+            "INKBOX_SIGNING_KEY": "previous-signing-secret",
+        }
+    )
+
+    result = bootstrap_module.bootstrap(
+        identity_handle="helper-agent",
+        api_key="agent-secret",
+    )
+
+    assert result["status"] == "requires_human"
+    assert "reused_local_signing_key" not in result["actions"]
+    assert identity.signing_creations == 0
+
+
+def test_bootstrap_preserves_existing_voice_instructions(monkeypatch):
+    identity = _Identity(voice_instructions="Keep these operator instructions.")
+    _install_fakes(monkeypatch, identity)
+
+    result = bootstrap_module.bootstrap(
+        identity_handle="helper-agent",
+        api_key="agent-secret",
+        voice_ai=True,
+    )
+
+    assert result["status"] == "configured"
+    assert identity.hosted_updates == []
+
+
+def test_bootstrap_rotates_only_when_explicitly_requested(monkeypatch):
+    identity = _Identity(signing_configured=True)
+    _install_fakes(monkeypatch, identity)
+
+    result = bootstrap_module.bootstrap(
+        identity_handle="helper-agent",
+        api_key="agent-secret",
+        rotate_signing_key=True,
+    )
+
+    assert result["status"] == "configured"
+    assert "rotated_signing_key" in result["actions"]
+    assert identity.signing_creations == 1
+
+
+def test_bootstrap_rejects_agent_key_for_another_identity(monkeypatch):
+    identity = _Identity(handle="different-agent")
+    _install_fakes(monkeypatch, identity)
+
+    result = bootstrap_module.bootstrap(
+        identity_handle="helper-agent",
+        api_key="agent-secret",
+    )
+
+    assert result["status"] == "error"
+    assert result["error"] == "The API key is not scoped to the requested identity."
+
+
+def test_bootstrap_redacts_credentials_from_errors(monkeypatch):
+    monkeypatch.setattr(
+        bootstrap_module,
+        "_load_inkbox_symbols",
+        lambda: (_ for _ in ()).throw(RuntimeError("failed while using top-secret")),
+    )
+
+    result = bootstrap_module.bootstrap(
+        identity_handle="helper-agent",
+        api_key="top-secret",
+    )
+
+    assert result["status"] == "error"
+    assert result["error"] == "failed while using [redacted]"
+
+
+def test_cli_reads_bootstrap_key_from_stdin_and_never_prints_it(monkeypatch, capsys):
+    parser = argparse.ArgumentParser()
+    subparser = parser.add_subparsers(dest="command").add_parser("inkbox")
+    cli.setup_argparse(subparser)
+    args = parser.parse_args(
+        [
+            "inkbox",
+            "bootstrap",
+            "--identity",
+            "helper-agent",
+            "--api-key-stdin",
+            "--voice-ai",
+        ]
+    )
+    monkeypatch.setattr(cli.sys, "stdin", types.SimpleNamespace(read=lambda: "top-secret\n"))
+    received = {}
+
+    def fake_bootstrap(**kwargs):
+        received.update(kwargs)
+        return {"status": "configured", "identity": "helper-agent"}
+
+    monkeypatch.setattr(cli, "bootstrap", fake_bootstrap)
+    args.func(args)
+
+    output = capsys.readouterr().out
+    assert json.loads(output)["status"] == "configured"
+    assert received["api_key"] == "top-secret"
+    assert "top-secret" not in output
+
+
+def test_cli_exits_nonzero_for_incomplete_bootstrap(monkeypatch, capsys):
+    args = types.SimpleNamespace(
+        inkbox_command="bootstrap",
+        api_key_stdin=False,
+        identity="helper-agent",
+        base_url="",
+        voice_ai=False,
+        voice_ai_instructions_file=None,
+        rotate_signing_key=False,
+        start_gateway=False,
+    )
+    monkeypatch.setenv("INKBOX_API_KEY", "top-secret")
+    monkeypatch.setattr(cli, "bootstrap", lambda **_kwargs: {"status": "requires_human"})
+
+    with pytest.raises(SystemExit) as exc:
+        cli.handle_cli(args)
+
+    assert exc.value.code == 2
+    assert "top-secret" not in capsys.readouterr().out

--- a/tests/test_voice_marker.py
+++ b/tests/test_voice_marker.py
@@ -67,9 +67,10 @@ def test_hosted_voice_workflow_keeps_peer_alive_for_test_owned_hangup():
     assert 'DIGITS="${GITHUB_RUN_ID: -4}${GITHUB_RUN_ATTEMPT: -1}"' in workflow
     assert (
         'export VOICE_DRIVER_LINE="After we hang up, send me one SMS. '
-        'Create the post-call action now with this exact SMS body: $HOSTED_MARKER. '
-        'Read those five words back to me after the action is saved. '
-        'Do not send it during the call."'
+        'Create one post-call action now with the title Send SMS and put this exact '
+        'five-word SMS body in the action details: $HOSTED_MARKER. Wait for the action '
+        'tool to succeed, then read all five words back to me. Do not paraphrase, omit '
+        'a word, or send the SMS during the call."'
         in workflow
     )
     assert "export VOICE_DRIVER_LISTEN=180" in workflow


### PR DESCRIPTION
## Executive Summary

Adds a resumable, non-interactive bootstrap command for connecting an existing Inkbox identity to Hermes.

- Validates the requested identity and persists only an agent-scoped API key.
- Configures hosted Voice AI, explicit signing-key replacement, and gateway startup.
- Emits structured JSON so an agent can complete setup or surface one specific human action.

## Description

`hermes inkbox bootstrap` accepts API-key input through standard input or `INKBOX_API_KEY`, validates the exact identity, scopes admin credentials down to the selected agent, persists the Hermes profile, configures optional hosted Voice AI and signing, and starts or restarts the gateway when requested.

The bootstrap is idempotent across reruns, preserves existing Voice AI instructions and authority, writes default connection guidance only when instructions are empty, seeds local identity state, redacts credentials from errors, and supports a detached gateway fallback when no service manager is available.

## Reason

An agent receiving an assigned Inkbox identity should be able to install and configure the official integration end to end without stepping through the interactive setup wizard.

## Decisions

- **Credential transport:** API keys are accepted through standard input or the environment so they do not need to appear in process arguments.
- **Least authority:** An admin key may select the requested identity and mint an agent-scoped key, but only the scoped key is persisted.
- **Signing-key safety:** Bootstrap creates a key when none exists, preserves a matching local key, and returns `requires_human` instead of replacing an unavailable existing key unless `--rotate-signing-key` is explicit.
- **Gateway lifetime:** `--start-gateway` starts or restarts an installed Hermes service when present; otherwise it starts a detached gateway for the current host or container lifetime.

## Testing

- `uv run pytest -q`: 509 passed and 25 live-only tests skipped.
- `ruff check .` and `ruff format --check bootstrap.py cli.py tests/test_bootstrap.py`: passed.
- PR CI: Python 3.11 unit, Python 3.12 unit, and current-host contract checks passed.
- Clean-container acceptance: Hermes followed the assigned bootstrap prompt, installed the integration, completed bootstrap, passed `hermes inkbox doctor` with zero findings, sent its introduction email, and returned the requested exact token through an external Inkbox A2A interaction.
