### PR TITLE
Bump plugin version to 0.2.10

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: inkbox
 label: Inkbox
 kind: platform
-version: 0.2.9
+version: 0.2.10
 description: Inkbox email, SMS/MMS, iMessage, voice, and A2A platform plugin for Hermes Agent.
 author: Inkbox
 requires_env: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hermes-agent-plugin"
-version = "0.2.9"
+version = "0.2.10"
 description = "Inkbox platform plugin for Hermes Agent"
 # inkbox>=0.4.7 requires Python 3.11+, so we can't claim 3.10 support.
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -484,7 +484,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent-plugin"
-version = "0.2.9"
+version = "0.2.10"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Executive Summary

Bumps the Hermes integration from 0.2.9 to 0.2.10 for the next patch release.

## Description

Updates the package metadata, plugin manifest, and lockfile so every published Hermes version surface reports 0.2.10.

## Reason

The recently merged non-interactive bootstrap capability needs a new patch version for distribution and runtime identification.

## Decisions

- **Patch release:** This is a metadata-only 0.0.1 increment.
- **Version consistency:** The package, plugin manifest, and lockfile remain synchronized.

## Testing

- `.venv/bin/ruff check .`: passed.
- `.venv/bin/python -m pytest -q`: 509 passed and 25 live-only tests skipped.