### PR TITLE
Surface verified x-inkbox-* headers on the A2A turn context

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -932,6 +932,32 @@ def _matched_webhook_contact(
     return None
 
 
+#: Inbound headers surfaced to plugins on the A2A turn context. Only the
+#: ``x-inkbox-`` namespace is kept, and the signature header is dropped: it has
+#: already done its job by the time the context is written, and there is no
+#: reason to keep it on disk.
+A2A_CONTEXT_HEADER_PREFIX = "x-inkbox-"
+A2A_CONTEXT_HEADER_EXCLUDE = frozenset({"x-inkbox-signature", "x-inkbox-timestamp"})
+
+
+def _a2a_context_headers(headers: Any) -> Dict[str, str]:
+    """Return the ``x-inkbox-*`` request headers worth carrying into a turn.
+
+    Callers pass headers only once a registered provider has verified the
+    request, so anything returned here is as trustworthy as the payload it
+    arrived with.
+    """
+    selected: Dict[str, str] = {}
+    for name, value in dict(headers or {}).items():
+        lowered = str(name).lower()
+        if not lowered.startswith(A2A_CONTEXT_HEADER_PREFIX):
+            continue
+        if lowered in A2A_CONTEXT_HEADER_EXCLUDE:
+            continue
+        selected[lowered] = str(value)
+    return selected
+
+
 def _split_routing_context(text: str) -> tuple[str, str, str]:
     marker, body = text.split("\n", 1) if "\n" in text else ("[inkbox:sms]", text)
     opening = "[inkbox:contact_memories]\n"
@@ -3606,7 +3632,12 @@ class InkboxAdapter(BasePlatformAdapter):
                 elif event_type and event_type.startswith("text."):
                     response = await self._on_text_lifecycle(envelope)
                 elif event_type and event_type.startswith("a2a."):
-                    response = await self._on_a2a_event(envelope)
+                    response = await self._on_a2a_event(
+                        envelope,
+                        headers=_a2a_context_headers(request.headers)
+                        if source is not None
+                        else None,
+                    )
                 elif event_type == "imessage.received":
                     response = await self._on_imessage_received(envelope)
                 elif event_type == "imessage.reaction_received":
@@ -4315,6 +4346,7 @@ class InkboxAdapter(BasePlatformAdapter):
         task_id: str,
         context_id: str,
         message_id: str,
+        headers: Optional[Dict[str, str]] = None,
     ) -> bool:
         """Bind verified webhook data to the host session used by tool calls."""
         handler_owner = getattr(
@@ -4338,6 +4370,7 @@ class InkboxAdapter(BasePlatformAdapter):
                     "context_id": context_id,
                     "message_id": message_id,
                     "reply_intent_committed": False,
+                    "headers": dict(headers or {}),
                 },
             )
             return True
@@ -4396,14 +4429,21 @@ class InkboxAdapter(BasePlatformAdapter):
         self._write_a2a_registry(key, data, "acknowledged")
         return True
 
-    async def _on_a2a_event(self, envelope: Dict[str, Any]) -> "web.Response":
+    async def _on_a2a_event(
+        self,
+        envelope: Dict[str, Any],
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "web.Response":
         """Serialize A2A admission so duplicate receipts cannot race."""
         async with self._a2a_ingest_lock:
-            return await self._on_a2a_event_locked(envelope)
+            return await self._on_a2a_event_locked(envelope, headers=headers)
 
     async def _on_a2a_event_locked(
         self,
         envelope: Dict[str, Any],
+        *,
+        headers: Optional[Dict[str, str]] = None,
     ) -> "web.Response":
         event_type = str(envelope.get("event_type") or "")
         data = envelope.get("data") if isinstance(envelope.get("data"), dict) else {}
@@ -4507,6 +4547,7 @@ class InkboxAdapter(BasePlatformAdapter):
                 task_id=task_id,
                 context_id=context_id,
                 message_id=message_id,
+                headers=headers,
             ):
                 self._write_a2a_registry(
                     key,

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: inkbox
 label: Inkbox
 kind: platform
-version: 0.2.10
+version: 0.2.11
 description: Inkbox email, SMS/MMS, iMessage, voice, and A2A platform plugin for Hermes Agent.
 author: Inkbox
 requires_env: []

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -913,3 +913,60 @@ def test_a2a_catch_up_skips_sdk_without_task_inbox(
     asyncio.run(adapter._catch_up_a2a_tasks())
 
     assert adapter._enqueued == []
+
+
+def test_a2a_turn_context_receives_verified_headers(tmp_path):
+    """Verified ``x-inkbox-*`` headers reach the turn-context binding."""
+    adapter = _adapter(tmp_path)
+    captured = {}
+
+    def _capture(*_args, **kwargs):
+        captured.update(kwargs)
+        return True
+
+    adapter._bind_a2a_turn_context = _capture
+
+    asyncio.run(
+        adapter._on_a2a_event(
+            _event(),
+            headers={"x-inkbox-example": "value-1", "x-inkbox-other": "value-2"},
+        )
+    )
+
+    assert captured["headers"] == {
+        "x-inkbox-example": "value-1",
+        "x-inkbox-other": "value-2",
+    }
+    assert captured["task_id"] == "task-1"
+
+
+def test_a2a_turn_context_headers_are_optional(tmp_path):
+    """A caller that passes no headers still binds, unchanged."""
+    adapter = _adapter(tmp_path)
+    captured = {}
+
+    def _capture(*_args, **kwargs):
+        captured.update(kwargs)
+        return True
+
+    adapter._bind_a2a_turn_context = _capture
+
+    response = asyncio.run(adapter._on_a2a_event(_event()))
+
+    assert response.text == "ok"
+    assert captured["headers"] is None
+
+
+def test_context_headers_filter_to_the_inkbox_namespace():
+    """Unrelated headers are dropped, and the signature is never retained."""
+    selected = adapter_mod._a2a_context_headers(
+        {
+            "Authorization": "Bearer secret",
+            "Cookie": "session=abc",
+            "X-Inkbox-Signature": "sig",
+            "X-Inkbox-Timestamp": "123",
+            "X-Inkbox-Example": "kept",
+        }
+    )
+
+    assert selected == {"x-inkbox-example": "kept"}


### PR DESCRIPTION
## Summary

An inbound A2A webhook's payload reaches the turn context, but its headers do
not. A plugin that needs to act on a header the sender attached currently has
no way to see one.

This carries the request headers through to the turn-context binding, filtered
to the `x-inkbox-` namespace.

## What changed

- `_a2a_context_headers()` selects the `x-inkbox-*` request headers, lowercasing
  names and dropping the signature and timestamp headers. Those have already
  done their job by the time the context is written, and there is no reason to
  keep them on disk.
- `_on_a2a_event()`, `_on_a2a_event_locked()`, and `_bind_a2a_turn_context()`
  take an optional keyword-only `headers` argument.
- The webhook handler passes headers only when a registered provider claimed the
  request, so anything recorded is as trustworthy as the payload it arrived with.
- The turn context gains a `headers` key.

## Compatibility

Additive. The new parameters are keyword-only with defaults, and the turn
context is a free-form mapping whose existing consumers read specific keys, so
an added key is inert. Installations that do not pass headers behave exactly as
before.

## Tests

`tests/test_a2a.py` covers headers reaching the binding, the argument being
optional, and the namespace filter dropping unrelated and signature headers.
Full suite: 511 passed, 26 skipped.