### PR TITLE
Add INKBOX_SKIP_WEBHOOK_RECONCILE for pre-provisioned subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ After the gateway starts:
 | `INKBOX_SIGNING_KEY` | inbound | - | Webhook HMAC secret. Required for signed inbound email, SMS, iMessage, and calls. |
 | `INKBOX_REQUIRE_SIGNATURE` | no | `true` | Refuse unsigned inbound Inkbox webhooks unless set to `false`. |
 | `INKBOX_EXTERNAL_EVENTS_ENABLED` | no | `false` | Gates whether **unverified/unknown** webhooks reach the agent: a source with no registered provider, or an Inkbox-signed payload with no matching handler. Off by default. **Verified registered third-party providers** (e.g. a configured GitHub secret via `INKBOX_WEBHOOK_SECRET_GITHUB`) are always delivered regardless of this flag; unverified sources are handed to the agent with a directive forbidding irreversible action. |
+| `INKBOX_SKIP_WEBHOOK_RECONCILE` | no | `false` | Leave webhook subscriptions untouched on connect. For deployments that provision them ahead of time, where the destination is fixed or the agent's key may not change it. The subscriptions must already point at this agent's webhook URL, or nothing will arrive. |
 | `INKBOX_BASE_URL` | no | SDK default | Override Inkbox API base URL. |
 | `INKBOX_PUBLIC_URL` | no | - | Public Hermes gateway URL. If omitted, the plugin opens an Inkbox tunnel. |
 | `INKBOX_TUNNEL_NAME` | no | identity handle | Override Inkbox tunnel name. |

--- a/adapter.py
+++ b/adapter.py
@@ -2002,6 +2002,11 @@ class InkboxAdapter(BasePlatformAdapter):
 
     MAX_MESSAGE_LENGTH = 4096  # email/voice are unbounded; SMS chunked separately in send()
 
+    #: Reconciling subscriptions on connect is the default. Declared here as
+    #: well as in __init__ so the safe behavior holds for instances built
+    #: without it.
+    _skip_webhook_reconcile: bool = False
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, _inkbox_platform())
         extra = config.extra or {}
@@ -2059,6 +2064,17 @@ class InkboxAdapter(BasePlatformAdapter):
         else:
             raw_require_signature = os.getenv("INKBOX_REQUIRE_SIGNATURE", "true")
         self._require_signature = str(raw_require_signature).lower() not in ("false", "0", "no")
+
+        # Whether this process installs its own webhook subscriptions on
+        # connect. Deployments that provision subscriptions ahead of time can
+        # set this, either because the destination is fixed or because the
+        # agent's API key is not permitted to change it. Same config-over-env
+        # precedence as above, so an explicit False is not coalesced away.
+        if "skip_webhook_reconcile" in extra:
+            raw_skip_reconcile = extra["skip_webhook_reconcile"]
+        else:
+            raw_skip_reconcile = os.getenv("INKBOX_SKIP_WEBHOOK_RECONCILE", "false")
+        self._skip_webhook_reconcile = str(raw_skip_reconcile).lower() in ("true", "1", "yes")
 
         # Whether non-Inkbox ("external") webhooks are passed through to the
         # agent at all.  These are signed by the source (Stripe/GitHub/...),
@@ -2491,6 +2507,14 @@ class InkboxAdapter(BasePlatformAdapter):
 
     def _patch_identity_objects(self) -> None:
         """Point every mailbox + phone number on the identity at this server."""
+        if self._skip_webhook_reconcile:
+            logger.info(
+                "[Inkbox] Leaving webhook subscriptions alone; expecting them "
+                "to already deliver to %s%s",
+                self._public_url, self._webhook_path,
+            )
+            return
+
         webhook_url = f"{self._public_url}{self._webhook_path}"
         ws_url = f"wss://{self._public_host}{self._ws_path}"
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: inkbox
 label: Inkbox
 kind: platform
-version: 0.2.11
+version: 0.2.12
 description: Inkbox email, SMS/MMS, iMessage, voice, and A2A platform plugin for Hermes Agent.
 author: Inkbox
 requires_env: []

--- a/tests/test_webhook_reconcile_flag.py
+++ b/tests/test_webhook_reconcile_flag.py
@@ -1,0 +1,80 @@
+"""
+tests/test_webhook_reconcile_flag.py
+
+By default the adapter installs its own webhook subscriptions on connect, so
+whatever URL it just came up on is the one that receives traffic.
+
+Some deployments provision those subscriptions ahead of time instead. There the
+destination is already fixed, and the agent's API key may not be permitted to
+change it, so writing on every connect is at best redundant and at worst the
+thing that stops the agent from starting. INKBOX_SKIP_WEBHOOK_RECONCILE turns
+that write off while leaving the rest of connect untouched.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from adapter import InkboxAdapter  # noqa: E402
+
+
+def _adapter(*, skip: bool):
+    """An adapter with only the state _patch_identity_objects reads."""
+    adapter = object.__new__(InkboxAdapter)
+    adapter._skip_webhook_reconcile = skip
+    adapter._public_url = "https://agent.example"
+    adapter._webhook_path = "/webhooks/inkbox"
+    adapter._public_host = "agent.example"
+    adapter._ws_path = "/ws"
+    adapter._identity_handle = "agent"
+
+    # Reaching the SDK means the skip did not take effect.
+    def _boom(*args, **kwargs):
+        raise AssertionError("reconcile touched the API despite the skip flag")
+
+    adapter._inkbox = type("_Inkbox", (), {"get_identity": staticmethod(_boom)})()
+    return adapter
+
+
+def _flag(raw: str | None) -> bool:
+    """Resolve the flag exactly as the constructor does."""
+    if raw is None:
+        os.environ.pop("INKBOX_SKIP_WEBHOOK_RECONCILE", None)
+    else:
+        os.environ["INKBOX_SKIP_WEBHOOK_RECONCILE"] = raw
+    value = os.getenv("INKBOX_SKIP_WEBHOOK_RECONCILE", "false")
+    return str(value).lower() in ("true", "1", "yes")
+
+
+def test_skipping_makes_no_api_calls() -> None:
+    """The whole point: connect proceeds without writing subscriptions."""
+    _adapter(skip=True)._patch_identity_objects()
+
+
+def test_not_skipping_still_reconciles() -> None:
+    """Default behavior is unchanged; the fixture asserts by exploding."""
+    with pytest.raises(AssertionError):
+        _adapter(skip=False)._patch_identity_objects()
+
+
+@pytest.mark.parametrize("raw", ["true", "True", "1", "yes", "YES"])
+def test_truthy_spellings_enable_the_skip(raw: str) -> None:
+    """Operators write this by hand, so accept the obvious spellings."""
+    assert _flag(raw) is True
+
+
+@pytest.mark.parametrize("raw", [None, "false", "False", "0", "no", ""])
+def test_everything_else_leaves_reconcile_on(raw: str | None) -> None:
+    """Unset or unrecognized must not silently disable subscription setup."""
+    assert _flag(raw) is False
+
+
+def teardown_module(module) -> None:
+    """Leave the environment as it was found."""
+    os.environ.pop("INKBOX_SKIP_WEBHOOK_RECONCILE", None)


### PR DESCRIPTION
On connect the adapter points the identity's mailboxes and phone numbers at whatever URL it just came up on, installing its own webhook subscriptions. That is the right default when the agent owns its ingress.

It is the wrong default when subscriptions are provisioned ahead of time. There the destination is already fixed, and the API key the agent runs with may not be permitted to change it — so the write is redundant at best, and at worst the reason the gateway never finishes connecting. The failure is not obvious from the outside: the platform registers, the reconcile raises, and `connect()` returns `False`, leaving a process that is up but receiving nothing.

## What changed

- `INKBOX_SKIP_WEBHOOK_RECONCILE`, default `false`. When set, `_patch_identity_objects` returns early and logs the URL it expects deliveries to already be pointed at.
- Config takes precedence over the environment (`skip_webhook_reconcile` in platform config), matching how `require_signature` resolves, so an explicit `False` in config is not coalesced into the env default.
- `_skip_webhook_reconcile` is also declared on the class. Several tests construct the adapter with `object.__new__` and no `__init__`; without the class attribute those raise `AttributeError` on connect. The declared default is the reconciling one, so a partially-constructed adapter fails safe.

## Behavior

Unchanged unless opted in. Unset, empty, or unrecognized values all leave reconciliation on — only `true`, `1`, and `yes` (case-insensitive) turn it off.

When enabled, the subscriptions must already deliver to this agent's webhook URL. If they do not, nothing arrives and the log line names the URL that was expected, which is the first thing to check.

## Testing

- `pytest tests/ --ignore=tests/live` — 540 passed, 1 skipped.
- New `tests/test_webhook_reconcile_flag.py`: skipping performs no API calls (the fixture raises if the SDK is touched), not skipping still reconciles, and the truthy/falsy spellings resolve as documented.

Version bumped to 0.2.12 and the environment table updated.