### PR TITLE
ci: run live suites with gpt-5.6-sol

### DIFF
--- a/.github/workflows/live-channels.yml
+++ b/.github/workflows/live-channels.yml
@@ -114,7 +114,7 @@ jobs:
             # OPENAI_API_KEY — no known-model alias, no OpenRouter aggregator.
             hermes config set model.provider custom || true
             hermes config set model.base_url https://api.openai.com/v1 || true
-            hermes config set model.default gpt-5.6-terra || true
+            hermes config set model.default gpt-5.6-sol || true
           else
             {
               echo "OPENAI_API_KEY=sk-mock-not-used"

--- a/.github/workflows/live-external-events.yml
+++ b/.github/workflows/live-external-events.yml
@@ -108,7 +108,7 @@ jobs:
           } >> "$HERMES_HOME/.env"
           hermes config set model.provider custom || true
           hermes config set model.base_url https://api.openai.com/v1 || true
-          hermes config set model.default gpt-5.6-terra || true
+          hermes config set model.default gpt-5.6-sol || true
 
       - name: Start gateway and wait for readiness
         run: |

--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -120,7 +120,7 @@ jobs:
           # the chat model; send it straight to OpenAI as-is.
           hermes config set model.provider custom || true
           hermes config set model.base_url https://api.openai.com/v1 || true
-          hermes config set model.default gpt-5.6-terra || true
+          hermes config set model.default gpt-5.6-sol || true
           if [ "${{ matrix.scenario }}" = "outbound_hosted" ]; then
             echo "INKBOX_VOICE_STACK=inkbox_voice_ai" >> "$HERMES_HOME/.env"
             echo "INKBOX_REALTIME_ENABLED=false" >> "$HERMES_HOME/.env"
@@ -130,6 +130,7 @@ jobs:
           else
             echo "INKBOX_VOICE_STACK=openai_realtime" >> "$HERMES_HOME/.env"
             echo "INKBOX_REALTIME_ENABLED=true" >> "$HERMES_HOME/.env"
+            echo "INKBOX_REALTIME_MODEL=gpt-realtime-2" >> "$HERMES_HOME/.env"
           fi
 
       - name: Start gateway and wait for readiness

--- a/tests/live/test_sms.py
+++ b/tests/live/test_sms.py
@@ -6,7 +6,7 @@ subject to carrier + spam filtering — so prompts ask for SHORT replies and avo
 spammy content.
 
   * mock leg → reachability (deterministic ``REPLY_OK`` from the mock model).
-  * real leg → intelligence (gpt-5.4): basic, own identity, sender, tools.
+  * real leg → intelligence (gpt-5.6-sol): basic, own identity, sender, tools.
 
 Skipped unless both keys are set. Replies are matched by *new* inbound message id
 from the AUT's number (robust to clock skew).


### PR DESCRIPTION
## Executive Summary

This PR moves real-model live CI to `gpt-5.6-sol`.

- Updates channel, external-event, and voice lanes.
- Keeps deterministic A2A and mock lanes unchanged.
- Explicitly pins realtime voice to `gpt-realtime-2`.

## Description

The real-model workflows now configure `gpt-5.6-sol` directly. The realtime voice scenario also writes the voice-model pin into the runtime environment, and the live SMS suite description now matches the configured model.

## Reason

Scheduled full-stack coverage should exercise the requested flagship model consistently across all real-model scenarios.

## Decisions

- **Model scope:** Left deterministic and mock lanes unchanged so their repeatability and cost profile remain intact.

## Testing

- Workflow configuration: Parsed every workflow YAML file successfully.
- Model configuration: Verified all three real-model workflows select `gpt-5.6-sol` and realtime voice selects `gpt-realtime-2`.
- Patch hygiene: `git diff --check` passed.