### PR TITLE
Add HD realtime voice and stabilize scheduled CI

### DIFF
--- a/.github/workflows/live-a2a.yml
+++ b/.github/workflows/live-a2a.yml
@@ -85,7 +85,7 @@ jobs:
             "$GITHUB_WORKSPACE/tests/ci/restrict_hermes_tools.py"
           "$HERMES_HOME/bin/uv" pip install \
             --python "$HERMES_HOME/hermes-agent/venv/bin/python3" \
-            'inkbox>=0.5.9,<1.0.0' 'aiohttp>=3.9' 'segno>=1.5'
+            'audioop-lts>=0.2.1; python_version >= "3.13"' 'inkbox>=0.5.9,<1.0.0' 'aiohttp>=3.9' 'segno>=1.5'
 
       - name: Configure the deterministic model and AUT identity
         env:

--- a/.github/workflows/live-channels.yml
+++ b/.github/workflows/live-channels.yml
@@ -78,7 +78,7 @@ jobs:
           "$HERMES_HOME/hermes-agent/venv/bin/python3" \
             "$GITHUB_WORKSPACE/tests/ci/restrict_hermes_tools.py"
           "$HERMES_HOME/bin/uv" pip install --python "$HERMES_HOME/hermes-agent/venv/bin/python3" \
-            'inkbox>=0.5.9,<1.0.0' \
+            'audioop-lts>=0.2.1; python_version >= "3.13"' 'inkbox>=0.5.9,<1.0.0' \
             'aiohttp>=3.9' 'segno>=1.5'
 
       - name: Configure AUT identity + model (${{ matrix.mode }})

--- a/.github/workflows/live-external-events.yml
+++ b/.github/workflows/live-external-events.yml
@@ -67,7 +67,7 @@ jobs:
           "$HERMES_HOME/hermes-agent/venv/bin/python3" \
             "$GITHUB_WORKSPACE/tests/ci/restrict_hermes_tools.py"
           "$HERMES_HOME/bin/uv" pip install --python "$HERMES_HOME/hermes-agent/venv/bin/python3" \
-            'inkbox>=0.5.9,<1.0.0' \
+            'audioop-lts>=0.2.1; python_version >= "3.13"' 'inkbox>=0.5.9,<1.0.0' \
             'aiohttp>=3.9' 'segno>=1.5'
 
       - name: Configure AUT identity + model

--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -159,8 +159,7 @@ jobs:
             # Pytest owns the early hangup after both the transcript and open
             # action gates pass. This is only the media peer's safety ceiling.
             export VOICE_DRIVER_LISTEN=180
-            export VOICE_DRIVER_REASK=30
-            export VOICE_DRIVER_NUDGE="Please verify the one queued SMS body is exactly: $HOSTED_MARKER. Correct the existing action if needed; do not create another action or send it yet."
+            export VOICE_DRIVER_REASK=0
           elif [ "${{ matrix.scenario }}" = "outbound_realtime_contact" ]; then
             # Must name the contact the test seeds (see test_voice.py LOOKUP_CONTACT_*).
             export VOICE_DRIVER_LINE="Hi! What email address do you have on file for your contact Olivia Parker? Please read the email out loud, then wait while I confirm I heard it."

--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -89,7 +89,7 @@ jobs:
           "$HERMES_HOME/hermes-agent/venv/bin/python3" \
             "$GITHUB_WORKSPACE/tests/ci/restrict_hermes_tools.py"
           "$HERMES_HOME/bin/uv" pip install --python "$HERMES_HOME/hermes-agent/venv/bin/python3" \
-            'inkbox>=0.5.9,<1.0.0' \
+            'audioop-lts>=0.2.1; python_version >= "3.13"' 'inkbox>=0.5.9,<1.0.0' \
             'aiohttp>=3.9' 'segno>=1.5' fastapi uvicorn
 
       - name: Configure AUT identity + model + speech path (${{ matrix.scenario }})
@@ -159,6 +159,8 @@ jobs:
             # Pytest owns the early hangup after both the transcript and open
             # action gates pass. This is only the media peer's safety ceiling.
             export VOICE_DRIVER_LISTEN=180
+            export VOICE_DRIVER_REASK=30
+            export VOICE_DRIVER_NUDGE="Please verify the one queued SMS body is exactly: $HOSTED_MARKER. Correct the existing action if needed; do not create another action or send it yet."
           elif [ "${{ matrix.scenario }}" = "outbound_realtime_contact" ]; then
             # Must name the contact the test seeds (see test_voice.py LOOKUP_CONTACT_*).
             export VOICE_DRIVER_LINE="Hi! What email address do you have on file for your contact Olivia Parker? Please read the email out loud, then wait while I confirm I heard it."

--- a/.github/workflows/scheduled-failure-report.yml
+++ b/.github/workflows/scheduled-failure-report.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   actions: read
+  contents: read
 
 jobs:
   report:
@@ -22,6 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Check out trusted reporting scripts
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
       - name: Post failure notification
         env:
           NOTIFICATION_URL: ${{ secrets.SCHEDULED_FAILURE_NOTIFICATION_URL }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v7
@@ -39,7 +39,7 @@ jobs:
         run: |
           uv venv --python ${{ matrix.python-version }}
           uv pip install \
-            'inkbox>=0.5.9,<1.0.0' \
+            'audioop-lts>=0.2.1; python_version >= "3.13"' 'inkbox>=0.5.9,<1.0.0' \
             'aiohttp>=3.9' 'segno>=1.5' 'pytest>=8' 'ruff>=0.11.0,<0.16'
 
       - name: Lint
@@ -74,7 +74,7 @@ jobs:
         run: |
           uv venv --python 3.12
           uv pip install \
-            'inkbox>=0.5.9,<1.0.0' \
+            'audioop-lts>=0.2.1; python_version >= "3.13"' 'inkbox>=0.5.9,<1.0.0' \
             'aiohttp>=3.9' 'segno>=1.5' 'pytest>=8' 'ruff>=0.11.0,<0.16'
           uv pip install --editable "$GITHUB_WORKSPACE/.upstream-hermes"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN /usr/local/bin/uv pip install \
         --python /opt/hermes/.venv/bin/python \
         "inkbox==0.5.9" \
         "aiohttp>=3.9" \
+        "audioop-lts>=0.2.1; python_version >= '3.13'" \
         "segno>=1.5"
 
 # Hermes's plugin installer expects a Git repository. Build one from the local

--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ Realtime calls receive the agent's Inkbox handle, mailbox, phone number, caller 
 
 When Realtime is enabled, the plugin preflights the OpenAI Realtime websocket before accepting the Inkbox call in raw-media mode. If that preflight fails, calls fall back to Inkbox STT/TTS by default. Set `INKBOX_REALTIME_FALLBACK_TO_INKBOX_STT_TTS=false` to fail the call instead.
 
+Realtime calls negotiate HD mono PCM16 audio at 16 kHz. The bridge resamples to and from the realtime session’s 24 kHz PCM format, with legacy 8 kHz call compatibility.
+
 ### Two calling lines
 
 Calls — inbound and outbound — can run over either of two lines, and the agent picks the one that matches the channel it's talking on:

--- a/adapter.py
+++ b/adapter.py
@@ -7877,6 +7877,7 @@ class InkboxAdapter(BasePlatformAdapter):
 
         async def _prepare_call_ws(*, use_realtime: bool) -> None:
             if use_realtime:
+                ws.headers["x-inkbox-audio-format"] = "pcm_s16le_16000"
                 ws.headers["x-use-inkbox-text-to-speech"] = "false"
                 ws.headers["x-use-inkbox-speech-to-text"] = "false"
             else:

--- a/adapter.py
+++ b/adapter.py
@@ -4307,6 +4307,9 @@ class InkboxAdapter(BasePlatformAdapter):
             "Call inkbox_send_sms exactly once with `to` set to the exact "
             f"authoritative remote number `{remote_phone}` and `text` set to "
             "the still-needed SMS body from the SMS-only context below.",
+            "If the caller supplied an exact message body in the action or "
+            "transcript, copy it verbatim. Do not replace it with an "
+            "acknowledgment, summary, or generic follow-up.",
             "Do not use conversationId, another recipient, or plain prose. "
             "Do not reply [SILENT] or skip the tool in this correction turn. "
             "Do not execute any non-SMS post-call action. Stop after the tool result.",
@@ -7548,6 +7551,21 @@ class InkboxAdapter(BasePlatformAdapter):
         call_id = str(call.get("id") or "").strip()
         if not call_id:
             return web.Response(status=200, text="ignored")
+        admissions = self.__dict__.setdefault("_hosted_call_admissions", set())
+        if call_id in admissions:
+            return web.Response(status=200, text="duplicate")
+        admissions.add(call_id)
+        try:
+            return await self._admit_hosted_call_completion(
+                envelope, data, call, call_id, _safe_recovery=_safe_recovery,
+            )
+        finally:
+            admissions.discard(call_id)
+
+    async def _admit_hosted_call_completion(
+        self, envelope: Dict[str, Any], data: Dict[str, Any],
+        call: Dict[str, Any], call_id: str, *, _safe_recovery: bool = False,
+    ) -> "web.Response":
         event_id = str(envelope.get("id") or "").strip()
         existing = self._read_hosted_call_registry().get(call_id)
         existing_state = (
@@ -7732,6 +7750,9 @@ class InkboxAdapter(BasePlatformAdapter):
                 f"remote number `{escaped_remote}` and `text` set to the "
                 "requested SMS body. Do not use conversationId for this "
                 "post-call send.",
+                "If the caller supplied an exact message body in the action or "
+                "transcript, copy it verbatim. Do not replace it with an "
+                "acknowledgment, summary, or generic follow-up.",
                 "The SMS commitment is complete only after inkbox_send_sms "
                 "returns a success payload with `ok: true`. Plain text is not "
                 "a send and does not complete the commitment.",
@@ -8601,6 +8622,9 @@ class InkboxAdapter(BasePlatformAdapter):
             "Do not merely say still-needed actions are impossible. If an email, "
             "SMS, note, or contact update is still needed and enough recipient/"
             "content info is present, perform it.",
+            "If the caller supplied an exact message body in the action or "
+            "transcript, copy it verbatim. Do not replace it with an "
+            "acknowledgment, summary, or generic follow-up.",
             "Do NOT send a confirmation follow-up after successful work unless the "
             "caller explicitly requested one. Only if required information is "
             "missing, ask the caller for the missing information. Try SMS first; "

--- a/adapter.py
+++ b/adapter.py
@@ -4214,10 +4214,9 @@ class InkboxAdapter(BasePlatformAdapter):
                 str(action.get(field) or "")
                 for field in ("action", "description", "details")
             )
-            context.extend(_positive_sms_clauses(
-                action_text,
-                _OPEN_ACTION_SMS_COMMITMENT_PATTERNS,
-            ))
+            if _positive_sms_clauses(action_text, _OPEN_ACTION_SMS_COMMITMENT_PATTERNS):
+                # Preserve explicit message bodies, including punctuation.
+                context.append(action_text)
         for text in transcript_texts:
             context.extend(_positive_sms_clauses(
                 text,

--- a/adapter.py
+++ b/adapter.py
@@ -388,6 +388,14 @@ _REPLY_AUTOSEND_DIRECTIVES: Dict[str, str] = {
     "just write it. Only call inkbox_send_email to email a DIFFERENT thread or "
     "recipient, never to reply here (that sends your message twice).",
 }
+_ACTION_EXECUTION_GUIDANCE = (
+    "For a requested action such as placing a call or sending to another channel, "
+    "invoke the relevant tool; a text reply does not perform that action. "
+    "If Hermes exposes tool_search, tool_describe, and tool_call, discovery only "
+    "returns schemas: execute a discovered tool with tool_call, passing its name "
+    "and arguments. If the tool is directly available, call it directly. "
+    "Do not report an action as performed unless its tool result confirms success."
+)
 SMS_MAX_LENGTH = 1600  # Inkbox SMS hard cap
 IMESSAGE_MAX_LENGTH = 18995  # Sendblue-compatible iMessage text cap
 IMESSAGE_MEDIA_MAX_BYTES = 10 * 1024 * 1024
@@ -5952,6 +5960,7 @@ class InkboxAdapter(BasePlatformAdapter):
         # it's always in context — an operator prompt (if any) is appended after.
         builtin = _REPLY_AUTOSEND_DIRECTIVES.get(modality)
         if builtin:
+            builtin = f"{builtin}\n\n{_ACTION_EXECUTION_GUIDANCE}"
             prompt = f"{builtin}\n\n{prompt}" if prompt else builtin
         configured = self._lookup_channel_skills(extra, contact_key, modality)
         return prompt, self._merge_auto_skills(default_skills, configured)

--- a/audio.py
+++ b/audio.py
@@ -1,0 +1,65 @@
+"""Streaming mono PCM16 conversion for call audio."""
+
+from __future__ import annotations
+
+import base64
+import sys
+
+
+class AudioConverter:
+    """Convert one continuous audio stream, preserving phase and partial samples."""
+
+    def __init__(self, source_rate: int, target_rate: int, *, decode_ulaw=False, encode_ulaw=False):
+        self.source_rate = source_rate
+        self.target_rate = target_rate
+        self.decode_ulaw = decode_ulaw
+        self.encode_ulaw = encode_ulaw
+        self.reset()
+
+    def reset(self):
+        self._state = None
+        self._pending = b""
+
+    def convert(self, payload: str) -> str:
+        import audioop
+
+        data = base64.b64decode(payload, validate=True)
+        if self.decode_ulaw:
+            data = audioop.ulaw2lin(data, 2)
+        else:
+            data = self._pending + data
+            complete = len(data) - len(data) % 2
+            self._pending, data = data[complete:], data[:complete]
+            if sys.byteorder != "little":
+                data = audioop.byteswap(data, 2)
+        if not data:
+            return ""
+        converted, self._state = audioop.ratecv(
+            data, 2, 1, self.source_rate, self.target_rate, self._state,
+        )
+        if self.encode_ulaw:
+            converted = audioop.lin2ulaw(converted, 2)
+        elif sys.byteorder != "little":
+            converted = audioop.byteswap(converted, 2)
+        return base64.b64encode(converted).decode("ascii")
+
+
+class CallAudio:
+    """Negotiate call media independently from the 24 kHz realtime session."""
+
+    def __init__(self):
+        self.configure(None)
+
+    def configure(self, descriptor):
+        if descriptor is None:
+            rate, ulaw = 8000, True
+        elif not isinstance(descriptor, dict):
+            raise ValueError("Unsupported call audio format")
+        elif (descriptor.get("encoding"), descriptor.get("sample_rate"), descriptor.get("channels")) == ("L16", 16000, 1):
+            rate, ulaw = 16000, False
+        elif (str(descriptor.get("encoding", "")).lower(), descriptor.get("sample_rate"), descriptor.get("channels")) == ("pcmu", 8000, 1):
+            rate, ulaw = 8000, True
+        else:
+            raise ValueError("Unsupported call audio format")
+        self.inbound = AudioConverter(rate, 24000, decode_ulaw=ulaw)
+        self.outbound = AudioConverter(24000, rate, encode_ulaw=ulaw)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ description = "Inkbox platform plugin for Hermes Agent"
 requires-python = ">=3.11"
 dependencies = [
   "aiohttp>=3.9",
+  "audioop-lts>=0.2.1; python_version >= '3.13'",
   "inkbox>=0.5.9,<1.0.0",
   "segno>=1.5",
 ]

--- a/realtime.py
+++ b/realtime.py
@@ -10,7 +10,7 @@ The bridge:
 1. Preflights an OpenAI Realtime API WebSocket
    (``wss://api.openai.com/v1/realtime?model=<model>``) and sends
    ``session.update`` configuring tools, instructions, and the
-   ``g711_ulaw`` input/output audio format.
+   24 kHz PCM input/output audio format.
 2. Lets the adapter accept the Inkbox call WS with
    ``x-use-inkbox-text-to-speech: false`` and
    ``x-use-inkbox-speech-to-text: false`` headers only after OpenAI is ready,
@@ -51,6 +51,11 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, Set, Tuple
 from urllib.parse import urlencode
 
 try:
+    from .audio import CallAudio
+except ImportError:  # Standalone plugin loading.
+    from audio import CallAudio
+
+try:
     import aiohttp
 except ImportError:  # pragma: no cover — aiohttp is a core dep on this fork
     aiohttp = None  # type: ignore
@@ -60,7 +65,7 @@ logger = logging.getLogger(__name__)
 REALTIME_URL = "wss://api.openai.com/v1/realtime"
 DEFAULT_MODEL = "gpt-realtime-2"
 DEFAULT_VOICE = "cedar"
-AUDIO_FORMAT_TELEPHONY = {"type": "audio/pcmu"}
+AUDIO_FORMAT_PCM = {"type": "audio/pcm", "rate": 24000}
 INPUT_TRANSCRIPTION_MODEL = "gpt-4o-mini-transcribe"
 
 AGENT_CONSULT_TOOL_NAME = "consult_agent"
@@ -538,6 +543,7 @@ class RealtimeConsultResult:
 
 @dataclass
 class _BridgeState:
+    audio: CallAudio = field(default_factory=CallAudio)
     transcript: List[Tuple[str, str]] = field(default_factory=list)
     post_call_actions: List[Dict[str, str]] = field(default_factory=list)
     consult_results: List[RealtimeConsultResult] = field(default_factory=list)
@@ -1167,7 +1173,7 @@ async def _send_session_update(
             "output_modalities": ["audio"],
             "audio": {
                 "input": {
-                    "format": AUDIO_FORMAT_TELEPHONY,
+                    "format": AUDIO_FORMAT_PCM,
                     "noise_reduction": None,
                     "transcription": {"model": INPUT_TRANSCRIPTION_MODEL},
                     # Server-side VAD with default settings — the model
@@ -1184,7 +1190,7 @@ async def _send_session_update(
                     },
                 },
                 "output": {
-                    "format": AUDIO_FORMAT_TELEPHONY,
+                    "format": AUDIO_FORMAT_PCM,
                     "voice": config.voice,
                 },
             },
@@ -1224,12 +1230,16 @@ async def _inkbox_to_openai_pump(
             event = (frame.get("event") or "").lower()
             if event == "start":
                 state.stream_id = frame.get("stream_id") or state.stream_id
+                state.audio.configure(frame.get("media_format"))
                 await _maybe_send_greeting(openai_ws, state, meta)
             elif event == "media":
                 if not state.greeting_triggered:
                     await _maybe_send_greeting(openai_ws, state, meta)
                 payload_b64 = (frame.get("media") or {}).get("payload")
                 if payload_b64:
+                    payload_b64 = state.audio.inbound.convert(payload_b64)
+                    if not payload_b64:
+                        continue
                     state.caller_media_frames += 1
                     await openai_ws.send_str(json.dumps({
                         "type": "input_audio_buffer.append",
@@ -1508,11 +1518,12 @@ async def _openai_to_inkbox_pump(
 
         # GA emits ``response.output_audio.delta``; beta ``response.audio.delta``.
         if ftype in ("response.output_audio.delta", "response.audio.delta"):
-            # Already μ-law base64. Forward as an outbound Inkbox media frame,
-            # echoing the stream_id and tagging the track per the Inkbox media
-            # protocol.
+            # Convert the streaming PCM response to the negotiated call format.
             delta_b64 = frame.get("delta") or ""
             if delta_b64:
+                delta_b64 = state.audio.outbound.convert(delta_b64)
+                if not delta_b64:
+                    continue
                 # Goodbye audio is still streaming — hold any pending
                 # auto-confirm so the farewell isn't clipped mid-word.
                 _cancel_hangup_auto_confirm(state)
@@ -1530,6 +1541,7 @@ async def _openai_to_inkbox_pump(
 
         # Outbound audio for a response finished — tell Inkbox to flush/play.
         elif ftype in ("response.output_audio.done", "response.audio.done"):
+            state.audio.outbound.reset()
             done = {"event": "audio_done"}
             if state.stream_id:
                 done["stream_id"] = state.stream_id
@@ -1556,6 +1568,7 @@ async def _openai_to_inkbox_pump(
 
         # Caller started speaking (barge-in) — drop any queued outbound audio.
         elif ftype == "input_audio_buffer.speech_started":
+            state.audio.outbound.reset()
             if state.hangup_armed_at is not None:
                 state.hangup_armed_at = None
                 _cancel_hangup_auto_confirm(state)

--- a/realtime.py
+++ b/realtime.py
@@ -1229,8 +1229,9 @@ async def _inkbox_to_openai_pump(
                 continue
             event = (frame.get("event") or "").lower()
             if event == "start":
-                state.stream_id = frame.get("stream_id") or state.stream_id
-                state.audio.configure(frame.get("media_format"))
+                start = frame.get("start") or {}
+                state.stream_id = frame.get("stream_id") or start.get("stream_id") or state.stream_id
+                state.audio.configure(start.get("media_format", frame.get("media_format")))
                 await _maybe_send_greeting(openai_ws, state, meta)
             elif event == "media":
                 if not state.greeting_triggered:

--- a/realtime.py
+++ b/realtime.py
@@ -1232,6 +1232,12 @@ async def _inkbox_to_openai_pump(
                 start = frame.get("start") or {}
                 state.stream_id = frame.get("stream_id") or start.get("stream_id") or state.stream_id
                 state.audio.configure(start.get("media_format", frame.get("media_format")))
+                logger.info(
+                    "[Inkbox realtime] call_id=%s audio_format=%s sample_rate=%d",
+                    meta.call_id,
+                    "pcmu" if state.audio.inbound.decode_ulaw else "pcm_s16le",
+                    state.audio.inbound.source_rate,
+                )
                 await _maybe_send_greeting(openai_ws, state, meta)
             elif event == "media":
                 if not state.greeting_triggered:

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -75,7 +75,10 @@ except Exception:  # pragma: no cover - local tests without Hermes
 
 
 INKBOX_MIN_VERSION = "0.5.9"
-INKBOX_REQUIREMENTS = (f"inkbox>={INKBOX_MIN_VERSION},<1.0.0", "aiohttp>=3.9", "segno>=1.5")
+INKBOX_REQUIREMENTS = (
+    f"inkbox>={INKBOX_MIN_VERSION},<1.0.0", "aiohttp>=3.9", "segno>=1.5",
+    "audioop-lts>=0.2.1; python_version >= '3.13'",
+)
 _BRACKETED_PASTE_PATTERN = re.compile(r"\x1b\[\s*200~|\x1b\[\s*201~")
 _AVATAR_PATH = Path(__file__).resolve().parent / "assets" / "hermes_with_iphone.png"
 _RAW_AVATAR_BASE_URL_DEFAULT = "https://inkbox.ai"

--- a/tests/ci/install_hermes.sh
+++ b/tests/ci/install_hermes.sh
@@ -5,12 +5,14 @@ set -euo pipefail
 installer_url="https://hermes-agent.nousresearch.com/install.sh"
 installer_path="${RUNNER_TEMP:?RUNNER_TEMP must be set}/hermes-install.sh"
 max_attempts="${HERMES_INSTALL_ATTEMPTS:-4}"
+attempt_timeout="${HERMES_INSTALL_TIMEOUT:-120}"
 
 for attempt in $(seq 1 "$max_attempts"); do
   if curl --fail --silent --show-error --location \
-      --retry 3 --retry-all-errors --retry-delay 5 \
+      --connect-timeout 15 --max-time 60 \
+      --retry 3 --retry-all-errors --retry-delay 5 --retry-max-time 90 \
       "$installer_url" --output "$installer_path" \
-    && bash "$installer_path" --non-interactive "$@"; then
+    && timeout --kill-after=10 "$attempt_timeout" bash "$installer_path" --non-interactive "$@"; then
     exit 0
   fi
 

--- a/tests/contract/test_host_interface.py
+++ b/tests/contract/test_host_interface.py
@@ -116,3 +116,36 @@ def test_live_inkbox_tool_scope_excludes_builtin_and_mcp(monkeypatch):
     assert "test-mcp" not in enabled
     assert "terminal" not in enabled
     assert "browser" not in enabled
+
+
+def test_deferred_discovery_does_not_execute_but_tool_call_does(monkeypatch):
+    import json
+    import model_tools
+    from tools.registry import registry
+
+    name = "inkbox_contract_call"
+    schema = {
+        "name": name,
+        "description": "Exercise deferred plugin action execution.",
+        "parameters": {"type": "object", "properties": {"purpose": {"type": "string"}}, "required": ["purpose"]},
+    }
+    called = []
+
+    def handler(args, **kwargs):
+        called.append(args)
+        return json.dumps({"ok": True, "call_id": "synthetic-call"})
+
+    monkeypatch.setattr(registry, "_tools", dict(registry._tools))
+    registry.register(name=name, toolset="inkbox", schema=schema, handler=handler)
+    defs = [{"type": "function", "function": schema}]
+    monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kwargs: defs)
+    described = json.loads(model_tools.handle_function_call(
+        "tool_describe", {"names": [name]}, enabled_toolsets=["inkbox"],
+    ))
+    assert described["tools"][name]["parameters"] == schema["parameters"]
+    assert called == []
+    result = json.loads(model_tools.handle_function_call(
+        "tool_call", {"name": name, "arguments": {"purpose": "Call me back"}}, enabled_toolsets=["inkbox"],
+    ))
+    assert result == {"ok": True, "call_id": "synthetic-call"}
+    assert called == [{"purpose": "Call me back"}]

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -914,6 +914,9 @@ def test_outbound_call_realtime_direct_contact_lookup():
             "the AUT call transcript did not persist the requested contact details"
         )
 
+        assert f"call_id={aut_call.id} audio_format=pcm_s16le sample_rate=16000" in _gateway_log_text(), (
+            "realtime call did not negotiate HD 16 kHz PCM audio"
+        )
         tts, stt = _aut_speech_mode(aut, aut_call.id)
         assert tts is False and stt is False, (
             f"call must be on the realtime path (Inkbox speech off), got tts={tts} stt={stt}"
@@ -979,6 +982,9 @@ def test_outbound_call_realtime():
         )
         assert agent_said, "agent produced no speech on the outbound call"
 
+        assert f"call_id={aut_call.id} audio_format=pcm_s16le sample_rate=16000" in _gateway_log_text(), (
+            "realtime call did not negotiate HD 16 kHz PCM audio"
+        )
         tts, stt = _aut_speech_mode(aut, aut_call.id)
         assert tts is False and stt is False, (
             f"outbound call must be powered by the realtime API (Inkbox speech off), got tts={tts} stt={stt}"

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -42,7 +42,10 @@ _CALL_ME_PHRASINGS = (
 def _call_me_text() -> str:
     """A fresh call-request body each send (rotating phrasing + unique ref)."""
     phrasing = _CALL_ME_PHRASINGS[uuid.uuid4().int % len(_CALL_ME_PHRASINGS)]
-    return f"{phrasing} (ref {uuid.uuid4().hex[:6]})"
+    return (
+        f"{phrasing} This is my authorization to place the call now; "
+        f"please execute the call rather than only describe it. (ref {uuid.uuid4().hex[:6]})"
+    )
 
 
 REMOTE_KEY = os.environ.get("REMOTE_INKBOX_API_KEY")

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,0 +1,90 @@
+import base64
+import math
+import struct
+
+import pytest
+
+from tests.test_realtime_bridge_parity import (
+    _BridgeState, _FakeOpenAIWS, _FakeWS, _meta,
+)
+from inkbox_plugin.audio import AudioConverter, CallAudio
+from inkbox_plugin import realtime
+
+
+def _encoded(data):
+    return base64.b64encode(data).decode()
+
+
+@pytest.mark.parametrize('source,target', [(16000, 24000), (24000, 16000)])
+def test_streaming_conversion_preserves_tone_duration_and_chunk_boundaries(source, target):
+    samples = [round(12000 * math.sin(2 * math.pi * 1000 * n / source)) for n in range(source // 10)]
+    pcm = struct.pack(f'<{len(samples)}h', *samples)
+    expected = base64.b64decode(AudioConverter(source, target).convert(_encoded(pcm)))
+    stream = AudioConverter(source, target)
+    actual = b''.join(base64.b64decode(stream.convert(_encoded(pcm[n:n + 37]))) for n in range(0, len(pcm), 37))
+    assert actual == expected
+    assert abs(len(actual) // 2 - target // 10) <= 1
+    output = struct.unpack(f'<{len(actual) // 2}h', actual)
+    crossings = sum(a < 0 <= b for a, b in zip(output, output[1:]))
+    assert 98 <= crossings <= 100
+    assert max(output) > 11000
+
+
+def test_pcm_silence_reset_and_legacy_formats():
+    call = CallAudio()
+    assert set(base64.b64decode(call.inbound.convert(_encoded(b'\xff' * 160)))) == {0}
+    assert set(base64.b64decode(call.outbound.convert(_encoded(bytes(960))))) == {255}
+    call.configure({'encoding': 'L16', 'sample_rate': 16000, 'channels': 1})
+    assert call.outbound.convert(_encoded(b'\xff')) == ''
+    call.outbound.reset()
+    assert set(base64.b64decode(call.outbound.convert(_encoded(bytes(960))))) == {0}
+    with pytest.raises(ValueError, match='Unsupported'):
+        call.configure({'encoding': 'L16', 'sample_rate': 8000, 'channels': 1})
+
+
+def test_start_descriptor_drives_actual_inbound_conversion():
+    import asyncio
+    descriptor = {'encoding': 'L16', 'sample_rate': 16000, 'channels': 1}
+    peer = _FakeOpenAIWS([
+        {'event': 'start', 'media_format': descriptor},
+        {'event': 'media', 'media': {'payload': _encoded(bytes(640))}},
+    ])
+    upstream = _FakeWS()
+    state = _BridgeState()
+    asyncio.run(realtime._inkbox_to_openai_pump(peer, upstream, state, _meta()))
+    append = next(frame for frame in upstream.sent if frame['type'] == 'input_audio_buffer.append')
+    assert 956 <= len(base64.b64decode(append['audio'])) <= 960
+    assert state.audio.outbound.target_rate == 16000
+
+
+def test_hd_output_converts_and_resets_partial_samples_on_interrupt():
+    import asyncio
+    state = _BridgeState()
+    state.audio.configure({'encoding': 'L16', 'sample_rate': 16000, 'channels': 1})
+    upstream = _FakeOpenAIWS([
+        {'type': 'response.output_audio.delta', 'delta': _encoded(b'\xff')},
+        {'type': 'input_audio_buffer.speech_started'},
+        {'type': 'response.output_audio.delta', 'delta': _encoded(bytes(960))},
+        {'type': 'response.output_audio.done'},
+    ])
+    peer = _FakeWS()
+
+    async def noop(*args):
+        return ''
+
+    asyncio.run(realtime._openai_to_inkbox_pump(
+        openai_ws=upstream, inkbox_ws=peer, state=state,
+        config=realtime.RealtimeConfig(enabled=True, api_key='test'), meta=_meta(), on_agent_consult=noop,
+    ))
+    media = [frame for frame in peer.sent if frame.get('event') == 'media']
+    assert len(media) == 1
+    assert base64.b64decode(media[0]['media']['payload']) == bytes(640)
+    assert state.audio.outbound._state is None
+
+
+def test_session_uses_supported_realtime_pcm_rate():
+    import asyncio
+    ws = _FakeWS()
+    asyncio.run(realtime._send_session_update(ws, realtime.RealtimeConfig(), _meta()))
+    audio = ws.sent[0]['session']['audio']
+    assert audio['input']['format'] == audio['output']['format'] == {'type': 'audio/pcm', 'rate': 24000}

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -46,7 +46,7 @@ def test_start_descriptor_drives_actual_inbound_conversion():
     import asyncio
     descriptor = {'encoding': 'L16', 'sample_rate': 16000, 'channels': 1}
     peer = _FakeOpenAIWS([
-        {'event': 'start', 'media_format': descriptor},
+        {'event': 'start', 'start': {'media_format': descriptor, 'stream_id': 'hd-stream'}},
         {'event': 'media', 'media': {'payload': _encoded(bytes(640))}},
     ])
     upstream = _FakeWS()
@@ -55,6 +55,7 @@ def test_start_descriptor_drives_actual_inbound_conversion():
     append = next(frame for frame in upstream.sent if frame['type'] == 'input_audio_buffer.append')
     assert 956 <= len(base64.b64decode(append['audio'])) <= 960
     assert state.audio.outbound.target_rate == 16000
+    assert state.stream_id == "hd-stream"
 
 
 def test_hd_output_converts_and_resets_partial_samples_on_interrupt():

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -42,7 +42,8 @@ def test_pcm_silence_reset_and_legacy_formats():
         call.configure({'encoding': 'L16', 'sample_rate': 8000, 'channels': 1})
 
 
-def test_start_descriptor_drives_actual_inbound_conversion():
+def test_start_descriptor_drives_actual_inbound_conversion(caplog):
+    caplog.set_level("INFO")
     import asyncio
     descriptor = {'encoding': 'L16', 'sample_rate': 16000, 'channels': 1}
     peer = _FakeOpenAIWS([
@@ -56,6 +57,7 @@ def test_start_descriptor_drives_actual_inbound_conversion():
     assert 956 <= len(base64.b64decode(append['audio'])) <= 960
     assert state.audio.outbound.target_rate == 16000
     assert state.stream_id == "hd-stream"
+    assert "call_id=call-123 audio_format=pcm_s16le sample_rate=16000" in caplog.text
 
 
 def test_hd_output_converts_and_resets_partial_samples_on_interrupt():

--- a/tests/test_channel_overrides.py
+++ b/tests/test_channel_overrides.py
@@ -148,3 +148,15 @@ def test_contact_binding_wins_over_modality_binding():
     )
     _, skills = adapter._resolve_channel_overrides("voice", "contact_1", None)
     assert skills == ["inkbox:inkbox-outbound-calling"]
+
+
+def test_text_channels_distinguish_discovery_from_execution():
+    adapter = _adapter({"channel_prompts": {"sms": "Be concise."}})
+    for modality in ("sms", "imessage", "email"):
+        prompt, _ = adapter._resolve_channel_overrides(modality, "contact_1", None)
+        assert "a text reply does not perform that action" in prompt
+        assert "If Hermes exposes tool_search, tool_describe, and tool_call" in prompt
+        assert "passing its name and arguments" in prompt
+        assert "If the tool is directly available, call it directly" in prompt
+        assert "unless its tool result confirms success" in prompt
+    assert adapter._resolve_channel_overrides("sms", "contact_1", None)[0].endswith("Be concise.")

--- a/tests/test_ci_resilience.py
+++ b/tests/test_ci_resilience.py
@@ -106,3 +106,33 @@ def test_live_identity_resolution_uses_the_configured_api(monkeypatch):
 
     assert resolve_identity(fake_client_factory) == "ci-agent"
     assert calls == [{"api_key": "test-key", "base_url": "https://example.com"}]
+
+
+def test_installer_retries_a_hung_attempt_without_waiting_for_job_timeout(tmp_path):
+    import os
+    import subprocess
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    curl = bin_dir / "curl"
+    curl.write_text('''#!/bin/bash
+cat > "$RUNNER_TEMP/hermes-install.sh" <<'INSTALL'
+#!/bin/bash
+if [ ! -e "$RUNNER_TEMP/first-attempt" ]; then
+  touch "$RUNNER_TEMP/first-attempt"
+  /bin/sleep 30
+fi
+INSTALL
+''')
+    curl.chmod(0o755)
+    sleep = bin_dir / "sleep"
+    sleep.write_text("#!/bin/bash\nexit 0\n")
+    sleep.chmod(0o755)
+    result = subprocess.run(
+        ["bash", str(ROOT / "tests/ci/install_hermes.sh"), "--skip-browser", "--no-skills"],
+        env={**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}", "RUNNER_TEMP": str(tmp_path),
+             "HERMES_INSTALL_TIMEOUT": "0.1", "HERMES_INSTALL_ATTEMPTS": "2"},
+        capture_output=True, text=True, timeout=5,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "attempt 1 failed; retrying" in result.stdout

--- a/tests/test_contact_memories.py
+++ b/tests/test_contact_memories.py
@@ -333,7 +333,10 @@ def test_auto_accept_call_context_carries_memories_without_webhook_prestash(monk
         headers={"x-call-context": context},
     )
 
-    asyncio.run(adapter._handle_call_ws(request))
+    ws = asyncio.run(adapter._handle_call_ws(request))
+    assert ws.headers["x-inkbox-audio-format"] == "pcm_s16le_16000"
+    assert ws.headers["x-use-inkbox-text-to-speech"] == "false"
+    assert ws.headers["x-use-inkbox-speech-to-text"] == "false"
 
     assert captured["meta"].contact_known is True
     assert captured["meta"].contact_name is None

--- a/tests/test_hosted_call_completion.py
+++ b/tests/test_hosted_call_completion.py
@@ -255,6 +255,8 @@ def test_hosted_sms_commitment_uses_exact_tool_success_contract(tmp_path):
     assert len(events) == 1
     prompt = events[0].text
     assert "SMS post-call tool contract:" in prompt
+    assert "copy it verbatim" in prompt
+    assert "acknowledgment, summary, or generic follow-up" in prompt
     assert "use inkbox_send_sms" in prompt
     assert "tool_search" in prompt
     assert "`to` set to the exact authoritative remote number `+15551112222`" in prompt
@@ -526,6 +528,7 @@ def test_hosted_sms_missing_tool_enqueues_one_correction(tmp_path, monkeypatch):
     assert len(events) == 2
     correction = events[1]
     assert "only correction attempt" in correction.text
+    assert "copy it verbatim" in correction.text
     assert "Do not reply [SILENT] or skip the tool" in correction.text
     assert correction.raw_message["_inkbox_hosted_reconciliation_attempt"] == 2
     receipt = instance._read_hosted_call_registry()["call-1"]
@@ -1144,3 +1147,45 @@ def test_hosted_completion_enqueue_failure_allows_webhook_retry(tmp_path):
         asyncio.run(instance._on_call_ended(_payload()))
 
     assert instance._read_hosted_call_registry() == {}
+
+
+def test_concurrent_distinct_events_for_one_call_enqueue_once(tmp_path, monkeypatch):
+    instance, events = _adapter(tmp_path)
+
+    async def scenario():
+        fetching = asyncio.Event()
+        release = asyncio.Event()
+
+        async def delayed_fetch(fn, *args):
+            fetching.set()
+            await release.wait()
+            return fn(*args)
+
+        monkeypatch.setattr(adapter_mod.asyncio, "to_thread", delayed_fetch)
+        first = asyncio.create_task(instance._on_call_ended(_payload(event_id="first")))
+        await fetching.wait()
+        duplicate = await instance._on_call_ended(_payload(event_id="second"))
+        assert duplicate.text == "duplicate"
+        assert not events
+        release.set()
+        assert (await first).status == 200
+        assert len(events) == 1
+        assert not instance._hosted_call_admissions
+
+    asyncio.run(scenario())
+
+
+def test_failed_admission_releases_call_for_retry(tmp_path):
+    instance, events = _adapter(tmp_path)
+    enqueue = instance._enqueue
+
+    async def fail_enqueue(event):
+        raise RuntimeError("queue unavailable")
+
+    instance._enqueue = fail_enqueue
+    with pytest.raises(RuntimeError, match="queue unavailable"):
+        asyncio.run(instance._on_call_ended(_payload()))
+    assert not instance._hosted_call_admissions
+    instance._enqueue = enqueue
+    assert asyncio.run(instance._on_call_ended(_payload())).status == 200
+    assert len(events) == 1

--- a/tests/test_hosted_call_completion.py
+++ b/tests/test_hosted_call_completion.py
@@ -1189,3 +1189,19 @@ def test_failed_admission_releases_call_for_retry(tmp_path):
     instance._enqueue = enqueue
     assert asyncio.run(instance._on_call_ended(_payload())).status == 200
     assert len(events) == 1
+
+
+def test_sms_correction_preserves_exact_action_body(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    instance, events = _adapter(tmp_path)
+    payload = _payload()
+    body = "Banana! Telescope? Library."
+    payload["data"]["post_call_action_items"] = [
+        {"action": "Email the release details", "status": "open"},
+        {"action": "Send the caller an SMS.", "details": f"Exact body: {body}", "status": "open"},
+    ]
+    asyncio.run(instance._on_call_ended(payload))
+    asyncio.run(instance.on_processing_start(events[0]))
+    asyncio.run(instance.on_processing_complete(events[0], "success"))
+    assert body in events[1].text
+    assert "Email the release details" not in events[1].text

--- a/tests/test_realtime_bridge_parity.py
+++ b/tests/test_realtime_bridge_parity.py
@@ -270,7 +270,7 @@ def test_proactive_greeting_fires_once_without_output_modalities():
 def test_openai_audio_frames_match_inkbox_media_protocol():
     inkbox_ws = _FakeWS()
     openai_ws = _FakeOpenAIWS([
-        {"type": "response.output_audio.delta", "delta": "AAAA"},
+        {"type": "response.output_audio.delta", "delta": "AAAAAAAA"},
         {"type": "response.output_audio.done"},
         {"type": "input_audio_buffer.speech_started"},
     ])
@@ -290,7 +290,7 @@ def test_openai_audio_frames_match_inkbox_media_protocol():
     ))
 
     media = next(frame for frame in inkbox_ws.sent if frame.get("event") == "media")
-    assert media["media"]["payload"] == "AAAA"
+    assert media["media"]["payload"] == "/w=="
     assert media["media"]["track"] == "outbound"
     assert media["stream_id"] == "stream-xyz"
     assert {"event": "audio_done", "stream_id": "stream-xyz"} in inkbox_ws.sent
@@ -449,7 +449,7 @@ def test_agent_consult_does_not_block_audio_pump():
             },
             # ...and audio arrives WHILE the consult is still running. The pump
             # must forward this without waiting for the consult to finish.
-            {"type": "response.output_audio.delta", "delta": "ONEMOMENT"},
+            {"type": "response.output_audio.delta", "delta": "AAAAAAAA"},
         ])
         state = _BridgeState()
         state.stream_id = "stream-c"
@@ -467,7 +467,7 @@ def test_agent_consult_does_not_block_audio_pump():
         # consult has not returned yet.
         assert any(
             frame.get("event") == "media"
-            and frame["media"]["payload"] == "ONEMOMENT"
+            and frame["media"]["payload"] == "/w=="
             for frame in inkbox_ws.sent
         )
         # The consult was handed off to a background task, not awaited inline.

--- a/tests/test_scheduled_failure_reporting.py
+++ b/tests/test_scheduled_failure_reporting.py
@@ -26,3 +26,12 @@ def test_scheduled_failures_use_one_verified_reporting_path():
     assert 'report_scheduled_failure.sh" event' in report
     assert "X-Hub-Signature-256" in reporter
     assert "chat_thread_key" in reporter
+
+
+def test_reporter_checks_out_trusted_scripts_before_execution():
+    report = (ROOT / ".github/workflows/scheduled-failure-report.yml").read_text()
+    assert "contents: read" in report
+    assert "ref: ${{ github.event.repository.default_branch }}" in report
+    assert "persist-credentials: false" in report
+    assert report.index("uses: actions/checkout@") < report.index("- name: Post failure notification")
+    assert "ref: ${{ github.event.workflow_run.head_sha }}" not in report

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -110,6 +110,7 @@ def test_install_command_prefers_uv_when_available(monkeypatch):
         "inkbox>=0.5.9,<1.0.0",
         "aiohttp>=3.9",
         "segno>=1.5",
+        "audioop-lts>=0.2.1; python_version >= '3.13'",
     ]]
 
 
@@ -118,10 +119,10 @@ def test_install_command_falls_back_to_pip_and_ensurepip(monkeypatch):
     monkeypatch.setattr(setup_wizard.shutil, "which", lambda _name: None)
 
     assert setup_wizard._install_commands() == [
-        [["/tmp/hermes/venv/bin/python", "-m", "pip", "install", "inkbox>=0.5.9,<1.0.0", "aiohttp>=3.9", "segno>=1.5"]],
+        [["/tmp/hermes/venv/bin/python", "-m", "pip", "install", "inkbox>=0.5.9,<1.0.0", "aiohttp>=3.9", "segno>=1.5", "audioop-lts>=0.2.1; python_version >= '3.13'"]],
         [
             ["/tmp/hermes/venv/bin/python", "-m", "ensurepip", "--upgrade"],
-            ["/tmp/hermes/venv/bin/python", "-m", "pip", "install", "inkbox>=0.5.9,<1.0.0", "aiohttp>=3.9", "segno>=1.5"],
+            ["/tmp/hermes/venv/bin/python", "-m", "pip", "install", "inkbox>=0.5.9,<1.0.0", "aiohttp>=3.9", "segno>=1.5", "audioop-lts>=0.2.1; python_version >= '3.13'"],
         ],
     ]
 

--- a/tests/test_voice_marker.py
+++ b/tests/test_voice_marker.py
@@ -72,6 +72,8 @@ def test_hosted_voice_workflow_keeps_peer_alive_for_test_owned_hangup():
         in workflow
     )
     assert "export VOICE_DRIVER_LISTEN=180" in workflow
+    assert "export VOICE_DRIVER_REASK=0" in workflow
+    assert "export VOICE_DRIVER_NUDGE=" not in workflow
     assert "export VOICE_DRIVER_LISTEN=45" not in workflow
     assert hosted_proof.index("_wait_for_hosted_request(") < hosted_proof.index("_wait_for_hosted_action(")
     assert hosted_proof.index("_wait_for_hosted_action(") < hosted_proof.index("finally:")

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,8 @@ revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
 ]
 
 [[package]]
@@ -209,6 +210,62 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "audioop-lts"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/53/946db57842a50b2da2e0c1e34bd37f36f5aadba1a929a3971c5d7841dbca/audioop_lts-0.2.2.tar.gz", hash = "sha256:64d0c62d88e67b98a1a5e71987b7aa7b5bcffc7dcee65b635823dbdd0a8dbbd0", size = 30686, upload-time = "2025-08-05T16:43:17.409Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/d4/94d277ca941de5a507b07f0b592f199c22454eeaec8f008a286b3fbbacd6/audioop_lts-0.2.2-cp313-abi3-macosx_10_13_universal2.whl", hash = "sha256:fd3d4602dc64914d462924a08c1a9816435a2155d74f325853c1f1ac3b2d9800", size = 46523, upload-time = "2025-08-05T16:42:20.836Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5a/656d1c2da4b555920ce4177167bfeb8623d98765594af59702c8873f60ec/audioop_lts-0.2.2-cp313-abi3-macosx_10_13_x86_64.whl", hash = "sha256:550c114a8df0aafe9a05442a1162dfc8fec37e9af1d625ae6060fed6e756f303", size = 27455, upload-time = "2025-08-05T16:42:22.283Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/83/ea581e364ce7b0d41456fb79d6ee0ad482beda61faf0cab20cbd4c63a541/audioop_lts-0.2.2-cp313-abi3-macosx_11_0_arm64.whl", hash = "sha256:9a13dc409f2564de15dd68be65b462ba0dde01b19663720c68c1140c782d1d75", size = 26997, upload-time = "2025-08-05T16:42:23.849Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/3b/e8964210b5e216e5041593b7d33e97ee65967f17c282e8510d19c666dab4/audioop_lts-0.2.2-cp313-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:51c916108c56aa6e426ce611946f901badac950ee2ddaf302b7ed35d9958970d", size = 85844, upload-time = "2025-08-05T16:42:25.208Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2e/0a1c52faf10d51def20531a59ce4c706cb7952323b11709e10de324d6493/audioop_lts-0.2.2-cp313-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:47eba38322370347b1c47024defbd36374a211e8dd5b0dcbce7b34fdb6f8847b", size = 85056, upload-time = "2025-08-05T16:42:26.559Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e8/cd95eef479656cb75ab05dfece8c1f8c395d17a7c651d88f8e6e291a63ab/audioop_lts-0.2.2-cp313-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ba7c3a7e5f23e215cb271516197030c32aef2e754252c4c70a50aaff7031a2c8", size = 93892, upload-time = "2025-08-05T16:42:27.902Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/1e/a0c42570b74f83efa5cca34905b3eef03f7ab09fe5637015df538a7f3345/audioop_lts-0.2.2-cp313-abi3-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:def246fe9e180626731b26e89816e79aae2276f825420a07b4a647abaa84becc", size = 96660, upload-time = "2025-08-05T16:42:28.9Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d5/8a0ae607ca07dbb34027bac8db805498ee7bfecc05fd2c148cc1ed7646e7/audioop_lts-0.2.2-cp313-abi3-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e160bf9df356d841bb6c180eeeea1834085464626dc1b68fa4e1d59070affdc3", size = 79143, upload-time = "2025-08-05T16:42:29.929Z" },
+    { url = "https://files.pythonhosted.org/packages/12/17/0d28c46179e7910bfb0bb62760ccb33edb5de973052cb2230b662c14ca2e/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4b4cd51a57b698b2d06cb9993b7ac8dfe89a3b2878e96bc7948e9f19ff51dba6", size = 84313, upload-time = "2025-08-05T16:42:30.949Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ba/bd5d3806641564f2024e97ca98ea8f8811d4e01d9b9f9831474bc9e14f9e/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:4a53aa7c16a60a6857e6b0b165261436396ef7293f8b5c9c828a3a203147ed4a", size = 93044, upload-time = "2025-08-05T16:42:31.959Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/5e/435ce8d5642f1f7679540d1e73c1c42d933331c0976eb397d1717d7f01a3/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:3fc38008969796f0f689f1453722a0f463da1b8a6fbee11987830bfbb664f623", size = 78766, upload-time = "2025-08-05T16:42:33.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/b909e76b606cbfd53875693ec8c156e93e15a1366a012f0b7e4fb52d3c34/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_s390x.whl", hash = "sha256:15ab25dd3e620790f40e9ead897f91e79c0d3ce65fe193c8ed6c26cffdd24be7", size = 87640, upload-time = "2025-08-05T16:42:34.854Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e7/8f1603b4572d79b775f2140d7952f200f5e6c62904585d08a01f0a70393a/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:03f061a1915538fd96272bac9551841859dbb2e3bf73ebe4a23ef043766f5449", size = 86052, upload-time = "2025-08-05T16:42:35.839Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/96/c37846df657ccdda62ba1ae2b6534fa90e2e1b1742ca8dcf8ebd38c53801/audioop_lts-0.2.2-cp313-abi3-win32.whl", hash = "sha256:3bcddaaf6cc5935a300a8387c99f7a7fbbe212a11568ec6cf6e4bc458c048636", size = 26185, upload-time = "2025-08-05T16:42:37.04Z" },
+    { url = "https://files.pythonhosted.org/packages/34/a5/9d78fdb5b844a83da8a71226c7bdae7cc638861085fff7a1d707cb4823fa/audioop_lts-0.2.2-cp313-abi3-win_amd64.whl", hash = "sha256:a2c2a947fae7d1062ef08c4e369e0ba2086049a5e598fda41122535557012e9e", size = 30503, upload-time = "2025-08-05T16:42:38.427Z" },
+    { url = "https://files.pythonhosted.org/packages/34/25/20d8fde083123e90c61b51afb547bb0ea7e77bab50d98c0ab243d02a0e43/audioop_lts-0.2.2-cp313-abi3-win_arm64.whl", hash = "sha256:5f93a5db13927a37d2d09637ccca4b2b6b48c19cd9eda7b17a2e9f77edee6a6f", size = 24173, upload-time = "2025-08-05T16:42:39.704Z" },
+    { url = "https://files.pythonhosted.org/packages/58/a7/0a764f77b5c4ac58dc13c01a580f5d32ae8c74c92020b961556a43e26d02/audioop_lts-0.2.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:73f80bf4cd5d2ca7814da30a120de1f9408ee0619cc75da87d0641273d202a09", size = 47096, upload-time = "2025-08-05T16:42:40.684Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ed/ebebedde1a18848b085ad0fa54b66ceb95f1f94a3fc04f1cd1b5ccb0ed42/audioop_lts-0.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:106753a83a25ee4d6f473f2be6b0966fc1c9af7e0017192f5531a3e7463dce58", size = 27748, upload-time = "2025-08-05T16:42:41.992Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/6e/11ca8c21af79f15dbb1c7f8017952ee8c810c438ce4e2b25638dfef2b02c/audioop_lts-0.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fbdd522624141e40948ab3e8cdae6e04c748d78710e9f0f8d4dae2750831de19", size = 27329, upload-time = "2025-08-05T16:42:42.987Z" },
+    { url = "https://files.pythonhosted.org/packages/84/52/0022f93d56d85eec5da6b9da6a958a1ef09e80c39f2cc0a590c6af81dcbb/audioop_lts-0.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:143fad0311e8209ece30a8dbddab3b65ab419cbe8c0dde6e8828da25999be911", size = 92407, upload-time = "2025-08-05T16:42:44.336Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1d/48a889855e67be8718adbc7a01f3c01d5743c325453a5e81cf3717664aad/audioop_lts-0.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfbbc74ec68a0fd08cfec1f4b5e8cca3d3cd7de5501b01c4b5d209995033cde9", size = 91811, upload-time = "2025-08-05T16:42:45.325Z" },
+    { url = "https://files.pythonhosted.org/packages/98/a6/94b7213190e8077547ffae75e13ed05edc488653c85aa5c41472c297d295/audioop_lts-0.2.2-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cfcac6aa6f42397471e4943e0feb2244549db5c5d01efcd02725b96af417f3fe", size = 100470, upload-time = "2025-08-05T16:42:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/e9/78450d7cb921ede0cfc33426d3a8023a3bda755883c95c868ee36db8d48d/audioop_lts-0.2.2-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:752d76472d9804ac60f0078c79cdae8b956f293177acd2316cd1e15149aee132", size = 103878, upload-time = "2025-08-05T16:42:47.576Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/e2/cd5439aad4f3e34ae1ee852025dc6aa8f67a82b97641e390bf7bd9891d3e/audioop_lts-0.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:83c381767e2cc10e93e40281a04852facc4cd9334550e0f392f72d1c0a9c5753", size = 84867, upload-time = "2025-08-05T16:42:49.003Z" },
+    { url = "https://files.pythonhosted.org/packages/68/4b/9d853e9076c43ebba0d411e8d2aa19061083349ac695a7d082540bad64d0/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c0022283e9556e0f3643b7c3c03f05063ca72b3063291834cca43234f20c60bb", size = 90001, upload-time = "2025-08-05T16:42:50.038Z" },
+    { url = "https://files.pythonhosted.org/packages/58/26/4bae7f9d2f116ed5593989d0e521d679b0d583973d203384679323d8fa85/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:a2d4f1513d63c795e82948e1305f31a6d530626e5f9f2605408b300ae6095093", size = 99046, upload-time = "2025-08-05T16:42:51.111Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/67/a9f4fb3e250dda9e9046f8866e9fa7d52664f8985e445c6b4ad6dfb55641/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c9c8e68d8b4a56fda8c025e538e639f8c5953f5073886b596c93ec9b620055e7", size = 84788, upload-time = "2025-08-05T16:42:52.198Z" },
+    { url = "https://files.pythonhosted.org/packages/70/f7/3de86562db0121956148bcb0fe5b506615e3bcf6e63c4357a612b910765a/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:96f19de485a2925314f5020e85911fb447ff5fbef56e8c7c6927851b95533a1c", size = 94472, upload-time = "2025-08-05T16:42:53.59Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/32/fd772bf9078ae1001207d2df1eef3da05bea611a87dd0e8217989b2848fa/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e541c3ef484852ef36545f66209444c48b28661e864ccadb29daddb6a4b8e5f5", size = 92279, upload-time = "2025-08-05T16:42:54.632Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/41/affea7181592ab0ab560044632571a38edaf9130b84928177823fbf3176a/audioop_lts-0.2.2-cp313-cp313t-win32.whl", hash = "sha256:d5e73fa573e273e4f2e5ff96f9043858a5e9311e94ffefd88a3186a910c70917", size = 26568, upload-time = "2025-08-05T16:42:55.627Z" },
+    { url = "https://files.pythonhosted.org/packages/28/2b/0372842877016641db8fc54d5c88596b542eec2f8f6c20a36fb6612bf9ee/audioop_lts-0.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:9191d68659eda01e448188f60364c7763a7ca6653ed3f87ebb165822153a8547", size = 30942, upload-time = "2025-08-05T16:42:56.674Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/baf2b9cc7e96c179bb4a54f30fcd83e6ecb340031bde68f486403f943768/audioop_lts-0.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c174e322bb5783c099aaf87faeb240c8d210686b04bd61dfd05a8e5a83d88969", size = 24603, upload-time = "2025-08-05T16:42:57.571Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/73/413b5a2804091e2c7d5def1d618e4837f1cb82464e230f827226278556b7/audioop_lts-0.2.2-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:f9ee9b52f5f857fbaf9d605a360884f034c92c1c23021fb90b2e39b8e64bede6", size = 47104, upload-time = "2025-08-05T16:42:58.518Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8c/daa3308dc6593944410c2c68306a5e217f5c05b70a12e70228e7dd42dc5c/audioop_lts-0.2.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:49ee1a41738a23e98d98b937a0638357a2477bc99e61b0f768a8f654f45d9b7a", size = 27754, upload-time = "2025-08-05T16:43:00.132Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/86/c2e0f627168fcf61781a8f72cab06b228fe1da4b9fa4ab39cfb791b5836b/audioop_lts-0.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5b00be98ccd0fc123dcfad31d50030d25fcf31488cde9e61692029cd7394733b", size = 27332, upload-time = "2025-08-05T16:43:01.666Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/bd/35dce665255434f54e5307de39e31912a6f902d4572da7c37582809de14f/audioop_lts-0.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6d2e0f9f7a69403e388894d4ca5ada5c47230716a03f2847cfc7bd1ecb589d6", size = 92396, upload-time = "2025-08-05T16:43:02.991Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d2/deeb9f51def1437b3afa35aeb729d577c04bcd89394cb56f9239a9f50b6f/audioop_lts-0.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9b0b8a03ef474f56d1a842af1a2e01398b8f7654009823c6d9e0ecff4d5cfbf", size = 91811, upload-time = "2025-08-05T16:43:04.096Z" },
+    { url = "https://files.pythonhosted.org/packages/76/3b/09f8b35b227cee28cc8231e296a82759ed80c1a08e349811d69773c48426/audioop_lts-0.2.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2b267b70747d82125f1a021506565bdc5609a2b24bcb4773c16d79d2bb260bbd", size = 100483, upload-time = "2025-08-05T16:43:05.085Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/15/05b48a935cf3b130c248bfdbdea71ce6437f5394ee8533e0edd7cfd93d5e/audioop_lts-0.2.2-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0337d658f9b81f4cd0fdb1f47635070cc084871a3d4646d9de74fdf4e7c3d24a", size = 103885, upload-time = "2025-08-05T16:43:06.197Z" },
+    { url = "https://files.pythonhosted.org/packages/83/80/186b7fce6d35b68d3d739f228dc31d60b3412105854edb975aa155a58339/audioop_lts-0.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:167d3b62586faef8b6b2275c3218796b12621a60e43f7e9d5845d627b9c9b80e", size = 84899, upload-time = "2025-08-05T16:43:07.291Z" },
+    { url = "https://files.pythonhosted.org/packages/49/89/c78cc5ac6cb5828f17514fb12966e299c850bc885e80f8ad94e38d450886/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0d9385e96f9f6da847f4d571ce3cb15b5091140edf3db97276872647ce37efd7", size = 89998, upload-time = "2025-08-05T16:43:08.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4b/6401888d0c010e586c2ca50fce4c903d70a6bb55928b16cfbdfd957a13da/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:48159d96962674eccdca9a3df280e864e8ac75e40a577cc97c5c42667ffabfc5", size = 99046, upload-time = "2025-08-05T16:43:09.367Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f8/c874ca9bb447dae0e2ef2e231f6c4c2b0c39e31ae684d2420b0f9e97ee68/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8fefe5868cd082db1186f2837d64cfbfa78b548ea0d0543e9b28935ccce81ce9", size = 84843, upload-time = "2025-08-05T16:43:10.749Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c0/0323e66f3daebc13fd46b36b30c3be47e3fc4257eae44f1e77eb828c703f/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:58cf54380c3884fb49fdd37dfb7a772632b6701d28edd3e2904743c5e1773602", size = 94490, upload-time = "2025-08-05T16:43:12.131Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6b/acc7734ac02d95ab791c10c3f17ffa3584ccb9ac5c18fd771c638ed6d1f5/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:088327f00488cdeed296edd9215ca159f3a5a5034741465789cad403fcf4bec0", size = 92297, upload-time = "2025-08-05T16:43:13.139Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c3/c3dc3f564ce6877ecd2a05f8d751b9b27a8c320c2533a98b0c86349778d0/audioop_lts-0.2.2-cp314-cp314t-win32.whl", hash = "sha256:068aa17a38b4e0e7de771c62c60bbca2455924b67a8814f3b0dee92b5820c0b3", size = 27331, upload-time = "2025-08-05T16:43:14.19Z" },
+    { url = "https://files.pythonhosted.org/packages/72/bb/b4608537e9ffcb86449091939d52d24a055216a36a8bf66b936af8c3e7ac/audioop_lts-0.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:a5bf613e96f49712073de86f20dbdd4014ca18efd4d34ed18c75bd808337851b", size = 31697, upload-time = "2025-08-05T16:43:15.193Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/22/91616fe707a5c5510de2cac9b046a30defe7007ba8a0c04f9c08f27df312/audioop_lts-0.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:b492c3b040153e68b9fdaff5913305aaaba5bb433d8a7f73d5cf6a64ed3cc1dd", size = 25206, upload-time = "2025-08-05T16:43:16.444Z" },
 ]
 
 [[package]]
@@ -488,6 +545,7 @@ version = "0.2.13"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },
+    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
     { name = "inkbox" },
     { name = "segno" },
 ]
@@ -501,6 +559,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9" },
+    { name = "audioop-lts", marker = "python_full_version >= '3.13'", specifier = ">=0.2.1" },
     { name = "inkbox", specifier = ">=0.5.9,<1.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
     { name = "ruff", marker = "extra == 'test'", specifier = ">=0.11.0,<0.16" },


### PR DESCRIPTION
## Executive Summary

Add HD realtime calling and repair scheduled CI reliability.

- Negotiate 16 kHz PCM call audio with streaming conversion to the realtime session’s 24 kHz PCM format.
- Preserve legacy 8 kHz calling and cover Python 3.13 dependency installation.
- Restore scheduled failure reporting, bound stalled installer attempts, and clarify live voice requests.

## Description

The call upgrade selects mono signed little-endian PCM16 at 16 kHz. Each call owns independent streaming converters, selected from its start-frame format; legacy calls retain 8 kHz μ-law compatibility. Output conversion state resets at audio completion and interruption, including incomplete samples.

Text-channel prompts distinguish schema discovery from execution through the host’s deferred tool bridge, while retaining direct calls when tools are directly exposed. Scheduled reporting now checks out trusted default-branch scripts before execution. Live host installation has bounded download and execution attempts. Concurrent completion events claim their call before transcript retrieval, preventing duplicate post-call turns. Exact message bodies and their punctuation are preserved verbatim across initial and correction prompts without repeating accepted sends. Hosted voice tests issue the original request once, with reminders and re-asks disabled; transcript, action-persistence, correlation, and exactly-once delivery assertions remain unchanged.

## Reason

Realtime calls should preserve wideband audio, and a transient installation stall or ambiguous live request should not prevent CI from exercising the plugin or reporting failures.

## Decisions

- **Audio rates:** Use 16 kHz PCM on the call connection and resample to 24 kHz because that is the supported realtime PCM session rate.
- **Compatibility:** Use 8 kHz μ-law when the start-frame descriptor is absent, preserving legacy call connections.
- **Live proof:** Require an unassisted first request, durable post-call action, autonomous wakeup, and exactly one matching SMS; no caller reminders or re-asks.

## Testing

- [Unassisted full-stack CI](https://github.com/inkbox-ai/hermes-agent-plugin/actions/runs/34184956915): all 14 jobs passed on `126e7a3`, including real/mock channels, all five A2A scenarios, all four voice scenarios, external events, and the final gate.
- `uv run pytest -q`: 617 passed, 25 skipped locally (host-contract and authenticated live lanes require their CI environments).
- `uv run ruff check .`, `bash -n tests/ci/install_hermes.sh`, and `git diff --check`: passed.
- Realtime calling: byte-level tests verify 16↔24 kHz tone frequency, amplitude, duration, arbitrary chunk boundaries, silence, handshake headers, legacy conversion, and interruption reset.
- Hosted completion: concurrent events with different event IDs enqueue one turn; failed enqueue releases admission for a safe retry.
- Deferred host tools: 15 contract checks passed locally against current Hermes; describing a synthetic action does not execute it, and `tool_call` executes it exactly once.
- Host installation: a deliberately hung installer attempt is terminated and the next attempt succeeds.
- Realtime live calling: require the current call’s negotiated `pcm_s16le` / `16000` diagnostic as well as two-way speech and disabled built-in speech processing; legacy fallback cannot satisfy the HD proof.
- Hosted calling: passed in 71 seconds with re-asks disabled and no reminder prompt. The original single request produced the required persisted action; Hermes autonomously enqueued and completed post-call reconciliation, and exactly one fresh SMS contained the run’s normalized marker after hangup. This checks marker containment, not byte-for-byte body equality.
